### PR TITLE
feat: limit provider reward with stake

### DIFF
--- a/smart-contracts/contracts/AppStorage.sol
+++ b/smart-contracts/contracts/AppStorage.sol
@@ -4,10 +4,15 @@ pragma solidity ^0.8.0;
 import { KeySet, AddressSet, Uint256Set } from "./libraries/KeySet.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+
+uint128 constant PROVIDER_REWARD_LIMITER_PERIOD = 365 days; // reward for this period will be limited by the stake
+
 struct Provider {
   string endpoint; // example 'domain.com:1234'
-  uint256 stake; // stake amount
+  uint256 stake; // stake amount, which also server as a reward limiter
   uint128 createdAt; // timestamp of the registration
+  uint128 limitPeriodEnd; // timestamp of the limiter period end
+  uint256 limitPeriodEarned; // total earned during the last limiter period
   bool isDeleted;
 }
 

--- a/smart-contracts/contracts/facets/ProviderRegistry.sol
+++ b/smart-contracts/contracts/facets/ProviderRegistry.sol
@@ -15,6 +15,9 @@ contract ProviderRegistry {
   event ProviderMinStakeUpdated(uint256 newStake);
 
   error StakeTooLow();
+  error ErrProviderNotDeleted();
+  error ErrNoStake();
+  error ErrNoWithdrawableStake();
 
   /// @notice Returns provider struct by address
   function providerMap(address addr) external view returns (Provider memory) {
@@ -90,11 +93,46 @@ contract ProviderRegistry {
     LibOwner._senderOrOwner(addr);
     s.activeProviders.remove(addr);
 
-    s.providerMap[addr].isDeleted = true;
-    uint256 stake = s.providerMap[addr].stake;
-
     emit ProviderDeregistered(addr);
-    s.token.transfer(addr, stake);
+
+    Provider storage p = s.providerMap[addr];
+    uint256 withdrawable = getWithdrawableStake(p);
+    p.stake -= withdrawable;
+    p.isDeleted = true;
+    s.token.transfer(addr, withdrawable);
+  }
+
+  /// @notice Withdraws stake from a provider after it has been deregistered
+  ///         Allows to withdraw the stake after provider reward period has ended
+  function providerWithdrawStake(address addr) external {
+    Provider storage p = s.providerMap[addr];
+    if (!p.isDeleted) {
+      revert ErrProviderNotDeleted();
+    }
+
+    if (p.stake == 0){
+      revert ErrNoStake();
+    }
+
+    uint256 withdrawable = getWithdrawableStake(p);
+    if (withdrawable == 0) {
+      revert ErrNoWithdrawableStake();
+    }
+
+    p.stake -= withdrawable;
+    s.token.transfer(addr, withdrawable);
+  }
+
+  /// @notice Returns the withdrawable stake for a provider
+  /// @dev    If the provider already earned this period then withdrawable stake 
+  ///         is limited by the amount earning that remains in the current period.
+  ///         It is done to prevent the provider from withdrawing and then staking
+  ///         again from a different address, which bypasses the limitation. 
+  function getWithdrawableStake(Provider memory p) private view returns (uint256) {
+    if (uint128(block.timestamp) > p.limitPeriodEnd) {
+      return p.stake;
+    }
+    return p.stake - p.limitPeriodEarned;
   }
 
   /// @notice Sets the minimum stake required for a provider

--- a/smart-contracts/test/ProviderRegistry.test.ts
+++ b/smart-contracts/test/ProviderRegistry.test.ts
@@ -4,6 +4,7 @@ import hre from "hardhat";
 import { getAddress } from "viem";
 import { catchError, getTxTimestamp } from "./utils";
 import { deployDiamond, deploySingleProvider } from "./fixtures";
+import { DAY } from "../utils/time";
 
 describe("Provider registry", function () {
   describe("Actions", function () {
@@ -33,6 +34,8 @@ describe("Provider registry", function () {
         endpoint: expectedProvider.endpoint,
         stake: expectedProvider.stake,
         createdAt: expectedProvider.createdAt,
+        limitPeriodEarned: expectedProvider.limitPeriodEarned,
+        limitPeriodEnd: expectedProvider.limitPeriodEnd,
         isDeleted: false,
       });
       expect(events.length).eq(1);
@@ -167,7 +170,6 @@ describe("Provider registry", function () {
         [provider.account.address, updates.addStake, updates.endpoint],
         { account: provider.account },
       );
-      const timestamp = await getTxTimestamp(publicClient, txHash);
       const providerData = await providerRegistry.read.providerMap([
         provider.account.address,
       ]);
@@ -175,7 +177,9 @@ describe("Provider registry", function () {
       expect(providerData).deep.equal({
         endpoint: updates.endpoint,
         stake: expectedProvider.stake + updates.addStake,
-        createdAt: timestamp,
+        createdAt: expectedProvider.createdAt,
+        limitPeriodEarned: expectedProvider.limitPeriodEarned,
+        limitPeriodEnd: expectedProvider.limitPeriodEnd,
         isDeleted: expectedProvider.isDeleted,
       });
     });
@@ -219,6 +223,8 @@ describe("Provider registry", function () {
       expect(providerData).deep.equal({
         endpoint: expectedProvider.endpoint,
         stake: expectedProvider.stake,
+        limitPeriodEarned: expectedProvider.limitPeriodEarned,
+        limitPeriodEnd: expectedProvider.limitPeriodEnd,
         createdAt: expectedProvider.createdAt,
         isDeleted: expectedProvider.isDeleted,
       });
@@ -234,6 +240,8 @@ describe("Provider registry", function () {
       expect(providerData).deep.equal({
         endpoint: expectedProvider.endpoint,
         stake: expectedProvider.stake,
+        limitPeriodEarned: expectedProvider.limitPeriodEarned,
+        limitPeriodEnd: expectedProvider.limitPeriodEnd,
         createdAt: expectedProvider.createdAt,
         isDeleted: expectedProvider.isDeleted,
       });
@@ -252,6 +260,8 @@ describe("Provider registry", function () {
       expect(providers[0]).deep.equal({
         endpoint: expectedProvider.endpoint,
         stake: expectedProvider.stake,
+        limitPeriodEarned: expectedProvider.limitPeriodEarned,
+        limitPeriodEnd: expectedProvider.limitPeriodEnd,
         createdAt: expectedProvider.createdAt,
         isDeleted: expectedProvider.isDeleted,
       });

--- a/smart-contracts/test/SessionRouter/closeSession.test.ts
+++ b/smart-contracts/test/SessionRouter/closeSession.test.ts
@@ -5,9 +5,10 @@ import {
 import { expect } from "chai";
 import hre from "hardhat";
 import { deploySingleBid, getProviderApproval, getReport } from "../fixtures";
-import { getSessionId } from "../utils";
+import { getSessionId, getTxTimestamp, nowChain } from "../utils";
 import { DAY, SECOND } from "../../utils/time";
 import { expectAlmostEqual, expectAlmostEqualDelta } from "../../utils/compare";
+import { getAddress, parseUnits } from "viem";
 
 describe("session closeout", function () {
   it("should open short (<1D) session and close after expiration", async function () {
@@ -193,7 +194,6 @@ describe("session closeout", function () {
     await sessionRouter.write.claimProviderBalance([
       sessionId,
       claimableProvider2,
-      exp.provider,
     ]);
 
     // verify provider balance after claim
@@ -203,4 +203,119 @@ describe("session closeout", function () {
     const providerClaimed = providerBalanceAfterClaim - providerBalanceAfter;
     expect(providerClaimed).to.equal(exp.totalCost);
   });
+
+  it.only("should limit reward by stake amount", async function () {
+    const {
+      sessionRouter,
+      marketplace,
+      expectedProvider,
+      expectedModel,
+      provider,
+      decimalsMOR,
+      user,
+      modelRegistry,
+      providerRegistry,
+      publicClient,
+      tokenMOR,
+    } = await loadFixture(deploySingleBid);
+
+    // expected bid
+    const expectedBid = {
+      id: "" as `0x${string}`,
+      providerAddr: getAddress(expectedProvider.address),
+      modelId: expectedModel.modelId,
+      pricePerSecond: parseUnits("0.1", decimalsMOR),
+      nonce: 0n,
+      createdAt: 0n,
+      deletedAt: 0n,
+    };
+
+    // add single bid
+    const postBidtx = await marketplace.simulate.postModelBid(
+      [
+        expectedBid.providerAddr,
+        expectedBid.modelId,
+        expectedBid.pricePerSecond,
+      ],
+      { account: provider.account.address },
+    );
+    const txHash = await provider.writeContract(postBidtx.request);
+
+    expectedBid.id = postBidtx.result;
+    expectedBid.createdAt = await getTxTimestamp(publicClient, txHash);
+
+    // calculate data for session opening
+    const totalCost = expectedProvider.stake * 2n;
+    const durationSeconds = totalCost / expectedBid.pricePerSecond;
+    const totalSupply = await sessionRouter.read.totalMORSupply([
+      await nowChain(),
+    ]);
+    const todaysBudget = await sessionRouter.read.getTodaysBudget([
+      await nowChain(),
+    ]);
+
+    const expectedSession = {
+      durationSeconds,
+      totalCost,
+      pricePerSecond: expectedBid.pricePerSecond,
+      user: getAddress(user.account.address),
+      provider: expectedBid.providerAddr,
+      modelAgentId: expectedBid.modelId,
+      bidID: expectedBid.id,
+      stake: (totalCost * totalSupply) / todaysBudget,
+    };
+
+    // set user balance and approve funds
+    await tokenMOR.write.transfer([
+      user.account.address,
+      expectedSession.stake,
+    ]);
+    await tokenMOR.write.approve(
+      [modelRegistry.address, expectedSession.stake],
+      {
+        account: user.account,
+      },
+    );
+
+    // open session
+    const { msg, signature } = await getProviderApproval(
+      provider,
+      expectedSession.bidID,
+    );
+    const openTx = await sessionRouter.write.openSession(
+      [expectedSession.stake, msg, signature],
+      { account: user.account.address },
+    );
+    const sessionId = await getSessionId(publicClient, hre, openTx);
+
+    // wait till session ends
+    await time.increase(expectedSession.durationSeconds);
+
+    const providerBalanceBefore = await tokenMOR.read.balanceOf([
+      provider.account.address,
+    ]);
+    // close session without dispute
+    const report = await getReport(provider, sessionId, 10);
+    await sessionRouter.write.closeSession([report.msg, report.sig], {
+      account: user.account,
+    });
+
+    const providerBalanceAfter = await tokenMOR.read.balanceOf([
+      provider.account.address,
+    ]);
+
+    const providerEarned = providerBalanceAfter - providerBalanceBefore;
+
+    expect(providerEarned).to.equal(expectedProvider.stake);
+
+    // check provider record if earning was updated
+    const providerRecord = await providerRegistry.read.providerMap([
+      provider.account.address,
+    ]);
+    expect(providerRecord.limitPeriodEarned).to.equal(expectedProvider.stake);
+  });
+
+  it("should reset provider limitPeriodEarned after period", async function () {});
+
+  it("should error with WithdrawableBalanceLimitByStakeReached() if claiming more that stake for a period", async function () {});
 });

--- a/smart-contracts/test/SessionRouter/closeSession.test.ts
+++ b/smart-contracts/test/SessionRouter/closeSession.test.ts
@@ -204,7 +204,7 @@ describe("session closeout", function () {
     expect(providerClaimed).to.equal(exp.totalCost);
   });
 
-  it.only("should limit reward by stake amount", async function () {
+  it("should limit reward by stake amount", async function () {
     const {
       sessionRouter,
       marketplace,

--- a/smart-contracts/test/fixtures.ts
+++ b/smart-contracts/test/fixtures.ts
@@ -10,7 +10,7 @@ import {
 import { getHex, getTxTimestamp, now, nowChain, randomBytes32 } from "./utils";
 import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 import { FacetCutAction, getSelectors } from "../libraries/diamond";
-import { HOUR, MINUTE, SECOND } from "../utils/time";
+import { DAY, HOUR, MINUTE, SECOND } from "../utils/time";
 import {
   GetContractReturnType,
   WalletClient,
@@ -153,6 +153,8 @@ export async function deploySingleProvider() {
     stake: parseUnits("100", decimalsMOR),
     endpoint: "localhost:3334",
     createdAt: 0n,
+    limitPeriodEarned: 0n,
+    limitPeriodEnd: 0n,
     isDeleted: false,
   };
 
@@ -182,6 +184,8 @@ export async function deploySingleProvider() {
     publicClient,
     addProviderHash,
   );
+  expectedProvider.limitPeriodEnd =
+    expectedProvider.createdAt + BigInt(365 * (DAY / SECOND));
 
   return {
     expectedProvider,
@@ -244,6 +248,7 @@ export async function deploySingleBid() {
     publicClient,
     tokenMOR,
     modelRegistry,
+    providerRegistry,
     user,
     decimalsMOR,
     marketplace,
@@ -361,7 +366,11 @@ export async function deploySingleBid() {
   return {
     expectedBid,
     expectedSession,
+    expectedProvider,
+    expectedModel,
     marketplace,
+    modelRegistry,
+    providerRegistry,
     owner,
     provider,
     publicClient,

--- a/smart-contracts/test/utils.ts
+++ b/smart-contracts/test/utils.ts
@@ -164,3 +164,6 @@ export const startOfTheDay = (timestamp: bigint): bigint => {
 export const NewDate = (timestamp: bigint): Date => {
   return new Date(Number(timestamp) * 1000);
 };
+
+export const PanicOutOfBoundsRegexp =
+  /.*reverted with panic code 0x32 (Array accessed at an out-of-bounds or negative index)*/;


### PR DESCRIPTION
Update session contract and provider registry to only let a provider claim in a calendar year what they've staked.

If a provider registers on June 25, 2024 and stakes 10 MOR then they can only earn up to 10 MOR until June 24, 2025. On June 25, 2025 their earning ability starts over.

If the provider increases their stake to 20 MOR on September 1st 2024, then the provider can earn up to 20 MOR until June 24, 2025. Even if the stake changes the dates stay the same.

The provider can only unstake MOR that isn't linked to earnings for that year. This should also be considered in the provider selection process in the proxy.