### PR TITLE
fix: prevent NaN provider scores from negative variance (production hotfix)

### DIFF
--- a/proxy-router/internal/rating/common.go
+++ b/proxy-router/internal/rating/common.go
@@ -32,7 +32,11 @@ func normRange(input float64, normRange float64) float64 {
 
 // getSD calculates the standard deviation from the standard deviation struct
 func getSD(sd s.LibSDSD, obsNum int64) float64 {
-	return math.Sqrt(getVariance(sd, obsNum))
+	variance := getVariance(sd, obsNum)
+	if variance <= 0 {
+		return 0
+	}
+	return math.Sqrt(variance)
 }
 
 // getVariance calculates the variance from the standard deviation struct


### PR DESCRIPTION
## Problem

In production, the C-Node is logging `provider score is not valid NaN` for our provider (`0xB399E0009784bf0eb871e946643c92dC1055E362`) on the `kimi-k2.5` model, causing **all session creation to fail** with `no provider accepting session`.

### Root Cause

`LibSDSD.SqSum` is a signed `int64` on-chain. When session activity accumulates (especially during repeated crash/restart cycles), the sum of squared values can overflow the int64 range and wrap to a **negative value**.

In `getSD()`:
```go
return math.Sqrt(getVariance(sd, obsNum))
```

`getVariance()` divides the negative `SqSum` by `(obsNum-1)`, producing a **negative variance**. `math.Sqrt(negative)` returns `NaN` per IEEE 754.

This NaN propagates through all score components — even with `weight=0`, because **`0 * NaN = NaN`** in floating point — causing every provider to be rejected in `RateBids`.

### Fix

Guard against negative (and zero) variance in `getSD`, returning `0` the same way the zero-observation case does. This degrades gracefully to the success/stake score components.

## Impact

- **Severity**: P0 — complete production outage, 0 sessions creating successfully
- **Affected**: All models served by our provider where on-chain stats have overflowed
- **Workaround attempted**: Rating config weight zeroing does not work due to `0 * NaN = NaN`

## Test

Existing `TestZeroObservations` test already validates non-NaN output for zero stats. The fix ensures negative-SqSum (overflow) scenarios also produce valid scores.

Made with [Cursor](https://cursor.com)