### PR TITLE
docs: cherry-pick SecretVM CLI instructions from test (PR #652)

### DIFF
--- a/docs/02.3-proxy-router-tee.md
+++ b/docs/02.3-proxy-router-tee.md
@@ -93,13 +93,44 @@ See [models-config.json.md](models-config.json.md) for the full schema.
 
 ### Step 3: Deploy on SecretVM (or Other TEE Platform)
 
-For **SecretVM** (https://secretai.scrtlabs.com/secret-vms/create):
+For **SecretVM** you can either use the web portal (https://secretai.scrtlabs.com/secret-vms/create) or **secretvm-cli**:
+
+#### Option A: Using the SecretAI Developers Portal
 
 1. Navigate to the SecretVM creation page
 2. Paste the contents of `docker-compose.tee.yml` into the compose configuration
 3. Enter your 5 secret values in the encrypted secrets section
 4. Select your hardware preference (Intel TDX or AMD SEV-SNP)
 5. Deploy the VM
+
+#### Option B: Using the SecretVM CLI
+
+1. Install the CLI.
+```bash
+sudo npm install --global secretvm-cli
+```
+2. Authenticate with your SecretAI devportal account:
+```bash
+secretvm-cli auth login
+```
+3. Use the CLI to create your VM, passing in your Docker Compose file and the required runtime secrets:
+```bash
+secretvm-cli -k <your_secret_vm_api_key> vm create \
+  --name <your_vm_name> \
+  --type small \
+  --persistence \
+  --upgradeability \
+  --docker-compose proxy-router/docker-compose.tee.yml \
+  --env <path_to_your_env_file_with_the_5_secret_values> \
+  --platform tdx # or sev
+```
+
+4. You can check the provisioning status of your new VM directly from the terminal:
+```bash
+secretvm-cli -k <your_secret_vm_api_key> vm list
+```
+
+`Note`: For complete installation instructions, global options, and the most up-to-date command reference, please consult the official [SecretVM CLI documentation](https://docs.scrt.network/secret-network-documentation/secretvm-confidential-virtual-machines/secretvm-cli).
 
 For other TEE platforms, consult their documentation for deploying Docker Compose workloads with encrypted secret injection. The image and compose file are platform-agnostic — any environment that supports `linux/amd64` Docker containers inside a TEE will work.
 


### PR DESCRIPTION
## Summary

Cherry-picks the SecretVM CLI deployment instructions contributed by SCRT Labs (PR #652) from `test` into `dev` to keep branches in sync.

Adds `secretvm-cli` as an alternative to the web portal for provisioning TEE VMs, including install, auth, `vm create`, and `vm list` commands.

## Context

PR #652 was submitted by SCRT Labs targeting `test` directly. This cherry-pick brings the same commit into `dev` so there are no merge conflicts when `dev` flows forward to `test`.


Made with [Cursor](https://cursor.com)