### PR TITLE
Full URL for models in provider models-config file 

### DIFF
--- a/.github/workflows/models-config.json
+++ b/.github/workflows/models-config.json
@@ -5,7 +5,7 @@
       "modelId": "0x0000000000000000000000000000000000000000000000000000000000000000",
       "modelName": "llama2",
       "apiType": "openai",
-      "apiUrl": "http://localhost:8080/v1"
+      "apiUrl": "http://localhost:8080/v1/chat/completions"
     }
   ]
 }

--- a/docs/models-config.json.md
+++ b/docs/models-config.json.md
@@ -3,7 +3,7 @@
 - `modelId` (required) is the model id
 - `modelName` (required) is the name of the model
 - `apiType` (required) is the type of the model api. Currently supported values are "prodia-sd", "prodia-sdxl", "prodia-v2" and "openai"
-- `apiUrl` (required) is the url of the LLM server or model API
+- `apiUrl` (required) is the url of the LLM server or model API. Full url including endpoint.
 - `apiKey` (optional) is the api key for the model
 - `concurrentSlots` (optional) are number of available distinct chats on the llm server and used for capacity policy
 - `capacityPolicy` (optional) can be one of the following: "idle_timeout", "simple"
@@ -21,20 +21,20 @@ This file enables the morpheus-proxy-router to route requests to the correct mod
       "modelId": "0x0000000000000000000000000000000000000000000000000000000000000000",
       "modelName": "llama2",
       "apiType": "openai",
