### PR TITLE
docs: TEE provider setup and consumer verification guide

### DIFF
--- a/docs/02.3-proxy-router-tee.md
+++ b/docs/02.3-proxy-router-tee.md
@@ -1,0 +1,258 @@
+
+# Proxy-Router TEE (Trusted Execution Environment) Setup & Verification
+
+This document covers two perspectives:
+1. **Provider**: How to deploy a TEE-hardened P-Node on a Confidential VM
+2. **Consumer**: How to verify that a provider's image is genuine and untampered
+
+---
+
+## What is the TEE Image?
+
+The `-tee` Docker image (`ghcr.io/morpheusais/morpheus-lumerin-node-tee`) is a hardened version of the standard proxy-router image with all non-secret configuration **baked in at build time**. This means:
+
+* Blockchain config (BASE Mainnet contracts, chain ID) cannot be changed
+* Chat context storage is disabled (`PROXY_STORE_CHAT_CONTEXT=false`)
+* Logging is set to production mode (JSON, no color, minimal verbosity)
+* Environment is locked to `production`
+
+Only **5 variables** are configurable at runtime — these are the secrets that differ per provider:
+
+| Variable | Description |
+|---|---|
+| `WALLET_PRIVATE_KEY` | Provider's wallet private key |
+| `ETH_NODE_ADDRESS` | RPC endpoint for BASE Mainnet (e.g., Alchemy, Infura) |
+| `MODELS_CONFIG_CONTENT` | JSON model configuration (model IDs, backend URLs, slots) |
+| `WEB_PUBLIC_URL` | Public-facing URL for the API (default: `http://localhost:8082`) |
+| `COOKIE_CONTENT` | API authentication credentials (default: `admin:admin`) |
+
+Because the configuration is frozen in the image, when it runs inside a TEE (Intel TDX or AMD SEV-SNP), the hardware can measure and attest that the software layer has not been modified.
+
+---
+
+## Part 1: Provider — Setting Up a TEE P-Node
+
+### Prerequisites
+
+* A funded wallet with MOR and ETH on BASE Mainnet and access to the private key
+* A BASE Mainnet RPC endpoint (e.g., `wss://base-mainnet.g.alchemy.com/v2/<your_key>`)
+* Your AI model backend accessible via a private endpoint (e.g., `http://my-model:8080/v1/chat/completions`)
+* A model configuration JSON (see [models-config.json.md](models-config.json.md) for format)
+* Access to a Confidential VM provider that supports Intel TDX or AMD SEV-SNP (e.g., [SecretVM](https://secretai.scrtlabs.com/secret-vms/create))
+
+### Step 1: Prepare the Docker Compose File
+
+The canonical compose file for TEE deployment is [`proxy-router/docker-compose.tee.yml`](../proxy-router/docker-compose.tee.yml):
+
+```yaml
+services:
+  proxy-router:
+    image: ghcr.io/morpheusais/morpheus-lumerin-node-tee:v5.14.6-test
+    restart: unless-stopped
+    ports:
+      - 8082:8082
+      - 3333:3333
+    volumes:
+      - proxy_data:/app/data
+    environment:
+      - WALLET_PRIVATE_KEY=${WALLET_PRIVATE_KEY}
+      - ETH_NODE_ADDRESS=${ETH_NODE_ADDRESS}
+      - MODELS_CONFIG_CONTENT=${MODELS_CONFIG_CONTENT}
+      - WEB_PUBLIC_URL=${WEB_PUBLIC_URL:-http://localhost:8082}
+      - COOKIE_CONTENT=${COOKIE_CONTENT:-admin:admin}
+    env_file:
+      - usr/.env
+volumes:
+  proxy_data: null
+```
+
+Update the `image:` tag to the version you want to deploy. Published images are listed at:
+https://github.com/orgs/MorpheusAIs/packages?repo_name=Morpheus-Lumerin-Node
+
+### Step 2: Prepare Your Secrets
+
+Your TEE platform will provide a mechanism to inject encrypted secrets that are only accessible inside the enclave.
+
+You need to set these 5 values:
+
+```
+WALLET_PRIVATE_KEY=<your_private_key>
+ETH_NODE_ADDRESS=wss://base-mainnet.g.alchemy.com/v2/<your_alchemy_key>
+MODELS_CONFIG_CONTENT=<your_models_json_single_line>
+WEB_PUBLIC_URL=https://your-public-domain.com:8082
+COOKIE_CONTENT=admin:<your_secure_password>
+```
+
+**Preparing `MODELS_CONFIG_CONTENT`**: This must be a single-line JSON string. Example:
+
+```
+MODELS_CONFIG_CONTENT={"models":[{"modelId":"0x626bcb19...","modelName":"hermes-4-14b","apiType":"openai","apiUrl":"http://your-model:8080/v1/chat/completions","concurrentSlots":6,"capacityPolicy":"simple"}]}
+```
+
+See [models-config.json.md](models-config.json.md) for the full schema.
+
+### Step 3: Deploy on SecretVM (or Other TEE Platform)
+
+For **SecretVM** (https://secretai.scrtlabs.com/secret-vms/create):
+
+1. Navigate to the SecretVM creation page
+2. Paste the contents of `docker-compose.tee.yml` into the compose configuration
+3. Enter your 5 secret values in the encrypted secrets section
+4. Select your hardware preference (Intel TDX or AMD SEV-SNP)
+5. Deploy the VM
+
+For other TEE platforms, consult their documentation for deploying Docker Compose workloads with encrypted secret injection. The image and compose file are platform-agnostic — any environment that supports `linux/amd64` Docker containers inside a TEE will work.
+
+### Step 4: Verify the Node is Running
+
+Once deployed, check the health endpoint:
+
+```bash
+curl https://<your-node-url>:8082/healthcheck
+```
+
+Expected response:
+```json
+{
+  "status": "healthy",
+  "version": "v5.14.6-test",
+  "uptime": "1m30s"
+}
+```
+
+Then proceed with the standard provider setup: register your provider, create your model (with the `tee` tag), and create a bid. See [03-provider-offer.md](03-provider-offer.md) for those steps.
+
+### Step 5: Verify Attestation (SecretVM)
+
+After deployment, SecretVM provides an attestation endpoint at port `29343`. You can verify your own deployment:
+
+1. **Quick verification** at https://secretai.scrtlabs.com/attestation — paste your compose file and the VM URL
+2. **Programmatic verification** — see Part 2 below
+
+---
+
+## Part 2: Consumer — Verifying a TEE Provider Image
+
+As a consumer, you can independently verify that a provider is running a genuine, untampered TEE image before interacting with it. This verification will eventually be built into the C-Node automatically for models tagged `tee`, but you can do it manually today.
+
+### Install cosign
+
+```bash
+# macOS
+brew install cosign
+
+# Linux (Debian/Ubuntu)
+sudo apt install cosign
+
+# Or download from: https://github.com/sigstore/cosign/releases
+```
+
+### Step 1: Verify the Image Signature
+
+This confirms the image was built by the official MorpheusAIs GitHub Actions CI/CD pipeline — not a fork, not a manual push, not a modified build.
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'MorpheusAIs/Morpheus-Lumerin-Node' \
+  ghcr.io/morpheusais/morpheus-lumerin-node-tee:<version>
+```
+
+A successful output will show:
+```
+Verification for ghcr.io/morpheusais/morpheus-lumerin-node-tee:<version> --
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - Existence of the claims in the transparency log was verified offline
+  - The code-signing certificate was verified using trusted certificate authority certificates
+```
+
+The output JSON includes the exact GitHub commit, branch, and workflow that produced the image.
+
+If verification **fails**, the image should not be trusted.
+
+### Step 2: Inspect the TEE Attestation Manifest
+
+The attestation manifest is a signed JSON document attached to the image that records exactly what configuration was baked into the TEE image.
+
+```bash
+cosign verify-attestation \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'MorpheusAIs/Morpheus-Lumerin-Node' \
+  --type https://morpheusais.github.io/tee-attestation/v1 \
+  ghcr.io/morpheusais/morpheus-lumerin-node-tee:<version> \
+  2>/dev/null | jq -r '.payload' | base64 -d | jq '.predicate'
+```
+
+This returns a JSON object. Key fields to check:
+
+| Field | What to Look For |
+|---|---|
+| `tee_image_digest` | The immutable `sha256:...` digest of this exact image |
+| `base_image_digest` | The digest of the standard image this TEE image was built on |
+| `compose_sha256` | Hash of the canonical `docker-compose.tee.yml` |
+| `build.commit` | The Git commit that produced this image — you can inspect the source |
+| `build.run_url` | Direct link to the GitHub Actions run that built it |
+| `baked_env.PROXY_STORE_CHAT_CONTEXT` | Should be `"false"` — confirms chat logging is disabled |
+| `baked_env.ENVIRONMENT` | Should be `"production"` |
+| `baked_env.ETH_NODE_CHAIN_ID` | Should be `"8453"` (BASE Mainnet) |
+| `runtime_secrets_only` | Lists the 5 variables that can differ per provider — everything else is frozen |
+
+### Step 3: View All Supply-Chain Artifacts
+
+To see the full tree of artifacts attached to an image:
+
+```bash
+cosign tree ghcr.io/morpheusais/morpheus-lumerin-node-tee:<version>
+```
+
+This shows:
+* **Signatures** (`.sig`) — proves who built it
+* **Attestations** (`.att`) — the TEE manifest with config hashes and build provenance
+* **SBOMs** (`.sbom`) — full inventory of Go dependencies in the binary
+
+### Step 4: Verify the Running Provider (SecretVM Attestation)
+
+If the provider is running on SecretVM, you can verify the hardware attestation:
+
+1. Go to https://secretai.scrtlabs.com/attestation
+2. Paste the `docker-compose.tee.yml` contents
+3. Enter the provider's VM URL or paste their attestation quote
+4. Click **Verify**
+
+The verification checks three layers:
+* **Hardware layer** — the CPU is a genuine Intel TDX or AMD SEV-SNP TEE
+* **VM layer** — the firmware, kernel, and initramfs match a known SecretVM release
+* **Software layer (RTMR3)** — the rootfs and Docker Compose match what was deployed
+
+If all three layers pass, the provider is running exactly the software that was published by the official CI/CD — inside genuine TEE hardware — with no ability to modify the configuration at runtime.
+
+---
+
+## What This Guarantees (and What It Doesn't)
+
+**Guarantees:**
+* The proxy-router binary is the exact binary built by the official CI/CD from a known commit
+* Chat context storage is disabled and cannot be re-enabled
+* Logging is in production mode and cannot be increased to capture prompts
+* The blockchain configuration (contracts, chain ID) is immutable
+* The image has not been tampered with between build and deployment
+
+**Current limitations (to be addressed in future phases):**
+* The model backend (LLM) that the proxy-router connects to is not yet attested separately. In future versions, the proxy-router and LLM will run in the same TEE VM.
+* Manual verification is required today. Future C-Node releases will automate this for models tagged `tee` on the blockchain.
+* Hardware attestation measurement values (RTMR3/SEV measurement) are not yet computed in CI/CD. The attestation manifest includes compose and Dockerfile hashes, which are the inputs to the measurement computation.
+
+---
+
+## Reference
+
+| Resource | Link |
+|---|---|
+| TEE images on GHCR | https://github.com/orgs/MorpheusAIs/packages?repo_name=Morpheus-Lumerin-Node |
+| Sigstore cosign | https://github.com/sigstore/cosign |
+| SecretVM documentation | https://docs.scrt.network/secret-network-documentation/secretvm-confidential-virtual-machines |
+| SecretVM attestation portal | https://secretai.scrtlabs.com/attestation |
+| Model configuration format | [models-config.json.md](models-config.json.md) |
+| Provider offer setup | [03-provider-offer.md](03-provider-offer.md) |
+| Standard Docker setup | [02.1-proxy-router-docker.md](02.1-proxy-router-docker.md) |


### PR DESCRIPTION
## Summary

- New doc at `docs/02.3-proxy-router-tee.md` following the existing provider setup numbering
- **Provider section**: Step-by-step guide for deploying a TEE-hardened P-Node on SecretVM (or any Intel TDX / AMD SEV platform)
- **Consumer section**: How to manually verify image signatures, inspect the signed attestation manifest, and validate hardware attestation via the SecretVM portal
- Includes a clear "what this guarantees / what it doesn't" section covering current limitations

## Context

Companion to the CI/CD supply-chain hardening (PR #646) and the compose format fix (PR #648). This gives providers and consumers the practical instructions to use the new TEE artifacts.


Made with [Cursor](https://cursor.com)