### PR TITLE
Fix streaming completions: forward usage chunks, [DONE] marker, and reserve original JSON

### DIFF
--- a/proxy-router/internal/proxyapi/controller_http.go
+++ b/proxy-router/internal/proxyapi/controller_http.go
@@ -225,6 +225,16 @@ func (c *ProxyController) Prompt(ctx *gin.Context) {
 			return nil
 		}
 
+		if body.Stream && completion.Type() == gsc.ChunkTypeControl {
+			controlMsg := completion.Data().(string)
+			_, err := ctx.Writer.Write([]byte(fmt.Sprintf("data: %s\n\n", controlMsg)))
+			if err != nil {
+				return err
+			}
+			ctx.Writer.Flush()
+			return nil
+		}
+
 		marshalledResponse, err := json.Marshal(completion.Data())
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixed multiple issues with streaming chat completions:
- Missing usage chunks: When LLMs send a final usage statistics chunk (with empty choices but populated usage data), it was being rejected and never forwarded to clients
- Stream termination: The stream would stop prematurely after receiving finish_reason: "stop" without waiting for potential usage chunks
- [DONE] marker not forwarded: The OpenAI-compatible [DONE] marker was consumed but never forwarded to consumers
- Unwanted default values: JSON marshaling was adding default values (like content_filter_results, empty strings) to streaming chunks that weren't in the original LLM response