### PR TITLE
fix(cicd): add go module verification and fix stale go.sum

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,51 @@ env:
   TEST_ENV_VAR: "test"
 
 jobs:
+  Go-Module-Verify:
+    name: Verify Go Modules
+    if: |
+      github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      (
+        (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test' || github.ref == 'refs/heads/dev')) ||
+        (github.event_name == 'workflow_dispatch') 
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.x"
+          cache-dependency-path: |
+            proxy-router/go.sum
+            cli/go.sum
+
+      - name: Verify proxy-router go.mod/go.sum are in sync
+        working-directory: proxy-router
+        run: |
+          go mod tidy
+          if ! git diff --exit-code go.mod go.sum; then
+            echo ""
+            echo "❌ proxy-router/go.mod or go.sum is out of date!"
+            echo "Run 'cd proxy-router && go mod tidy' locally and commit the changes."
+            exit 1
+          fi
+          echo "✅ proxy-router go.mod/go.sum are in sync"
+
+      - name: Verify cli go.mod/go.sum are in sync
+        working-directory: cli
+        run: |
+          go mod tidy
+          if ! git diff --exit-code go.mod go.sum; then
+            echo ""
+            echo "❌ cli/go.mod or go.sum is out of date!"
+            echo "Run 'cd cli && go mod tidy' locally and commit the changes."
+            exit 1
+          fi
+          echo "✅ cli go.mod/go.sum are in sync"
+
   Generate-Tag:
     runs-on: ubuntu-latest
     name: Generate Tag Name
@@ -133,7 +178,9 @@ jobs:
         (github.event_name == 'workflow_dispatch') 
       )
     runs-on: ubuntu-latest
-    needs: Generate-Tag
+    needs:
+      - Generate-Tag
+      - Go-Module-Verify
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -251,7 +298,9 @@ jobs:
         (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true') 
       )
-    needs: Generate-Tag
+    needs:
+      - Generate-Tag
+      - Go-Module-Verify
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/holiman/uint256 v1.3.1 // indirect
-	github.com/joho/godotenv v1.5.1
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -21,8 +21,6 @@ github.com/ethereum/go-ethereum v1.14.11 h1:8nFDCUUE67rPc6AKxFj7JKaOa2W/W1Rse3oS
 github.com/ethereum/go-ethereum v1.14.11/go.mod h1:+l/fr42Mma+xBnhefL/+z11/hcmJ2egl+ScIVPjhc7E=
 github.com/holiman/uint256 v1.3.1 h1:JfTzmih28bittyHM8z360dCjIA9dbPIBlcTI6lmctQs=
 github.com/holiman/uint256 v1.3.1/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
-github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
-github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=

--- a/proxy-router/go.sum
+++ b/proxy-router/go.sum
@@ -835,8 +835,8 @@ github.com/swaggo/swag v1.16.4/go.mod h1:VBsHJRsDvfYvqoiMKnsdwhNV9LEMHgEDZcyVYX0
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDdvS342BElfbETmL1Aiz3i2t0zfRj16Hs=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/tiktoken-go/tokenizer v0.2.1 h1:/VBr0BUWaSO1yMsnJliVVyCmEMzHDzTJNYxWxR0jWQA=
-github.com/tiktoken-go/tokenizer v0.2.1/go.mod h1:7SZW3pZUKWLJRilTvWCa86TOVIiiJhYj3FQ5V3alWcg=
+github.com/tiktoken-go/tokenizer v0.7.0 h1:VMu6MPT0bXFDHr7UPh9uii7CNItVt3X9K90omxL54vw=
+github.com/tiktoken-go/tokenizer v0.7.0/go.mod h1:6UCYI/DtOallbmL7sSy30p6YQv60qNyU/4aVigPOx6w=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=


### PR DESCRIPTION
## Summary

- Adds a **Go-Module-Verify** CI job that runs `go mod tidy` on both `proxy-router/` and `cli/` modules, then checks `git diff --exit-code` — failing the build with a clear remediation message if `go.mod` or `go.sum` are out of sync
- Gates `Build-Proxy-Router-Test` and `Build-Service-Executables` on the verify job, so stale checksums are caught **before** any Docker build, executable build, or deployment
- Fixes existing drift: `proxy-router/go.sum` had `tiktoken-go/tokenizer v0.2.1` checksums while `go.mod` referenced `v0.7.0`; `cli/go.mod` had an unused `godotenv` dependency

## Context

Surfaced during review of external PR #637 — the contributor included a `go.sum` fix that should have been caught by CI. Both the Dockerfile and Build-Service-Executables already run `go mod tidy` before building (so deployed artifacts were safe), but there was no guardrail to prevent the drift from being committed. This also caused incorrect CI cache keys since `hashFiles('**/go.sum')` was using stale checksums.

## Test plan

- [ ] CI runs on this branch (dev triggers build + test, no deploy) — the new Go-Module-Verify job should pass since go.sum is now correct
- [ ] Verify the job would fail on the previous commit by checking the `go.sum` diff shown in this PR
- [ ] Confirm Build-Proxy-Router-Test and Build-Service-Executables still succeed (they already ran `go mod tidy` internally, now they also wait for the verify gate)


Made with [Cursor](https://cursor.com)