### PR TITLE
cicd: bump macos-x86 to v13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,8 +96,8 @@ jobs:
           path: mor-launch-${{ steps.tag.outputs.name }}-ubuntu-x64.zip
           name: mor-launch-ubuntu-x64.zip
 
-  macOS-12-x64:
-    runs-on: macos-12
+  macOS-13-x64:
+    runs-on: macos-13
     steps:
       - name: Clone
         uses: actions/checkout@v4
@@ -328,7 +328,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - Ubuntu-22-x64
-      - macOS-12-x64
+      - macOS-13-x64
       - macOS-14-arm64
       - Windows-avx2-x64
     steps:


### PR DESCRIPTION
For more details, see https://github.com/actions/runner-images/issues/10721