### PR TITLE
fix: prevent NaN provider scores from blocking session creation

### DIFF
--- a/proxy-router/internal/rating/common.go
+++ b/proxy-router/internal/rating/common.go
@@ -40,7 +40,13 @@ func getVariance(sd s.LibSDSD, obsNum int64) float64 {
 	if obsNum <= 1 {
 		return 0
 	}
-	return float64(sd.SqSum) / float64(obsNum-1)
+	v := float64(sd.SqSum) / float64(obsNum-1)
+	if v < 0 {
+		// SqSum should never be negative (sum of squares), but can happen
+		// due to integer overflow in on-chain computation or ABI truncation
+		return 0
+	}
+	return v
 }
 
 // cutRange01 cuts the value to the range [0, 1]

--- a/proxy-router/internal/rating/rating.go
+++ b/proxy-router/internal/rating/rating.go
@@ -25,7 +25,7 @@ func (r *Rating) RateBids(scoreInputs []RatingInput, log lib.ILogger) []RatingRe
 		}
 
 		if math.IsNaN(score) || math.IsInf(score, 0) {
-			log.Warnf("provider score is not valid %d for %+v), skipping", score, input)
+			log.Warnf("provider score is not valid %f for %+v), skipping", score, input)
 			continue
 		}
 

--- a/proxy-router/internal/storages/storage_test.go
+++ b/proxy-router/internal/storages/storage_test.go
@@ -1,0 +1,98 @@
+package storages
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+	badger "github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStorage_CorruptionRecovery(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "testdb")
+	log := &lib.LoggerMock{}
+
+	opts := badger.DefaultOptions(dbPath)
+	opts.Logger = nil
+
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+
+	for i := 0; i < 5000; i++ {
+		err := db.Update(func(txn *badger.Txn) error {
+			key := []byte(fmt.Sprintf("key-%06d", i))
+			val := make([]byte, 4096)
+			return txn.Set(key, val)
+		})
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, db.Close())
+
+	sstFiles, err := filepath.Glob(filepath.Join(dbPath, "*.sst"))
+	require.NoError(t, err)
+	require.NotEmpty(t, sstFiles, "expected SST files after writing data")
+
+	t.Logf("created %d SST files, deleting one to simulate corruption", len(sstFiles))
+	require.NoError(t, os.Remove(sstFiles[0]))
+
+	storage, err := NewStorage(log, dbPath)
+	require.NoError(t, err, "NewStorage should recover from corruption")
+	defer storage.Close()
+
+	require.NoError(t, storage.Set([]byte("post-recovery"), []byte("works")))
+	val, err := storage.Get([]byte("post-recovery"))
+	require.NoError(t, err)
+	require.Equal(t, "works", string(val))
+
+	_, err = storage.Get([]byte("key-000001"))
+	require.ErrorIs(t, err, badger.ErrKeyNotFound, "old data should be gone after recovery")
+}
+
+func TestNewStorage_NormalOpen(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "testdb")
+	log := &lib.LoggerMock{}
+
+	storage, err := NewStorage(log, dbPath)
+	require.NoError(t, err)
+
+	require.NoError(t, storage.Set([]byte("hello"), []byte("world")))
+	require.NoError(t, storage.Close())
+
+	storage2, err := NewStorage(log, dbPath)
+	require.NoError(t, err)
+	defer storage2.Close()
+
+	val, err := storage2.Get([]byte("hello"))
+	require.NoError(t, err)
+	require.Equal(t, "world", string(val))
+}
+
+func TestIsBadgerCorruptionError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"nil error", nil, false},
+		{"generic error", fmt.Errorf("connection refused"), false},
+		{"permission denied", fmt.Errorf("permission denied"), false},
+		{"file does not exist for table", fmt.Errorf("file does not exist for table 8"), true},
+		{"file with ID not found", fmt.Errorf("file with ID: 2719 not found"), true},
+		{"MANIFEST error", fmt.Errorf("MANIFEST file corrupted"), true},
+		{"checksum mismatch", fmt.Errorf("checksum mismatch for table"), true},
+		{"table file corruption", fmt.Errorf("Table file corruption detected"), true},
+		{"value log truncate", fmt.Errorf("Value log truncate required"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, isBadgerCorruptionError(tt.err))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Fix NaN provider scoring bug**: On-chain `LibSD.sqSum` can drift negative due to integer division truncation in Welford's algorithm after many session close cycles. This causes `sqrt(negative) = NaN`, which bypasses the `sd == 0` guard and propagates through the entire scoring pipeline — every bid is skipped, producing "no provider accepting session" errors indefinitely. Added a negative variance guard in `getVariance()` to clamp to zero.
- **Fix broken NaN test**: `require.NotEqual(t, math.NaN(), score)` always passes because `NaN != NaN` is true in IEEE 754. Replaced with `require.False(t, math.IsNaN(score))` and added a regression test with negative `SqSum`.
- **Fix log format verb**: Changed `%d` to `%f` for float64 score in the warning log (was producing garbled `%!d(float64=NaN)` output).
- **BadgerDB corruption auto-recovery**: Detect corruption errors on startup and automatically wipe + recreate the database instead of failing permanently.