### PR TITLE
feat: centralize token usage calculation and fix streaming usage updates

### DIFF
--- a/proxy-router/internal/chatstorage/genericchatstorage/chat_completion.go
+++ b/proxy-router/internal/chatstorage/genericchatstorage/chat_completion.go
@@ -119,6 +119,14 @@ func (c ChatCompletionResponseExtra) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
+// SetOriginalJSONUsage updates the usage field in originalJSON
+func (c *ChatCompletionResponseExtra) SetOriginalJSONUsage(usageBytes []byte) {
+	if c.originalJSON == nil {
+		c.originalJSON = make(map[string]json.RawMessage)
+	}
+	c.originalJSON["usage"] = usageBytes
+}
+
 type ChatCompletionStreamResponseExtra struct {
 	openai.ChatCompletionStreamResponse                            // typed, known part
 	Extra                               map[string]json.RawMessage `json:"-"` // unknown bits
@@ -188,4 +196,12 @@ func (c ChatCompletionStreamResponseExtra) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(m)
+}
+
+// SetOriginalJSONUsage updates the usage field in originalJSON
+func (c *ChatCompletionStreamResponseExtra) SetOriginalJSONUsage(usageBytes []byte) {
+	if c.originalJSON == nil {
+		c.originalJSON = make(map[string]json.RawMessage)
+	}
+	c.originalJSON["usage"] = usageBytes
 }

--- a/proxy-router/internal/chatstorage/genericchatstorage/chat_completion.go
+++ b/proxy-router/internal/chatstorage/genericchatstorage/chat_completion.go
@@ -127,6 +127,23 @@ func (c *ChatCompletionResponseExtra) SetOriginalJSONUsage(usageBytes []byte) {
 	c.originalJSON["usage"] = usageBytes
 }
 
+// SetCustomUsage sets a custom usage field (usage_from_provider or usage_from_consumer) in Extra map
+// Does NOT modify the original "usage" field from the LLM
+func (c *ChatCompletionResponseExtra) SetCustomUsage(fieldName string, promptTokens, completionTokens int) {
+	if c.Extra == nil {
+		c.Extra = make(map[string]json.RawMessage)
+	}
+	usage := map[string]int{
+		"prompt_tokens":     promptTokens,
+		"completion_tokens": completionTokens,
+		"total_tokens":      promptTokens + completionTokens,
+	}
+	usageBytes, err := json.Marshal(usage)
+	if err == nil {
+		c.Extra[fieldName] = usageBytes
+	}
+}
+
 type ChatCompletionStreamResponseExtra struct {
 	openai.ChatCompletionStreamResponse                            // typed, known part
 	Extra                               map[string]json.RawMessage `json:"-"` // unknown bits
@@ -204,4 +221,21 @@ func (c *ChatCompletionStreamResponseExtra) SetOriginalJSONUsage(usageBytes []by
 		c.originalJSON = make(map[string]json.RawMessage)
 	}
 	c.originalJSON["usage"] = usageBytes
+}
+
+// SetCustomUsage sets a custom usage field (usage_from_provider or usage_from_consumer) in Extra map
+// Does NOT modify the original "usage" field from the LLM
+func (c *ChatCompletionStreamResponseExtra) SetCustomUsage(fieldName string, promptTokens, completionTokens int) {
+	if c.Extra == nil {
+		c.Extra = make(map[string]json.RawMessage)
+	}
+	usage := map[string]int{
+		"prompt_tokens":     promptTokens,
+		"completion_tokens": completionTokens,
+		"total_tokens":      promptTokens + completionTokens,
+	}
+	usageBytes, err := json.Marshal(usage)
+	if err == nil {
+		c.Extra[fieldName] = usageBytes
+	}
 }

