### PR TITLE
ci: increase yarn install net timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           cd ../proxy-router
           go mod download
           cd ../ui-desktop
-          yarn install
+          yarn install --network-timeout 600000
 
       - name: Build
         id: build
@@ -119,7 +119,7 @@ jobs:
           cd ../proxy-router
           go mod download
           cd ../ui-desktop
-          yarn install
+          yarn install --network-timeout 600000
 
       - name: Build
         id: build
@@ -187,7 +187,7 @@ jobs:
           cd ../proxy-router
           go mod download
           cd ../ui-desktop
-          yarn install
+          yarn install --network-timeout 600000
 
       - name: Build
         id: build
@@ -259,7 +259,7 @@ jobs:
           cd ../proxy-router
           go mod download
           cd ../ui-desktop
-          yarn install
+          yarn install --network-timeout 600000
 
       - name: Build
         id: build


### PR DESCRIPTION
ci: increase yarn install net timeout

Occasional workflow jobs fail because yarn install times-out fetching dependencies! Increasing the network timeout should "fix"