### PR TITLE
add CI with manual release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,178 @@
+name: CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      create_release:
+        description: 'Create new release'
+        required: true
+        type: boolean
+  push:
+    branches:
+      - main
+    paths: ['.github/workflows/**', '**/Makefile', '**/*.go']
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  Ubuntu-22-x64:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+        id: checkout
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.x'
+          cache-dependency-path: launcher/go.sum
+
+      - name: Install dependencies
+        run: |
+          cd launcher
+          go mod tidy
+
+      - name: Build
+        id: build
+        run: |
+          cd launcher
+          make
+
+      - name: Determine tag name
+        id: tag
+        run: |
+          SHORT_HASH="$(git rev-parse --short=7 HEAD)"
+          echo "name=${SHORT_HASH}" >> $GITHUB_OUTPUT
+
+      - name: Pack artifacts
+        id: pack_artifacts
+        run: |
+          ARTIFACT=mor-launch-${{ steps.tag.outputs.name }}-ubuntu-x64.zip
+          LLAMACPP=llama-b2699-bin-ubuntu-x64.zip
+          MODEL=tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+          wget https://github.com/ggerganov/llama.cpp/releases/download/b2699/$LLAMACPP
+          wget https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/$MODEL
+          unzip -o -j $LLAMACPP build/bin/server
+          echo '{"run":["./server -m ./'$MODEL'"]}' > mor-launch.json
+          zip -j $ARTIFACT ./LICENSE ./launcher/mor-launch server $MODEL mor-launch.json
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: mor-launch-${{ steps.tag.outputs.name }}-ubuntu-x64.zip
+          name: mor-launch-ubuntu-x64.zip
+
+  macOS-12-x64:
+    runs-on: macos-12
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+        id: checkout
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.x'
+          cache-dependency-path: launcher/go.sum
+
+      - name: Install dependencies
+        run: |
+          cd launcher
+          go mod tidy
+
+      - name: Build
+        id: build
+        run: |
+          cd launcher
+          make
+
+      - name: Determine tag name
+        id: tag
+        run: |
+          SHORT_HASH="$(git rev-parse --short=7 HEAD)"
+          echo "name=${SHORT_HASH}" >> $GITHUB_OUTPUT
+
+      - name: Pack artifacts
+        id: pack_artifacts
+        run: |
+          ARTIFACT=mor-launch-${{ steps.tag.outputs.name }}-macos-x64.zip
+          LLAMACPP=llama-b2699-bin-macos-x64.zip
+          MODEL=tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+          wget https://github.com/ggerganov/llama.cpp/releases/download/b2699/$LLAMACPP
+          wget https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/$MODEL
+          unzip -o -j $LLAMACPP build/bin/server
+          echo '{"run":["./server -m ./'$MODEL'"]}' > mor-launch.json
+          zip -j $ARTIFACT ./LICENSE ./launcher/mor-launch server $MODEL mor-launch.json
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: mor-launch-${{ steps.tag.outputs.name }}-macos-x64.zip
+          name: mor-launch-macos-x64.zip
+
+  release:
+    if: ${{ github.event.inputs.create_release == 'true' }}
+    runs-on: ubuntu-latest
+    needs:
+      - Ubuntu-22-x64
+      - macOS-12-x64
+    steps:
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Determine tag name
+        id: tag
+        run: |
+          SHORT_HASH="$(git rev-parse --short=7 HEAD)"
+          echo "name=${SHORT_HASH}" >> $GITHUB_OUTPUT
+
+      - name: Download artifacts
+        id: download-artifact
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifact
+
+      - name: Move artifacts
+        id: move_artifacts
+        run: |
+          mkdir -p ./artifact/release
+          mv ./artifact/*/*.zip ./artifact/release
+
+      - name: Create release
+        id: create_release
+        uses: anzz1/action-create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag.outputs.name }}
+
+      - name: Upload release
+        id: upload_release
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const path = require('path');
+            const fs = require('fs');
+            const release_id = '${{ steps.create_release.outputs.id }}';
+            for (let file of await fs.readdirSync('./artifact/release')) {
+              if (path.extname(file) === '.zip') {
+                console.log('uploadReleaseAsset', file);
+                await github.repos.uploadReleaseAsset({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  release_id: release_id,
+                  name: file,
+                  data: await fs.readFileSync(`./artifact/release/${file}`)
+                });
+              }
+            }
+


### PR DESCRIPTION
Initially only Mac and Linux release builds (someone who uses Windows will need to add Windows releases), and only creating release with launcher, server and model (someone working on wallet/UI will need to add those).
