### PR TITLE
fix: pause active models refresh during provider rolling deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -917,6 +917,14 @@ jobs:
           aws-secret-access-key: ${{ secrets.MORPHEUS_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
 
+      - name: Pause Active Models refresh
+        run: |
+          ENV="prd"
+          RULE_NAME="${ENV}-morpheus-active-models-updater"
+          echo "⏸️ Disabling Active Models EventBridge rule: $RULE_NAME"
+          aws events disable-rule --name "$RULE_NAME" --region us-east-2
+          echo "✅ Active Models refresh paused — prevents stale data during provider rolling deploy"
+
       - name: Deploy to Morpheus Provider ECS
         run: |
           BUILDTAG=${{ needs.Generate-Tag.outputs.tag_name }}
@@ -1131,6 +1139,36 @@ jobs:
             # Don't fail the deployment for version mismatch, as it might be a timing issue
             # The ECS service update was successful, version verification is informational
             echo "⚠️ Continuing with warning - ECS deployment completed but version verification inconclusive"
+          fi
+
+      - name: Resume Active Models refresh
+        if: always()
+        run: |
+          ENV="prd"
+          RULE_NAME="${ENV}-morpheus-active-models-updater"
+          FUNCTION_NAME="${ENV}-morpheus-active-models-updater"
+          
+          echo "▶️ Re-enabling Active Models EventBridge rule: $RULE_NAME"
+          aws events enable-rule --name "$RULE_NAME" --region us-east-2
+          echo "✅ Active Models refresh re-enabled"
+          
+          echo "🔄 Invoking Active Models Lambda to refresh immediately..."
+          INVOKE_RESULT=$(aws lambda invoke \
+            --function-name "$FUNCTION_NAME" \
+            --region us-east-2 \
+            --log-type Tail \
+            --payload '{}' \
+            /tmp/lambda-response.json 2>&1)
+          
+          INVOKE_STATUS=$?
+          if [ $INVOKE_STATUS -eq 0 ]; then
+            echo "✅ Active Models Lambda invoked successfully"
+            echo "📋 Response:"
+            cat /tmp/lambda-response.json | jq . 2>/dev/null || cat /tmp/lambda-response.json
+          else
+            echo "⚠️ Active Models Lambda invocation failed (status: $INVOKE_STATUS)"
+            echo "$INVOKE_RESULT"
+            echo "ℹ️ The EventBridge schedule will pick it up on the next cycle"
           fi
 
   UI-macOS-latest-arm64:


### PR DESCRIPTION
## Summary
- Pauses the Active Models EventBridge schedule before the provider node rolling deploy to prevent the Lambda from writing stale/empty data to S3 when it can't ping the restarting provider
- Re-enables the schedule after deploy completes (`if: always()` ensures re-enable even on failure)
- Immediately invokes the Lambda post-deploy so active models are refreshed without waiting for the next schedule cycle

## Companion Terraform Changes (Morpheus-Infra — separate apply)
1. **ECS stop-before-start** (`03_svc_provider.tf`): `deployment_minimum_healthy_percent = 0`, `deployment_maximum_percent = 100` — guarantees the old provider task stops before the new one starts (required due to BadgerDB file locking on shared EFS)
2. **IAM permissions** (`01_iam_role_gh_actions.tf`): Adds `events:DisableRule`/`events:EnableRule` and `lambda:InvokeFunction` scoped to the `prd-morpheus-active-models-updater` resources

## Deploy Order
1. Apply Morpheus-Infra Terraform changes first (IAM + ECS deployment config)
2. Merge this PR — the next `main` push will use the new CICD flow

## Test plan
- [ ] Verify Terraform plan for `02-morpheus_c_node` shows IAM policy additions only
- [ ] Verify Terraform plan for `02-morpheus_p_node` shows ECS service deployment config change only
- [ ] Apply Terraform changes
- [ ] Merge to dev, then test → verify CICD pipeline runs the pause/resume steps
- [ ] Merge to main → confirm provider deploy pauses/resumes Active Models and Lambda invocation succeeds in the workflow logs


Made with [Cursor](https://cursor.com)