### PR TITLE
fix(cicd): healthcheck version verification case-sensitivity bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -579,9 +579,9 @@ jobs:
               echo "📡 Health response: $HEALTH_RESPONSE"
               
               # Parse version from JSON response
-              DEPLOYED_VERSION=$(echo "$HEALTH_RESPONSE" | jq -r '.Version // empty' 2>/dev/null)
-              UPTIME=$(echo "$HEALTH_RESPONSE" | jq -r '.Uptime // empty' 2>/dev/null)
-              STATUS=$(echo "$HEALTH_RESPONSE" | jq -r '.Status // empty' 2>/dev/null)
+              DEPLOYED_VERSION=$(echo "$HEALTH_RESPONSE" | jq -r '(.version // .Version // empty)' 2>/dev/null)
+              UPTIME=$(echo "$HEALTH_RESPONSE" | jq -r '(.uptime // .Uptime // empty)' 2>/dev/null)
+              STATUS=$(echo "$HEALTH_RESPONSE" | jq -r '(.status // .Status // empty)' 2>/dev/null)
               
               if [ -n "$DEPLOYED_VERSION" ] && [ "$STATUS" = "healthy" ]; then
                 echo "🏥 Service Status: $STATUS"
@@ -834,9 +834,9 @@ jobs:
               echo "📡 Health response: $HEALTH_RESPONSE"
               
               # Parse version from JSON response
-              DEPLOYED_VERSION=$(echo "$HEALTH_RESPONSE" | jq -r '.Version // empty' 2>/dev/null)
-              UPTIME=$(echo "$HEALTH_RESPONSE" | jq -r '.Uptime // empty' 2>/dev/null)
-              STATUS=$(echo "$HEALTH_RESPONSE" | jq -r '.Status // empty' 2>/dev/null)
+              DEPLOYED_VERSION=$(echo "$HEALTH_RESPONSE" | jq -r '(.version // .Version // empty)' 2>/dev/null)
+              UPTIME=$(echo "$HEALTH_RESPONSE" | jq -r '(.uptime // .Uptime // empty)' 2>/dev/null)
+              STATUS=$(echo "$HEALTH_RESPONSE" | jq -r '(.status // .Status // empty)' 2>/dev/null)
               
               if [ -n "$DEPLOYED_VERSION" ] && [ "$STATUS" = "healthy" ]; then
                 echo "🏥 Service Status: $STATUS"
@@ -1078,9 +1078,9 @@ jobs:
               echo "📡 Health response: $HEALTH_RESPONSE"
               
               # Parse version from JSON response
-              DEPLOYED_VERSION=$(echo "$HEALTH_RESPONSE" | jq -r '.Version // empty' 2>/dev/null)
-              UPTIME=$(echo "$HEALTH_RESPONSE" | jq -r '.Uptime // empty' 2>/dev/null)
-              STATUS=$(echo "$HEALTH_RESPONSE" | jq -r '.Status // empty' 2>/dev/null)
+              DEPLOYED_VERSION=$(echo "$HEALTH_RESPONSE" | jq -r '(.version // .Version // empty)' 2>/dev/null)
+              UPTIME=$(echo "$HEALTH_RESPONSE" | jq -r '(.uptime // .Uptime // empty)' 2>/dev/null)
+              STATUS=$(echo "$HEALTH_RESPONSE" | jq -r '(.status // .Status // empty)' 2>/dev/null)
               
               if [ -n "$DEPLOYED_VERSION" ] && [ "$STATUS" = "healthy" ]; then
                 echo "🏥 Service Status: $STATUS"


### PR DESCRIPTION
## Summary
- Fixes a case-sensitivity bug in the post-deploy health verification across all three deploy jobs (Consumer, Titan, Provider)
- The healthcheck endpoint returns lowercase JSON keys (`status`, `version`, `uptime`) but the jq queries used PascalCase (`.Version`, `.Status`, `.Uptime`), causing version verification to silently fail on **every single deploy**
- The deploy itself succeeded because the verification was treated as a non-fatal warning, but version confirmation never actually worked

## Evidence
From [run #1372](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22857338948) (test branch deploy of v5.14.3-test):
```
📡 Health response: {"status":"healthy","version":"v5.14.3-test","uptime":"7m29s","components":{"badgerdb":"healthy, size=2048.0MB"}}
⚠️ Service not healthy or version not available
```
The service was healthy with the correct version, but jq returned empty strings due to the key casing.

## Fix
Changed `.Version` → `(.version // .Version // empty)` (and same for `.Status`, `.Uptime`) so lowercase is tried first with PascalCase as a fallback.

## Test plan
- [ ] Merge to dev → verify CI runs the build jobs
- [ ] Merge dev to test → verify the Consumer and Titan deploy jobs now show "Version verification successful!" instead of "Service not healthy or version not available"


Made with [Cursor](https://cursor.com)