--- a/proxy-router/internal/chatstorage/genericchatstorage/completion.go
+++ b/proxy-router/internal/chatstorage/genericchatstorage/completion.go
@@ -38,7 +38,8 @@ func (c *ChunkText) IsStreaming() bool {
 }
 
 func (c *ChunkText) Tokens() int {
-	return c.data.Usage.CompletionTokens
+	// Return the usage data as-is (token calculation is done in proxy_receiver.go)
+	return c.data.Usage.TotalTokens
 }
 
 func (c *ChunkText) Type() ChunkType {
@@ -46,7 +47,10 @@ func (c *ChunkText) Type() ChunkType {
 }
 
 func (c *ChunkText) String() string {
-	return c.data.Choices[0].Message.Content
+	if len(c.data.Choices) > 0 {
+		return c.data.Choices[0].Message.Content
+	}
+	return ""
 }
 
 func (c *ChunkText) Data() interface{} {
@@ -68,7 +72,11 @@ func (c *ChunkStreaming) IsStreaming() bool {
 }
 
 func (c *ChunkStreaming) Tokens() int {
-	return len(c.data.Choices)
+	// Return the usage data if available (token calculation is done in proxy_receiver.go)
+	if c.data.Usage != nil {
+		return c.data.Usage.TotalTokens
+	}
+	return 0
 }
 
 func (c *ChunkStreaming) Type() ChunkType {
@@ -415,3 +423,4 @@ func NewAiEngineErrorResponse(ProviderModelError interface{}) *AiEngineErrorResp
 		ProviderModelError: ProviderModelError,
 	}
 }
+

--- a/proxy-router/internal/lib/tokens.go
+++ b/proxy-router/internal/lib/tokens.go
@@ -1,0 +1,94 @@
+package lib
+
+import (
+	"encoding/json"
+
+	"github.com/sashabaranov/go-openai"
+	"github.com/tiktoken-go/tokenizer"
+	"fmt"
+)
+
+// CountTokens counts the number of tokens in a text string using tiktoken
+func CountTokens(text string) int {
+	enc, err := tokenizer.Get(tokenizer.Cl100kBase)
+	if err != nil {
+		// Fallback to rough estimation if tokenizer fails
+		fmt.Println("Error getting tokenizer: ", err)
+		return (len(text) + 3) / 4
+	}
+	ids, _, _ := enc.Encode(text)
+	return len(ids)
+}
+
+// CountPromptTokens calculates the total tokens in the chat request messages
+func CountPromptTokens(messages []openai.ChatCompletionMessage) int {
+	var totalTokens int
+	for _, msg := range messages {
+		// Count role tokens (approximately 1 token for role)
+		totalTokens += 1
+		// Count content tokens
+		if len(msg.MultiContent) > 0 {
+			// Handle multi-content messages
+			for _, part := range msg.MultiContent {
+				if part.Type == openai.ChatMessagePartTypeText {
+					totalTokens += CountTokens(part.Text)
+				}
+				// Note: Image tokens would need special handling based on resolution
+			}
+		} else {
+			totalTokens += CountTokens(msg.Content)
+		}
+		// Count name tokens if present
+		if msg.Name != "" {
+			totalTokens += CountTokens(msg.Name)
+		}
+	}
+	// Add overhead tokens for message formatting (approximately 3 tokens per message)
+	totalTokens += len(messages) * 3
+	return totalTokens
+}
+
+// UsageSetter is an interface for types that can set their originalJSON usage field
+type UsageSetter interface {
+	SetOriginalJSONUsage(usageBytes []byte)
+}
+
+// UpdateUsagePtr updates usage in a response where Usage is a pointer field
+// It takes a double pointer to usage so it can create if nil
+func UpdateUsagePtr(usage **openai.Usage, promptTokens, completionTokens int, setter UsageSetter) {
+	if usage == nil {
+		return
+	}
+	if *usage == nil {
+		*usage = &openai.Usage{}
+	}
+	(*usage).PromptTokens = promptTokens
+	(*usage).CompletionTokens = completionTokens
+	(*usage).TotalTokens = promptTokens + completionTokens
+
+	// Update the originalJSON to ensure the usage is reflected in marshalled output
+	if setter != nil {
+		usageBytes, err := json.Marshal(*usage)
+		if err == nil {
+			setter.SetOriginalJSONUsage(usageBytes)
+		}
+	}
+}
+
+// UpdateUsage updates usage in a response where Usage is a value field (not pointer)
+func UpdateUsage(usage *openai.Usage, promptTokens, completionTokens int, setter UsageSetter) {
+	if usage == nil {
+		return
+	}
+	usage.PromptTokens = promptTokens
+	usage.CompletionTokens = completionTokens
+	usage.TotalTokens = promptTokens + completionTokens
+
+	// Update the originalJSON to ensure the usage is reflected in marshalled output
+	if setter != nil {
+		usageBytes, err := json.Marshal(usage)
+		if err == nil {
+			setter.SetOriginalJSONUsage(usageBytes)
+		}
+	}
+}

--- a/proxy-router/internal/lib/tokens.go
+++ b/proxy-router/internal/lib/tokens.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/sashabaranov/go-openai"
 	"github.com/tiktoken-go/tokenizer"
-	"fmt"
 )
 
 // CountTokens counts the number of tokens in a text string using tiktoken
@@ -13,7 +12,6 @@ func CountTokens(text string) int {
 	enc, err := tokenizer.Get(tokenizer.Cl100kBase)
 	if err != nil {
 		// Fallback to rough estimation if tokenizer fails
-		fmt.Println("Error getting tokenizer: ", err)
 		return (len(text) + 3) / 4
 	}
 	ids, _, _ := enc.Encode(text)
@@ -91,4 +89,27 @@ func UpdateUsage(usage *openai.Usage, promptTokens, completionTokens int, setter
 			setter.SetOriginalJSONUsage(usageBytes)
 		}
 	}
+}
+
+// CustomUsageSetter is an interface for types that can set custom usage fields in Extra map
+type CustomUsageSetter interface {
+	SetCustomUsage(fieldName string, promptTokens, completionTokens int)
+}
+
+// SetUsageFromProvider sets the usage_from_provider field with calculated tokens
+// Does NOT modify the original "usage" field from the LLM
+func SetUsageFromProvider(setter CustomUsageSetter, promptTokens, completionTokens int) {
+	if setter == nil {
+		return
+	}
+	setter.SetCustomUsage("usage_from_provider", promptTokens, completionTokens)
+}
+
+// SetUsageFromConsumer sets the usage_from_consumer field with calculated tokens
+// Does NOT modify the original "usage" field from the LLM
+func SetUsageFromConsumer(setter CustomUsageSetter, promptTokens, completionTokens int) {
+	if setter == nil {
+		return
+	}
+	setter.SetCustomUsage("usage_from_consumer", promptTokens, completionTokens)
 }


### PR DESCRIPTION
- Add internal/lib/tokens.go to centralize token counting (CountTokens, CountPromptTokens) and usage updating helpers.
- Update proxy_sender chat completion handling to robustly detect streaming chunks (including choices+usage), accumulate deltas, and compute&append usage on the final streaming chunk using the shared helpers.
- Align proxy_receiver usage handling with the new helpers so non‑streaming and streaming responses have consistent prompt_tokens, completion_tokens, and total_tokens fields.