-      "apiUrl": "http://localhost:8080/v1"
+      "apiUrl": "http://localhost:8080/v1/chat/completions"
     },
     {
       "modelId": "0x0000000000000000000000000000000000000000000000000000000000000001",
       "modelName": "inference.sdxl.txt2img.v1",
       "apiType": "prodia-v2",
-      "apiUrl": "https://inference.prodia.com/v2",
+      "apiUrl": "https://inference.prodia.com/v2/job",
       "apiKey": "FILL_ME_IN"
     },
     {
       "modelId": "0x0000000000000000000000000000000000000000000000000000000000000002",
       "modelName": "SDXL1.0-base",
       "apiType": "hyperbolic-sd",
-      "apiUrl": "https://api.hyperbolic.xyz/v1",
+      "apiUrl": "https://api.hyperbolic.xyz/v1/image/generation",
       "apiKey": "FILL_ME_IN"
       "parameters": {
         "cfg_scale": "5",
@@ -45,23 +45,44 @@ This file enables the morpheus-proxy-router to route requests to the correct mod
       "modelId": "0x0000000000000000000000000000000000000000000000000000000000000003",
       "modelName": "claude-3-5-sonnet-20241022",
       "apiType": "claudeai",
-      "apiUrl": "https://api.anthropic.com/v1",
+      "apiUrl": "https://api.anthropic.com/v1/messages",
       "apiKey": "FILL_ME_IN"
     },
     {
       "modelId": "0x0000000000000000000000000000000000000000000000000000000000000004",
       "modelName": "inference.sd15.txt2img.v1",
       "apiType": "prodia-v2",
-      "apiUrl": "https://inference.prodia.com/v2",
+      "apiUrl": "https://inference.prodia.com/v2/job",
       "apiKey": "FILL_ME_IN"  
     },    
     {
       "modelId": "0x0000000000000000000000000000000000000000000000000000000000000005",
       "modelName": "gpt-4o-mini",
       "apiType": "openai",
-      "apiUrl": "https://api.openai.com/v1",
+      "apiUrl": "https://api.openai.com/v1/chat/completions",
       "apiKey": "FILL_ME_IN"
-    }
+    },
+    {
+      "modelId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+      "modelName": "text-embedding-bge-m3",
+      "apiType": "openai",
+      "apiUrl": "https://api.venice.ai/api/v1/embeddings",
+      "apiKey": "FILL_ME_IN"
+    },
+    {
+      "modelId": "0x0000000000000000000000000000000000000000000000000000000000000007",
+      "modelName": "tts-kokoro",
+      "apiType": "openai",
+      "apiUrl": "https://api.venice.ai/api/v1/audio/speech",
+      "apiKey": "FILL_ME_IN"
+    },
+        {
+      "modelId": "0x0000000000000000000000000000000000000000000000000000000000000008",
+      "modelName": "whisper-1",
+      "apiType": "openai",
+      "apiUrl": "https://api.openai.com/v1/audio/transcriptions",
+      "apiKey": "FILL_ME_IN"
+    },
   ]
 }
 ```

--- a/proxy-router/docs/docs.go
+++ b/proxy-router/docs/docs.go
@@ -2914,7 +2914,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "audio"
+                    "embeddings"
                 ],
                 "summary": "Generate embeddings",
                 "parameters": [

--- a/proxy-router/docs/swagger.json
+++ b/proxy-router/docs/swagger.json
@@ -2906,7 +2906,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "audio"
+                    "embeddings"
                 ],
                 "summary": "Generate embeddings",
                 "parameters": [

--- a/proxy-router/docs/swagger.yaml
+++ b/proxy-router/docs/swagger.yaml
@@ -2930,7 +2930,7 @@ paths:
       - BasicAuth: []
       summary: Generate embeddings
       tags:
-      - audio
+      - embeddings
   /v1/models:
     get:
       produces:

--- a/proxy-router/internal/aiengine/claudeai.go
+++ b/proxy-router/internal/aiengine/claudeai.go
@@ -95,7 +95,7 @@ func (a *ClaudeAI) Prompt(ctx context.Context, compl *gcs.OpenAICompletionReques
 		return fmt.Errorf("failed to encode request: %v", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", a.baseURL+"/messages", bytes.NewReader(requestBody))
+	req, err := http.NewRequestWithContext(ctx, "POST", a.baseURL, bytes.NewReader(requestBody))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %v", err)
 	}

--- a/proxy-router/internal/aiengine/hyperbolic_sd.go
+++ b/proxy-router/internal/aiengine/hyperbolic_sd.go
@@ -14,7 +14,7 @@ import (
 )
 
 const API_TYPE_HYPERBOLIC_SD = "hyperbolic-sd"
-const HYPERBOLIC_DEFAULT_BASE_URL = "https://api.hyperbolic.xyz/v1"
+const HYPERBOLIC_DEFAULT_BASE_URL = "https://api.hyperbolic.xyz/v1/image/generation"
 
 type HyperbolicSD struct {
 	modelName  string
@@ -66,7 +66,7 @@ func (s *HyperbolicSD) Prompt(ctx context.Context, prompt *gcs.OpenAICompletionR
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/image/generation", s.apiURL), bytes.NewReader(payload))
+	req, err := http.NewRequest("POST", s.apiURL, bytes.NewReader(payload))
 	if err != nil {
 		err = lib.WrapError(ErrImageGenerationRequest, err)
 		s.log.Error(err)

--- a/proxy-router/internal/aiengine/openai.go
+++ b/proxy-router/internal/aiengine/openai.go
@@ -49,7 +49,7 @@ func (a *OpenAI) Prompt(ctx context.Context, compl *gcs.OpenAICompletionRequestE
 		return fmt.Errorf("failed to encode request: %v", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", a.baseURL+"/chat/completions", bytes.NewReader(requestBody))
+	req, err := http.NewRequestWithContext(ctx, "POST", a.baseURL, bytes.NewReader(requestBody))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %v", err)
 	}

--- a/proxy-router/internal/aiengine/prodia_sd.go
+++ b/proxy-router/internal/aiengine/prodia_sd.go
@@ -49,7 +49,7 @@ func (s *ProdiaSD) Prompt(ctx context.Context, prompt *gcs.OpenAICompletionReque
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/sd/generate", s.apiURL), bytes.NewReader(payload))
+	req, err := http.NewRequest("POST", s.apiURL, bytes.NewReader(payload))
 	if err != nil {
 		err = lib.WrapError(ErrImageGenerationRequest, err)
 		s.log.Error(err)

--- a/proxy-router/internal/aiengine/prodia_sdxl.go
+++ b/proxy-router/internal/aiengine/prodia_sdxl.go
@@ -49,7 +49,7 @@ func (s *ProdiaSDXL) Prompt(ctx context.Context, prompt *gcs.OpenAICompletionReq
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/sdxl/generate", s.apiURL), bytes.NewReader(payload))
+	req, err := http.NewRequest("POST", s.apiURL, bytes.NewReader(payload))
 	if err != nil {
 		err = lib.WrapError(ErrImageGenerationRequest, err)
 		s.log.Error(err)

--- a/proxy-router/internal/aiengine/prodia_v2.go
+++ b/proxy-router/internal/aiengine/prodia_v2.go
@@ -17,7 +17,7 @@ import (
 )
 
 const API_TYPE_PRODIA_V2 = "prodia-v2"
-const PRODIA_V2_DEFAULT_BASE_URL = "https://inference.prodia.com/v2"
+const PRODIA_V2_DEFAULT_BASE_URL = "https://inference.prodia.com/v2/job"
 
 var (
 	ErrCapacity               = errors.New("unable to schedule job with current token")
@@ -61,7 +61,7 @@ func (s *ProdiaV2) Prompt(ctx context.Context, prompt *gcs.OpenAICompletionReque
 		return err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/job", s.apiURL), bytes.NewReader(payload))
+	req, err := http.NewRequest("POST", s.apiURL, bytes.NewReader(payload))
 	if err != nil {
 		err = lib.WrapError(ErrImageGenerationRequest, err)
 		s.log.Error(err)

--- a/proxy-router/internal/config/models-config-schema.json
+++ b/proxy-router/internal/config/models-config-schema.json
@@ -28,10 +28,10 @@
           },
           "apiUrl": {
             "title": "API URL",
-            "description": "The URL of the API to be used with this model",
+            "description": "The URL of the API to be used with this model. Full url including endpoint.",
             "type": "string",
             "format": "uri",
-            "examples": ["http://localhost:11434/v1"]
+            "examples": ["http://localhost:11434/v1/chat/completions"]
           },
           "apiKey": {
             "title": "API Key",

--- a/proxy-router/internal/proxyapi/controller_http.go
+++ b/proxy-router/internal/proxyapi/controller_http.go
@@ -1645,7 +1645,7 @@ func (c *ProxyController) executeSpeechGeneration(ctx *gin.Context, adapter aien
 //
 //	@Summary		Generate embeddings
 //	@Description	Generate vector embeddings for the provided input
-//	@Tags			audio
+//	@Tags			embeddings
 //	@Produce		json
 //	@Param			session_id	header		string								false	"Session ID"	format(hex32)
 //	@Param			model_id	header		string								false	"Model ID"		format(hex32)


### PR DESCRIPTION
Remove ambiguity for API endpoints of LLM providers for all models 
eg: instead of assuming /api/v1/chat/completions or /api/v1/embeddings