### PR TITLE
Blockchain API: Fix empty errors in JSON payload and logs 

### DIFF
--- a/proxy-router/internal/blockchainapi/controller.go
+++ b/proxy-router/internal/blockchainapi/controller.go
@@ -84,13 +84,13 @@ func (c *BlockchainController) getProviderClaimableBalance(ctx *gin.Context) {
 	err := ctx.ShouldBindUri(&params)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	balance, err := c.service.GetProviderClaimableBalance(ctx, params.ID.Hash)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -113,21 +113,21 @@ func (c *BlockchainController) claimProviderBalance(ctx *gin.Context) {
 	err := ctx.ShouldBindUri(&params)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	_, amount, err := c.getSendParams(ctx)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	txHash, err := c.service.ClaimProviderBalance(ctx, params.ID.Hash, amount)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -147,7 +147,7 @@ func (c *BlockchainController) getAllProviders(ctx *gin.Context) {
 	providers, err := c.service.GetAllProviders(ctx)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -168,14 +168,14 @@ func (c *BlockchainController) sendETH(ctx *gin.Context) {
 	to, amount, err := c.getSendParams(ctx)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	txHash, err := c.service.SendETH(ctx, to, amount)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -196,13 +196,13 @@ func (c *BlockchainController) sendMOR(ctx *gin.Context) {
 	to, amount, err := c.getSendParams(ctx)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 	txhash, err := c.service.SendMOR(ctx, to, amount)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -226,21 +226,21 @@ func (c *BlockchainController) getBidsByProvider(ctx *gin.Context) {
 	err := ctx.ShouldBindUri(&params)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	offset, limit, err := getOffsetLimit(ctx)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	bids, err := c.service.GetBidsByProvider(ctx, params.ID.Address, offset, limit)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -262,14 +262,14 @@ func (c *BlockchainController) getActiveBidsByProvider(ctx *gin.Context) {
 	err := ctx.ShouldBindUri(&params)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	bids, err := c.service.GetActiveBidsByProvider(ctx, params.ID.Address)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -289,7 +289,7 @@ func (c *BlockchainController) getAllModels(ctx *gin.Context) {
 	models, err := c.service.GetAllModels(ctx)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -313,21 +313,21 @@ func (c *BlockchainController) getBidsByModelAgent(ctx *gin.Context) {
 	err := ctx.ShouldBindUri(&params)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	offset, limit, err := getOffsetLimit(ctx)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	bids, err := c.service.GetBidsByModelAgent(ctx, params.ID.Hash, offset, limit)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -349,14 +349,14 @@ func (c *BlockchainController) getActiveBidsByModel(ctx *gin.Context) {
 	err := ctx.ShouldBindUri(&params)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	bids, err := c.service.GetActiveBidsByModel(ctx, params.ID.Hash)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -376,7 +376,7 @@ func (s *BlockchainController) getBalance(ctx *gin.Context) {
 	ethBalance, morBalance, err := s.service.GetBalance(ctx)
 	if err != nil {
 		s.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -401,14 +401,14 @@ func (c *BlockchainController) getTransactions(ctx *gin.Context) {
 	page, limit, err := getPageLimit(ctx)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	txs, err := c.service.GetTransactions(ctx, page, limit)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -429,14 +429,14 @@ func (c *BlockchainController) getAllowance(ctx *gin.Context) {
 	err := ctx.ShouldBindQuery(&query)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	allowance, err := c.service.GetAllowance(ctx, query.Spender.Address)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -459,14 +459,14 @@ func (c *BlockchainController) approve(ctx *gin.Context) {
 	err := ctx.ShouldBindQuery(&query)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	tx, err := c.service.Approve(ctx, query.Spender.Address, query.Amount.Unpack())
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -488,14 +488,14 @@ func (c *BlockchainController) openSession(ctx *gin.Context) {
 	var reqPayload structs.OpenSessionRequest
 	if err := ctx.ShouldBindJSON(&reqPayload); err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	sessionId, err := c.service.OpenSession(ctx, reqPayload.Approval, reqPayload.ApprovalSig, reqPayload.Stake.Unpack())
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -517,20 +517,20 @@ func (c *BlockchainController) openSession(ctx *gin.Context) {
 func (s *BlockchainController) openSessionByBid(ctx *gin.Context) {
 	var reqPayload structs.OpenSessionWithDurationRequest
 	if err := ctx.ShouldBindJSON(&reqPayload); err != nil {
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	var params structs.PathHex32ID
 	err := ctx.ShouldBindUri(&params)
 	if err != nil {
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	sessionId, err := s.service.openSessionByBid(ctx, params.ID.Hash, reqPayload.SessionDuration.Unpack())
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -553,7 +553,7 @@ func (s *BlockchainController) openSessionByModelId(ctx *gin.Context) {
 	var reqPayload structs.OpenSessionWithDurationRequest
 	if err := ctx.ShouldBindJSON(&reqPayload); err != nil {
 		s.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -568,7 +568,7 @@ func (s *BlockchainController) openSessionByModelId(ctx *gin.Context) {
 	sessionId, err := s.service.OpenSessionByModelId(ctx, params.ID.Hash, reqPayload.SessionDuration.Unpack())
 	if err != nil {
 		s.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -590,14 +590,14 @@ func (c *BlockchainController) closeSession(ctx *gin.Context) {
 	err := ctx.ShouldBindUri(&params)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	txHash, err := c.service.CloseSession(ctx, params.ID.Hash)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -619,14 +619,14 @@ func (c *BlockchainController) getSession(ctx *gin.Context) {
 	err := ctx.ShouldBindUri(&params)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	session, err := c.service.GetSession(ctx, params.ID.Hash)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -650,7 +650,7 @@ func (c *BlockchainController) getSessions(ctx *gin.Context) {
 	offset, limit, err := getOffsetLimit(ctx)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -658,7 +658,7 @@ func (c *BlockchainController) getSessions(ctx *gin.Context) {
 	err = ctx.ShouldBindQuery(&req)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -666,20 +666,22 @@ func (c *BlockchainController) getSessions(ctx *gin.Context) {
 	hasProvider := req.Provider != lib.Address{}
 
 	if !hasUser && !hasProvider {
+		err := fmt.Errorf("user or provider is required")
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: fmt.Errorf("user or provider is required")})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 	if hasUser && hasProvider {
+		err := fmt.Errorf("only one of user or provider is allowed")
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: fmt.Errorf("only one of user or provider is allowed")})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	sessions, err := c.service.GetSessions(ctx, req.User.Address, req.Provider.Address, offset, limit)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -699,7 +701,7 @@ func (s *BlockchainController) getBudget(ctx *gin.Context) {
 	budget, err := s.service.GetTodaysBudget(ctx)
 	if err != nil {
 		s.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -719,7 +721,7 @@ func (s *BlockchainController) getSupply(ctx *gin.Context) {
 	supply, err := s.service.GetTokenSupply(ctx)
 	if err != nil {
 		s.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -739,7 +741,7 @@ func (c *BlockchainController) getLatestBlock(ctx *gin.Context) {
 	block, err := c.service.GetLatestBlock(ctx)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 	ctx.JSON(http.StatusOK, structs.BlockRes{Block: block})
@@ -760,14 +762,14 @@ func (c *BlockchainController) getBidByID(ctx *gin.Context) {
 	err := ctx.ShouldBindUri(&params)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	bid, err := c.service.GetBidByID(ctx, params.ID.Hash)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -789,14 +791,14 @@ func (c *BlockchainController) getRatedBids(ctx *gin.Context) {
 	err := ctx.ShouldBindUri(&params)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	bids, err := c.service.GetRatedBids(ctx, params.ID.Hash)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -817,14 +819,14 @@ func (c *BlockchainController) createProvider(ctx *gin.Context) {
 	var provider structs.CreateProviderRequest
 	if err := ctx.ShouldBindJSON(&provider); err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	result, err := c.service.CreateNewProvider(ctx, provider.Stake, provider.Endpoint)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -845,14 +847,14 @@ func (c *BlockchainController) deregisterProvider(ctx *gin.Context) {
 	err := ctx.ShouldBindUri(&params)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	txHash, err := c.service.DeregisterProdiver(ctx, params.ID.Address)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -873,7 +875,7 @@ func (c *BlockchainController) createNewModel(ctx *gin.Context) {
 	var model structs.CreateModelRequest
 	if err := ctx.ShouldBindJSON(&model); err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -883,7 +885,7 @@ func (c *BlockchainController) createNewModel(ctx *gin.Context) {
 		_, err := rand.Read(hash[:])
 		if err != nil {
 			c.log.Error(err)
-			ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+			ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 			return
 		}
 		modelId = hash
@@ -895,7 +897,7 @@ func (c *BlockchainController) createNewModel(ctx *gin.Context) {
 	result, err := c.service.CreateNewModel(ctx, modelId, ipsfHash, model.Fee, model.Stake, model.Name, model.Tags)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -917,14 +919,14 @@ func (c *BlockchainController) deregisterModel(ctx *gin.Context) {
 	err := ctx.ShouldBindUri(&params)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	txHash, err := c.service.DeregisterModel(ctx, params.ID.Hash)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -945,7 +947,7 @@ func (c *BlockchainController) createNewBid(ctx *gin.Context) {
 	var bid structs.CreateBidRequest
 	if err := ctx.ShouldBindJSON(&bid); err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -953,7 +955,7 @@ func (c *BlockchainController) createNewBid(ctx *gin.Context) {
 	result, err := c.service.CreateNewBid(ctx, modelId, bid.PricePerSecond)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
@@ -974,14 +976,14 @@ func (c *BlockchainController) deleteBid(ctx *gin.Context) {
 	err := ctx.ShouldBindUri(&params)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusBadRequest, structs.ErrRes{Error: err.Error()})
 		return
 	}
 
 	txHash, err := c.service.DeleteBid(ctx, params.ID.Hash)
 	if err != nil {
 		c.log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err})
+		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})
 		return
 	}
 

--- a/proxy-router/internal/blockchainapi/structs/res.go
+++ b/proxy-router/internal/blockchainapi/structs/res.go
@@ -14,7 +14,7 @@ type TxRes struct {
 }
 
 type ErrRes struct {
-	Error error `json:"error" example:"error message"`
+	Error string `json:"error" example:"error message"`
 }
 
 type OpenSessionRes struct {


### PR DESCRIPTION
Fixes #190 

Of note: I ended up changing the response struct for Error from `error` to `string`. In my recollection and a quick cursory double check, `error` does not automatically marshal to JSON, hence why it was always empty. 