### PR TITLE
feat: add input_tokens and output_tokens in session report

### DIFF
--- a/proxy-router/internal/proxyapi/controller_morrpc.go
+++ b/proxy-router/internal/proxyapi/controller_morrpc.go
@@ -167,7 +167,7 @@ func (s *MORRPCController) sessionPrompt(ctx context.Context, msg m.RPCMessage, 
 	}
 
 	now := time.Now().Unix()
-	ttftMs, totalTokens, err := s.service.SessionPrompt(ctx, msg.ID, user.PubKey, []byte(req.Message), req.SessionID, sendResponse, sourceLog)
+	ttftMs, inputTokens, outputTokens, err := s.service.SessionPrompt(ctx, msg.ID, user.PubKey, []byte(req.Message), req.SessionID, sendResponse, sourceLog)
 	if err != nil {
 		sourceLog.Error(err)
 		return err
@@ -178,8 +178,8 @@ func (s *MORRPCController) sessionPrompt(ctx context.Context, msg m.RPCMessage, 
 		requestDuration = 1
 	}
 
-	tpsScaled1000 := totalTokens * 1000 / requestDuration
-	session.AddStats(tpsScaled1000, ttftMs)
+	tpsScaled1000 := outputTokens * 1000 / requestDuration
+	session.AddStats(tpsScaled1000, ttftMs, inputTokens, outputTokens)
 
 	err = s.sessionRepo.SaveSession(ctx, session)
 	if err != nil {
@@ -569,7 +569,7 @@ func (s *MORRPCController) processStreamedAudioFile(ctx context.Context, session
 	}
 
 	now := time.Now().Unix()
-	ttftMs, totalTokens, err := s.service.SessionPrompt(ctx, requestID, userPubKey, payload, sessionID, sendResponse, sourceLog)
+	ttftMs, inputTokens, outputTokens, err := s.service.SessionPrompt(ctx, requestID, userPubKey, payload, sessionID, sendResponse, sourceLog)
 	if err != nil {
 		sourceLog.Error(err)
 		return err
@@ -580,8 +580,8 @@ func (s *MORRPCController) processStreamedAudioFile(ctx context.Context, session
 		requestDuration = 1
 	}
 
-	tpsScaled1000 := totalTokens * 1000 / requestDuration
-	session.AddStats(tpsScaled1000, ttftMs)
+	tpsScaled1000 := outputTokens * 1000 / requestDuration
+	session.AddStats(tpsScaled1000, ttftMs, inputTokens, outputTokens)
 
 	err = s.sessionRepo.SaveSession(ctx, session)
 	if err != nil {

--- a/proxy-router/internal/proxyapi/morrpcmessage/abi.go
+++ b/proxy-router/internal/proxyapi/morrpcmessage/abi.go
@@ -15,4 +15,6 @@ var sessionReportAbi = []lib.AbiParameter{
 	{Type: "uint128"}, // timestamp
 	{Type: "uint32"},  // tpsScaled1000
 	{Type: "uint32"},  // ttftMs
+	{Type: "uint32"},  // inputTokens
+	{Type: "uint32"},  // outputTokens
 }

--- a/proxy-router/internal/proxyapi/morrpcmessage/mor_rpc.go
+++ b/proxy-router/internal/proxyapi/morrpcmessage/mor_rpc.go
@@ -84,10 +84,10 @@ func (m *MORRPCMessage) InitiateSessionResponse(providerPubKey lib.HexString, us
 	}, nil
 }
 
-func (m *MORRPCMessage) SessionReportResponse(tps uint32, ttfp uint32, sessionID common.Hash, providerPrivateKeyHex lib.HexString, requestID string, chainID *big.Int) (*RpcResponse, error) {
+func (m *MORRPCMessage) SessionReportResponse(tps uint32, ttfp uint32, inputTokens uint32, outputTokens uint32, sessionID common.Hash, providerPrivateKeyHex lib.HexString, requestID string, chainID *big.Int) (*RpcResponse, error) {
 	timestamp := m.generateTimestamp()
 
-	report, err := lib.EncodeAbiParameters(sessionReportAbi, []interface{}{sessionID, chainID, big.NewInt(int64(timestamp)), tps, ttfp})
+	report, err := lib.EncodeAbiParameters(sessionReportAbi, []interface{}{sessionID, chainID, big.NewInt(int64(timestamp)), tps, ttfp, inputTokens, outputTokens})
 	if err != nil {
 		return &RpcResponse{}, err
 	}

--- a/proxy-router/internal/repositories/session/session_model.go
+++ b/proxy-router/internal/repositories/session/session_model.go
@@ -16,6 +16,8 @@ type SessionModel struct {
 
 	tpsScaled1000Arr []int
 	ttftMsArr        []int
+	inputTokens      int
+	outputTokens     int
 	failoverEnabled  bool
 	directPayment    bool
 }
@@ -57,9 +59,19 @@ func (s *SessionModel) DirectPayment() bool {
 	return s.directPayment
 }
 
-func (s *SessionModel) AddStats(tpsScaled1000 int, ttftMs int) {
+func (s *SessionModel) AddStats(tpsScaled1000 int, ttftMs int, inputTokens int, outputTokens int) {
 	s.tpsScaled1000Arr = append(s.tpsScaled1000Arr, tpsScaled1000)
 	s.ttftMsArr = append(s.ttftMsArr, ttftMs)
+	s.inputTokens += inputTokens
+	s.outputTokens += outputTokens
+}
+
+func (s *SessionModel) InputTokens() int {
+	return s.inputTokens
+}
+
+func (s *SessionModel) OutputTokens() int {
+	return s.outputTokens
 }
 
 func (s *SessionModel) SetFailoverEnabled(enabled bool) {

--- a/proxy-router/internal/repositories/session/session_repo.go
+++ b/proxy-router/internal/repositories/session/session_repo.go
@@ -3,10 +3,10 @@ package sessionrepo
 import (
 	"context"
 
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/repositories/registries"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/storages"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
 )
 
 type SessionRepositoryCached struct {
@@ -108,6 +108,8 @@ func (r *SessionRepositoryCached) getSessionFromCache(id common.Hash) (*SessionM
 		endsAt:           ses.EndsAt,
 		tpsScaled1000Arr: ses.TPSScaled1000Arr,
 		ttftMsArr:        ses.TTFTMsArr,
+		inputTokens:      ses.InputTokens,
+		outputTokens:     ses.OutputTokens,
 		failoverEnabled:  ses.FailoverEnabled,
 		agentUsername:    ses.AgentUsername,
 	}, true
@@ -122,6 +124,8 @@ func (r *SessionRepositoryCached) saveSessionToCache(ses *SessionModel) error {
 		ModelID:          ses.modelID.Hex(),
 		TPSScaled1000Arr: ses.tpsScaled1000Arr,
 		TTFTMsArr:        ses.ttftMsArr,
+		InputTokens:      ses.inputTokens,
+		OutputTokens:     ses.outputTokens,
 		FailoverEnabled:  ses.failoverEnabled,
 		DirectPayment:    ses.directPayment,
 		AgentUsername:    ses.agentUsername,

--- a/proxy-router/internal/storages/structs.go
+++ b/proxy-router/internal/storages/structs.go
@@ -16,6 +16,8 @@ type Session struct {
 
 	TPSScaled1000Arr []int
 	TTFTMsArr        []int
+	InputTokens      int
+	OutputTokens     int
 	FailoverEnabled  bool
 	DirectPayment    bool
 }


### PR DESCRIPTION
New Report ABI:
```
var sessionReportAbi = []lib.AbiParameter{
	{Type: "bytes32"}, // sessionID
	{Type: "uint256"}, // chainID
	{Type: "uint128"}, // timestamp
	{Type: "uint32"},  // tpsScaled1000
	{Type: "uint32"},  // ttftMs
	{Type: "uint32"},  // inputTokens
	{Type: "uint32"},  // outputTokens
}
```