### PR TITLE
fix: rehydrate session cache from chain on startup to prevent orphaned sessions

### DIFF
--- a/proxy-router/internal/blockchainapi/service.go
+++ b/proxy-router/internal/blockchainapi/service.go
@@ -978,6 +978,45 @@ func (s *BlockchainService) GetSessions(ctx context.Context, user, provider comm
 	return mapSessions(ids, sessions, bids), nil
 }
 
+// GetUnclosedUserSessions fetches a page of sessions for a user and returns
+// only those that are still open on-chain (ClosedAt == 0). Bids are fetched
+// only for the unclosed subset, avoiding unnecessary RPC calls for the
+// (typically much larger) set of already-closed sessions.
+func (s *BlockchainService) GetUnclosedUserSessions(ctx context.Context, user common.Address, offset *big.Int, limit uint8, order r.Order) (unclosed []*structs.Session, closedCount int, totalFetched int, err error) {
+	ids, sessions, err := s.sessionRouter.GetSessionsByUser(ctx, user, offset, limit, order)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+
+	totalFetched = len(sessions)
+
+	var unclosedIDs [][32]byte
+	var unclosedSes []sr.ISessionStorageSession
+	for i, ses := range sessions {
+		if ses.ClosedAt.Int64() == 0 {
+			unclosedIDs = append(unclosedIDs, ids[i])
+			unclosedSes = append(unclosedSes, ses)
+		} else {
+			closedCount++
+		}
+	}
+
+	if len(unclosedIDs) == 0 {
+		return nil, closedCount, totalFetched, nil
+	}
+
+	bidIDs := make([][32]byte, len(unclosedSes))
+	for i, ses := range unclosedSes {
+		bidIDs[i] = ses.BidId
+	}
+	_, bids, err := s.marketplace.GetMultipleBids(ctx, bidIDs)
+	if err != nil {
+		return nil, closedCount, totalFetched, err
+	}
+
+	return mapSessions(unclosedIDs, unclosedSes, bids), closedCount, totalFetched, nil
+}
+
 func (s *BlockchainService) GetSessionsIds(ctx context.Context, user, provider common.Address, offset *big.Int, limit uint8, order r.Order) ([]common.Hash, error) {
 	ids, err := s.sessionRouter.GetSessionsIdsByUser(ctx, user, offset, limit, order)
 

--- a/proxy-router/internal/blockchainapi/session_expiry_handler.go
+++ b/proxy-router/internal/blockchainapi/session_expiry_handler.go
@@ -2,11 +2,19 @@ package blockchainapi
 
 import (
 	"context"
+	"math/big"
 	"time"
 
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/interfaces"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+	r "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/repositories/registries"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/storages"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	rehydrationPageSize       uint8 = 255
+	earlyTerminationThreshold       = 3 // consecutive all-closed pages before stopping
 )
 
 type SessionExpiryHandler struct {
@@ -39,8 +47,97 @@ func (s *SessionExpiryHandler) getWalletAddress() (string, error) {
 	return addr.Hex(), nil
 }
 
+// rehydrateFromChain queries the blockchain for all sessions opened by this
+// wallet and populates the local BadgerDB cache with any that are still
+// unclosed. This allows the node to recover session state after a restart
+// with ephemeral storage, enabling it to both close expired orphaned sessions
+// and resume routing for sessions that are still active.
+//
+// Two optimizations are applied:
+//   - Two-pass filtering: session data is fetched first and filtered for
+//     ClosedAt == 0 before fetching the associated bid data, avoiding
+//     unnecessary RPC calls for already-closed sessions.
+//   - Early termination: when scanning in descending order (newest first),
+//     the scan stops after encountering several consecutive pages of
+//     entirely-closed sessions, since older sessions are overwhelmingly
+//     likely to also be closed.
+func (s *SessionExpiryHandler) rehydrateFromChain(ctx context.Context) {
+	addr, err := s.getWalletAddress()
+	if err != nil {
+		s.log.Errorf("rehydration: cannot get wallet address: %s", err)
+		return
+	}
+
+	walletAddr := common.HexToAddress(addr)
+	now := time.Now().Unix()
+	var offset uint64
+	var rehydratedExpired, rehydratedActive, totalClosed int
+	var consecutiveAllClosedPages int
+
+	s.log.Infof("Rehydrating session cache from chain for %s", addr)
+
+	for {
+		unclosed, closedInPage, fetched, err := s.blockchainService.GetUnclosedUserSessions(
+			ctx, walletAddr,
+			new(big.Int).SetUint64(offset), rehydrationPageSize,
+			r.OrderDESC,
+		)
+		if err != nil {
+			s.log.Errorf("rehydration: error at offset %d: %s", offset, err)
+			break
+		}
+		if fetched == 0 {
+			break
+		}
+
+		totalClosed += closedInPage
+
+		if len(unclosed) == 0 && closedInPage > 0 {
+			consecutiveAllClosedPages++
+			if consecutiveAllClosedPages >= earlyTerminationThreshold {
+				s.log.Infof(
+					"Rehydration: %d consecutive all-closed pages at offset %d, stopping scan early",
+					earlyTerminationThreshold, offset,
+				)
+				break
+			}
+		} else {
+			consecutiveAllClosedPages = 0
+		}
+
+		for _, ses := range unclosed {
+			err := s.sessionStorage.AddSession(&storages.Session{
+				Id:           ses.Id,
+				UserAddr:     ses.User.Hex(),
+				ProviderAddr: ses.Provider.Hex(),
+				EndsAt:       ses.EndsAt,
+				ModelID:      ses.ModelAgentId,
+			})
+			if err != nil {
+				s.log.Warnf("rehydration: error caching session %s: %s", ses.Id, err)
+				continue
+			}
+
+			if ses.EndsAt.Int64() < now {
+				rehydratedExpired++
+			} else {
+				rehydratedActive++
+			}
+		}
+
+		offset += uint64(fetched)
+	}
+
+	s.log.Infof(
+		"Rehydration complete: %d expired-unclosed, %d active, %d closed (skipped)",
+		rehydratedExpired, rehydratedActive, totalClosed,
+	)
+}
+
 // Run starts the session autoclose process, checking every minute if any session has ended and closes it.
 func (s *SessionExpiryHandler) Run(ctx context.Context) error {
+	s.rehydrateFromChain(ctx)
+
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 


### PR DESCRIPTION
## Problem

The C-Node's `SESSION_CLOSER` relies on a local BadgerDB cache to track which sessions it needs to close. However, the C-Node runs on ECS Fargate with **ephemeral storage** — unlike the P-Node which uses EFS-backed persistent BadgerDB. Every time the C-Node task restarts or is redeployed, the local BadgerDB is wiped clean.

This creates a critical issue: **sessions opened by a previous C-Node instance become orphaned**. The new instance has no record of them, so the `SESSION_CLOSER` never attempts to close them on-chain. Consequences:

- **User MOR stake remains locked** in the `SessionRouter` contract indefinitely (we observed ~30,245 MOR locked across 177 unclosed sessions in production)
- **Provider payouts are blocked** because `closeSession` is atomic — it refunds the user AND pays the provider in a single transaction
- **The C-Node retries in a tight loop** (every 60 seconds) for sessions it *does* know about, generating thousands of `cannot close session` log entries when the funding account is also low

This was discovered on 2026-03-06 when production logs showed 60,728+ C-Node errors and 19,731+ API Gateway `expired_session_close_error` events, traced back to a combination of a depleted `fundingAccount` and orphaned sessions from previous deployments.

## Solution

On startup, `SessionExpiryHandler.Run()` now calls a new `rehydrateFromChain()` method **before** the ticker loop begins. This method:

1. Queries the blockchain for all sessions opened by this wallet via `getUserSessions()`
2. Filters for sessions where `ClosedAt == 0` (still unclosed on-chain)
3. Populates the local BadgerDB cache with those sessions
4. The existing ticker loop then naturally processes them:
   - **Expired unclosed sessions** (`EndsAt < now`) → closed on-chain, releasing user stake
   - **Active sessions** (`EndsAt > now`) → cached and available for request routing

This means the C-Node fully recovers its session state after any restart, making ephemeral storage a non-issue for session management. The blockchain becomes the source of truth, as it should be.

### Optimizations

Two optimizations keep the startup scan efficient even for wallets with thousands of historical sessions:

1. **Two-pass filtering** (`GetUnclosedUserSessions` in `service.go`): Raw session data is fetched and filtered for `ClosedAt == 0` *before* fetching associated bid data. This avoids unnecessary multicall RPC requests for the typically much larger set of already-closed sessions.

2. **Early termination**: Scanning newest-first (DESC order), the scan stops after 3 consecutive pages (765 sessions) of entirely-closed sessions. Since sessions are opened chronologically, once we pass the unclosed region, everything older is overwhelmingly likely to also be closed.

## Changes

| File | Change |
|---|---|
| `proxy-router/internal/blockchainapi/session_expiry_handler.go` | Added `rehydrateFromChain()` method; call it at the top of `Run()` before the ticker starts |
| `proxy-router/internal/blockchainapi/service.go` | Added `GetUnclosedUserSessions()` — a two-pass variant of `GetSessions()` that filters for unclosed sessions before fetching bid data |

## Design Decisions

- **Non-fatal**: If rehydration fails partway (e.g., RPC timeout), the ticker loop still starts with whatever was cached. Partial rehydration is better than none.
- **Synchronous before ticker**: Runs before the ticker starts so the cache is fully populated before the first tick. This avoids a race between the closer and the rehydrator.
- **Idempotent**: `AddSession` overwrites existing entries. Safe across repeated calls.
- **DESC pagination**: Most recent sessions are cached first. If interrupted, the most relevant sessions (recently active/expired) are already in cache.
- **Missing performance fields**: Fields like `TPSScaled1000Arr`, `TTFTMsArr`, and `AgentUsername` are not available from chain data and default to zero/empty. The closer doesn't need them, and for active session routing they restart from zero which is acceptable.

## Test Plan

- [ ] Verify the C-Node starts up and rehydration log messages appear (`Rehydrating session cache from chain for 0x...` and `Rehydration complete: N expired-unclosed, N active, N closed (skipped)`)
- [ ] Confirm expired unclosed sessions are closed on-chain after rehydration
- [ ] Confirm active sessions are available for request routing after a restart
- [ ] Verify early termination kicks in for wallets with large session history (check for `stopping scan early` log)
- [ ] Verify normal session lifecycle (open, use, close) is unaffected
- [ ] Deploy to dev/staging and monitor CloudWatch for `SESSION_CLOSER` log patterns


Made with [Cursor](https://cursor.com)