### PR TITLE
feat: compute RTMR3 in CI/CD and publish in signed attestation manifest

### DIFF
--- a/.github/actions/docker_test/action.yml
+++ b/.github/actions/docker_test/action.yml
@@ -80,7 +80,7 @@ runs:
 
     # Set up the Go environment
     - name: Set up Go environment
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: 1.23
 

--- a/.github/actions/upload_release/action.yml
+++ b/.github/actions/upload_release/action.yml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/github-script@v3
+    - uses: actions/github-script@v7
       with:
         script: |
           const fs = require('fs');
@@ -32,7 +32,7 @@ runs:
             }
             
             console.log(`Uploading file: ${file}`);
-            await github.repos.uploadReleaseAsset({
+            await github.rest.repos.uploadReleaseAsset({
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: releaseId,

--- a/.github/tee/secretvm.env
+++ b/.github/tee/secretvm.env
@@ -3,17 +3,23 @@
 #
 # Source: https://github.com/scrtlabs/secret-vm-build/releases
 # Algorithm: scrtlabs/reproduce-mr (RTMR3 = replayRTMR of sha256(compose) + sha256(rootfs))
+#
+# IMPORTANT: Always use the "prod" rootfs variant — SecretVM runs "environment prod"
+# even for developer portal deployments. Using "dev" rootfs produces wrong RTMR3.
 
-SECRETVM_RELEASE=v0.0.23
+SECRETVM_RELEASE=v0.0.25
+SECRETVM_ROOTFS_VARIANT=rootfs-prod-tdx
 
-# Intel TDX rootfs (non-GPU, dev — used for proxy-router P-Node deployments)
-SECRETVM_ROOTFS_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.23/rootfs-dev-v0.0.23-tdx.iso
-SECRETVM_ROOTFS_TDX_SHA256=c0537c896f6084c04b89a76ce95fe06a654b3b36c1aaa8bff77f0e6512216336
+# Intel TDX rootfs (non-GPU, prod — used for proxy-router P-Node deployments)
+# URL is derived: .../download/${RELEASE}/${VARIANT_BASE}-${RELEASE}-tdx.iso
+SECRETVM_ROOTFS_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.25/rootfs-prod-v0.0.25-tdx.iso
+# SHA256 will be captured on first CI/CD run and pinned here
+SECRETVM_ROOTFS_TDX_SHA256=
 
-# Future: AMD SEV rootfs
-# SECRETVM_ROOTFS_SEV_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.23/rootfs-dev-v0.0.23-sev.iso
-# SECRETVM_ROOTFS_SEV_SHA256=a80ce27f69ac6c5f51ca3e1fae572fba48a19b4d4be633b13bccac5fc8eeeb41
+# AMD SEV rootfs (prod)
+# SECRETVM_ROOTFS_SEV_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.25/rootfs-prod-v0.0.25-sev.iso
+# SECRETVM_ROOTFS_SEV_SHA256=
 
-# Future: GPU variant (for co-located proxy+LLM deployments)
-# SECRETVM_ROOTFS_GPU_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.23/rootfs-gpu-prod-v0.0.23-tdx.iso
-# SECRETVM_ROOTFS_GPU_TDX_SHA256=56b9aa7607e847c43d7bfea6144c7fccc1b995083deba092c4627b5dc60b8629
+# GPU variant (for co-located proxy+LLM deployments)
+# SECRETVM_ROOTFS_GPU_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.25/rootfs-gpu-prod-v0.0.25-tdx.iso
+# SECRETVM_ROOTFS_GPU_TDX_SHA256=

--- a/.github/tee/secretvm.env
+++ b/.github/tee/secretvm.env
@@ -1,0 +1,19 @@
+# SecretVM artifact configuration for RTMR3 computation
+# Update these when SCRT Labs publishes a new stable VM release.
+#
+# Source: https://github.com/scrtlabs/secret-vm-build/releases
+# Algorithm: scrtlabs/reproduce-mr (RTMR3 = replayRTMR of sha256(compose) + sha256(rootfs))
+
+SECRETVM_RELEASE=v0.0.23
+
+# Intel TDX rootfs (non-GPU, dev — used for proxy-router P-Node deployments)
+SECRETVM_ROOTFS_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.23/rootfs-dev-v0.0.23-tdx.iso
+SECRETVM_ROOTFS_TDX_SHA256=c0537c896f6084c04b89a76ce95fe06a654b3b36c1aaa8bff77f0e6512216336
+
+# Future: AMD SEV rootfs
+# SECRETVM_ROOTFS_SEV_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.23/rootfs-dev-v0.0.23-sev.iso
+# SECRETVM_ROOTFS_SEV_SHA256=a80ce27f69ac6c5f51ca3e1fae572fba48a19b4d4be633b13bccac5fc8eeeb41
+
+# Future: GPU variant (for co-located proxy+LLM deployments)
+# SECRETVM_ROOTFS_GPU_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.23/rootfs-gpu-prod-v0.0.23-tdx.iso
+# SECRETVM_ROOTFS_GPU_TDX_SHA256=56b9aa7607e847c43d7bfea6144c7fccc1b995083deba092c4627b5dc60b8629

--- a/.github/tee/secretvm.env
+++ b/.github/tee/secretvm.env
@@ -14,7 +14,7 @@ SECRETVM_ROOTFS_VARIANT=rootfs-prod-tdx
 # URL is derived: .../download/${RELEASE}/${VARIANT_BASE}-${RELEASE}-tdx.iso
 SECRETVM_ROOTFS_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.25/rootfs-prod-v0.0.25-tdx.iso
 # SHA256 will be captured on first CI/CD run and pinned here
-SECRETVM_ROOTFS_TDX_SHA256=
+SECRETVM_ROOTFS_TDX_SHA256=2a6d16965f5ce5143bcba614bb7896cdfc598a71c6e1ecc55efd3d8f74ba7c8a
 
 # AMD SEV rootfs (prod)
 # SECRETVM_ROOTFS_SEV_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.25/rootfs-prod-v0.0.25-sev.iso

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,7 +243,7 @@ jobs:
           fetch-tags: true
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -340,7 +340,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.0
 
       - name: Install syft
         uses: anchore/sbom-action/download-syft@v0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -422,7 +422,18 @@ jobs:
           sed "s|image: .*|image: ${TEE_IMAGE}@${DIGEST}|" \
             proxy-router/docker-compose.tee.yml > /tmp/docker-compose.tee.deployed.yml
           
+          # SecretVM appends a trailing newline to compose content — ensure ours matches
+          if [ "$(tail -c1 /tmp/docker-compose.tee.deployed.yml | xxd -p)" != "0a" ] || \
+             [ "$(tail -c2 /tmp/docker-compose.tee.deployed.yml | xxd -p)" != "0a0a" ]; then
+            echo "" >> /tmp/docker-compose.tee.deployed.yml
+          fi
+          
+          COMPOSE_BYTES=$(wc -c < /tmp/docker-compose.tee.deployed.yml | tr -d ' ')
+          COMPOSE_SHA=$(sha256sum /tmp/docker-compose.tee.deployed.yml | cut -d' ' -f1)
+          echo "compose_sha256=$COMPOSE_SHA" >> $GITHUB_OUTPUT
+          
           echo "📋 Generated deployed compose (digest-pinned):" >> $GITHUB_STEP_SUMMARY
+          echo "   SHA-256: \`$COMPOSE_SHA\`  (${COMPOSE_BYTES} bytes)" >> $GITHUB_STEP_SUMMARY
           echo '```yaml' >> $GITHUB_STEP_SUMMARY
           cat /tmp/docker-compose.tee.deployed.yml >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
@@ -432,9 +443,17 @@ jobs:
         run: |
           RTMR3=$(python3 proxy-router/scripts/compute-rtmr3.py \
             /tmp/docker-compose.tee.deployed.yml \
-            /tmp/secretvm-artifacts/rootfs-dev-tdx.iso)
-          echo "rtmr3=$RTMR3" >> $GITHUB_OUTPUT
-          echo "🔐 Expected RTMR3: \`$RTMR3\`" >> $GITHUB_STEP_SUMMARY
+            /tmp/secretvm-artifacts/rootfs-dev-tdx.iso \
+            --json)
+          
+          RTMR3_HEX=$(echo "$RTMR3" | python3 -c "import sys,json; print(json.load(sys.stdin)['rtmr3'])")
+          COMPOSE_HASH=$(echo "$RTMR3" | python3 -c "import sys,json; print(json.load(sys.stdin)['compose_sha256'])")
+          ROOTFS_HASH=$(echo "$RTMR3" | python3 -c "import sys,json; print(json.load(sys.stdin)['rootfs_sha256'])")
+          
+          echo "rtmr3=$RTMR3_HEX" >> $GITHUB_OUTPUT
+          echo "🔐 Expected RTMR3: \`$RTMR3_HEX\`" >> $GITHUB_STEP_SUMMARY
+          echo "   compose sha256: \`$COMPOSE_HASH\`" >> $GITHUB_STEP_SUMMARY
+          echo "   rootfs sha256:  \`$ROOTFS_HASH\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Generate and attach SBOM
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -434,12 +434,6 @@ jobs:
           sed "s|image: .*|image: ${TEE_IMAGE}@${DIGEST}|" \
             proxy-router/docker-compose.tee.yml > /tmp/docker-compose.tee.deployed.yml
           
-          # SecretVM appends a trailing newline to compose content — ensure ours matches
-          if [ "$(tail -c1 /tmp/docker-compose.tee.deployed.yml | xxd -p)" != "0a" ] || \
-             [ "$(tail -c2 /tmp/docker-compose.tee.deployed.yml | xxd -p)" != "0a0a" ]; then
-            echo "" >> /tmp/docker-compose.tee.deployed.yml
-          fi
-          
           COMPOSE_BYTES=$(wc -c < /tmp/docker-compose.tee.deployed.yml | tr -d ' ')
           COMPOSE_SHA=$(sha256sum /tmp/docker-compose.tee.deployed.yml | cut -d' ' -f1)
           echo "compose_sha256=$COMPOSE_SHA" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -335,6 +335,7 @@ jobs:
       id-token: write
     outputs:
       digest: ${{ steps.capture-digest.outputs.digest }}
+      rtmr3: ${{ steps.compute-rtmr3.outputs.rtmr3 }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -591,13 +592,32 @@ jobs:
           docker buildx imagetools create -t $TEE_IMAGE:$LATEST_TAG $TEE_IMAGE:$BUILDTAG || (echo "❌ Failed to create TEE :$LATEST_TAG tag" && exit 1)
           echo "✅ TEE Image tag pushed: $TEE_IMAGE:$LATEST_TAG"
 
+  Deploy-SecretVM-Test:
+    name: Deploy TEE Image to SecretVM (test)
+    if: github.ref == 'refs/heads/test'
+    needs:
+      - Generate-Tag
+      - GHCR-Build-and-Push-TEE
+    runs-on: ubuntu-latest
+    environment: test
+    steps:
+      - name: Download deployed compose artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: docker-compose-tee-deployed-${{ needs.Generate-Tag.outputs.tag_name }}
+          path: /tmp
+
       - name: Deploy to SecretVM test instance
-        if: ${{ secrets.SECRETVM_API_KEY != '' && secrets.SECRETVM_TEST_VM_UUID != '' && secrets.SECRETVM_TEST_ENV != '' }}
         env:
           SECRETVM_API_KEY: ${{ secrets.SECRETVM_API_KEY }}
           SECRETVM_TEST_VM_UUID: ${{ secrets.SECRETVM_TEST_VM_UUID }}
           SECRETVM_TEST_ENV_B64: ${{ secrets.SECRETVM_TEST_ENV }}
         run: |
+          if [ -z "$SECRETVM_API_KEY" ] || [ -z "$SECRETVM_TEST_VM_UUID" ] || [ -z "$SECRETVM_TEST_ENV_B64" ]; then
+            echo "⏭️  SecretVM secrets not configured — skipping deploy" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
           npm install --global secretvm-cli
 
           echo "$SECRETVM_TEST_ENV_B64" | base64 -d > /tmp/secretvm-test.env
@@ -612,7 +632,7 @@ jobs:
 
           echo "✅ SecretVM test instance updated with new TEE image" >> $GITHUB_STEP_SUMMARY
           echo "   Compose: \`docker-compose-tee-deployed-${{ needs.Generate-Tag.outputs.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "   Expected RTMR3: \`${{ steps.compute-rtmr3.outputs.rtmr3 }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "   Expected RTMR3: \`${{ needs.GHCR-Build-and-Push-TEE.outputs.rtmr3 }}\`" >> $GITHUB_STEP_SUMMARY
 
   Build-Service-Executables:
     name: Build Service Executables

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -393,6 +393,7 @@ jobs:
         run: |
           source .github/tee/secretvm.env
           echo "release=$SECRETVM_RELEASE" >> $GITHUB_OUTPUT
+          echo "rootfs_variant=$SECRETVM_ROOTFS_VARIANT" >> $GITHUB_OUTPUT
           echo "rootfs_url=$SECRETVM_ROOTFS_TDX_URL" >> $GITHUB_OUTPUT
           echo "rootfs_sha256=$SECRETVM_ROOTFS_TDX_SHA256" >> $GITHUB_OUTPUT
 
@@ -401,17 +402,28 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /tmp/secretvm-artifacts
-          key: secretvm-${{ steps.secretvm-config.outputs.release }}-rootfs-dev-tdx
+          key: secretvm-${{ steps.secretvm-config.outputs.release }}-${{ steps.secretvm-config.outputs.rootfs_variant }}
 
       - name: Download SecretVM rootfs
         if: steps.cache-rootfs.outputs.cache-hit != 'true'
         run: |
           mkdir -p /tmp/secretvm-artifacts
           echo "⬇️  Downloading SecretVM rootfs (${{ steps.secretvm-config.outputs.release }})..."
-          curl -L --retry 3 --retry-delay 5 -o /tmp/secretvm-artifacts/rootfs-dev-tdx.iso \
+          ROOTFS_FILE="/tmp/secretvm-artifacts/${{ steps.secretvm-config.outputs.rootfs_variant }}.iso"
+          curl -L --retry 3 --retry-delay 5 -o "$ROOTFS_FILE" \
             "${{ steps.secretvm-config.outputs.rootfs_url }}"
-          echo "${{ steps.secretvm-config.outputs.rootfs_sha256 }}  /tmp/secretvm-artifacts/rootfs-dev-tdx.iso" | sha256sum -c -
-          echo "✅ SecretVM rootfs downloaded and verified" >> $GITHUB_STEP_SUMMARY
+          
+          ACTUAL_SHA=$(sha256sum "$ROOTFS_FILE" | cut -d' ' -f1)
+          EXPECTED_SHA="${{ steps.secretvm-config.outputs.rootfs_sha256 }}"
+          
+          if [ -n "$EXPECTED_SHA" ]; then
+            echo "$EXPECTED_SHA  $ROOTFS_FILE" | sha256sum -c -
+            echo "✅ SecretVM rootfs downloaded and verified" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⚠️  No expected SHA256 configured — rootfs hash: \`$ACTUAL_SHA\`" >> $GITHUB_STEP_SUMMARY
+            echo "   PIN THIS in .github/tee/secretvm.env as SECRETVM_ROOTFS_TDX_SHA256" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "   rootfs sha256: \`$ACTUAL_SHA\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Generate deployed compose with immutable digest
         id: generate-compose
@@ -441,9 +453,10 @@ jobs:
       - name: Compute RTMR3 (Intel TDX)
         id: compute-rtmr3
         run: |
+          ROOTFS_FILE="/tmp/secretvm-artifacts/${{ steps.secretvm-config.outputs.rootfs_variant }}.iso"
           RTMR3=$(python3 proxy-router/scripts/compute-rtmr3.py \
             /tmp/docker-compose.tee.deployed.yml \
-            /tmp/secretvm-artifacts/rootfs-dev-tdx.iso \
+            "$ROOTFS_FILE" \
             --json)
           
           RTMR3_HEX=$(echo "$RTMR3" | python3 -c "import sys,json; print(json.load(sys.stdin)['rtmr3'])")
@@ -473,6 +486,7 @@ jobs:
           BUILDTAG=${{ needs.Generate-Tag.outputs.tag_name }}
           RTMR3=${{ steps.compute-rtmr3.outputs.rtmr3 }}
           SECRETVM_RELEASE=${{ steps.secretvm-config.outputs.release }}
+          ROOTFS_VARIANT=${{ steps.secretvm-config.outputs.rootfs_variant }}
           ROOTFS_SHA256=${{ steps.secretvm-config.outputs.rootfs_sha256 }}
           
           COMPOSE_SHA="sha256:$(sha256sum /tmp/docker-compose.tee.deployed.yml | cut -d' ' -f1)"
@@ -495,6 +509,7 @@ jobs:
             --arg timestamp "$TIMESTAMP" \
             --arg rtmr3 "$RTMR3" \
             --arg secretvm_release "$SECRETVM_RELEASE" \
+            --arg rootfs_variant "$ROOTFS_VARIANT" \
             --arg rootfs_sha256 "$ROOTFS_SHA256" \
             '{
               tee_image: $tee_image,
@@ -536,7 +551,7 @@ jobs:
                 intel_tdx: {
                   rtmr3: $rtmr3,
                   secretvm_release: $secretvm_release,
-                  rootfs_variant: "rootfs-dev-tdx",
+                  rootfs_variant: $rootfs_variant,
                   rootfs_sha256: $rootfs_sha256,
                   note: "RTMR0-2 require full reproduce-mr with firmware/kernel/templates (Phase 1b follow-up)"
                 },

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -594,7 +594,7 @@ jobs:
 
   Deploy-SecretVM-Test:
     name: Deploy TEE Image to SecretVM (test)
-    if: github.ref == 'refs/heads/test'
+    if: github.ref == 'refs/heads/test' || startsWith(github.ref, 'refs/heads/cicd/')
     needs:
       - Generate-Tag
       - GHCR-Build-and-Push-TEE
@@ -636,12 +636,15 @@ jobs:
 
   Build-Service-Executables:
     name: Build Service Executables
-    if: |
-      github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
-      (
-        (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
-        (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true') 
-      )
+    # TEMPORARILY DISABLED — re-enable when merging to main/test
+    # Disabling this cascades: all UI-* build jobs and UI-Release are skipped.
+    if: false
+    # if: |
+    #   github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+    #   (
+    #     (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
+    #     (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true') 
+    #   )
     needs:
       - Generate-Tag
       - Go-Module-Verify

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,10 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.22.x"
           cache-dependency-path: |
@@ -117,7 +117,7 @@ jobs:
       artifacts_base_url: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ steps.gen_tag_name.outputs.tag_name }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -186,13 +186,13 @@ jobs:
       - Go-Module-Verify
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker Image to Test
         run: |
@@ -237,19 +237,19 @@ jobs:
       digest: ${{ steps.capture-digest.outputs.digest }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -337,19 +337,19 @@ jobs:
       digest: ${{ steps.capture-digest.outputs.digest }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Install syft
         uses: anchore/sbom-action/download-syft@v0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -398,7 +398,7 @@ jobs:
 
       - name: Cache SecretVM rootfs
         id: cache-rootfs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/secretvm-artifacts
           key: secretvm-${{ steps.secretvm-config.outputs.release }}-rootfs-dev-tdx
@@ -543,7 +543,7 @@ jobs:
           echo "🔏 TEE attestation manifest signed and attached to \`$TEE_IMAGE@$DIGEST\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload deployed compose as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: docker-compose-tee-deployed-${{ needs.Generate-Tag.outputs.tag_name }}
           path: /tmp/docker-compose.tee.deployed.yml
@@ -577,13 +577,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.22.x"
           cache-dependency-path: |
@@ -591,7 +591,7 @@ jobs:
             cli/go.sum
 
       - name: Cache Go build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/go-build
@@ -680,7 +680,7 @@ jobs:
 
 
       - name: Upload CLI artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cli
           path: |
@@ -691,7 +691,7 @@ jobs:
             cli/win-x64-morpheus-cli-${{ needs.Generate-Tag.outputs.vfull }}.exe
     
       - name: Upload ProxyRouter artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: proxy-router
           path: |
@@ -716,13 +716,13 @@ jobs:
     environment: ${{ github.ref_name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.TITAN_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TITAN_AWS_SECRET_ACCESS_KEY }}
@@ -971,13 +971,13 @@ jobs:
     environment: ${{ github.ref_name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.MORPHEUS_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.MORPHEUS_AWS_SECRET_ACCESS_KEY }}
@@ -1227,13 +1227,13 @@ jobs:
     environment: ${{ github.ref_name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.MORPHEUS_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.MORPHEUS_AWS_SECRET_ACCESS_KEY }}
@@ -1510,20 +1510,20 @@ jobs:
     steps:
       - name: Clone
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: "yarn"
           cache-dependency-path: ui-desktop/yarn.lock
 
       - name: Cache Electron binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/electron
@@ -1552,7 +1552,7 @@ jobs:
           yarn build:mac-arm64
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: ./ui-desktop/dist/mac-arm64-morpheus-app-${{ needs.Generate-Tag.outputs.vfull }}.dmg
           name: mac-arm64-morpheus-app-${{ needs.Generate-Tag.outputs.vfull }}.dmg
@@ -1574,20 +1574,20 @@ jobs:
     steps:
       - name: Clone
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: "yarn"
           cache-dependency-path: ui-desktop/yarn.lock
 
       - name: Cache Electron binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/electron
@@ -1615,7 +1615,7 @@ jobs:
           yarn build:linux-x64
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: ./ui-desktop/dist/linux-x86_64-morpheus-app-${{ needs.Generate-Tag.outputs.vfull }}.AppImage
           name: linux-x86_64-morpheus-app-${{ needs.Generate-Tag.outputs.vfull }}.AppImage
@@ -1637,20 +1637,20 @@ jobs:
     steps:
       - name: Clone
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: "yarn"
           cache-dependency-path: ui-desktop/yarn.lock
 
       - name: Cache Electron binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/electron
@@ -1678,7 +1678,7 @@ jobs:
           yarn build:linux-arm64
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: ./ui-desktop/dist/linux-arm64-morpheus-app-${{ needs.Generate-Tag.outputs.vfull }}.AppImage
           name: linux-arm64-morpheus-app-${{ needs.Generate-Tag.outputs.vfull }}.AppImage
@@ -1700,20 +1700,20 @@ jobs:
     steps:
       - name: Clone
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: "yarn"
           cache-dependency-path: ui-desktop/yarn.lock
 
       - name: Cache Electron binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/electron
@@ -1742,7 +1742,7 @@ jobs:
           yarn build:mac-x64
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: ./ui-desktop/dist/mac-x64-morpheus-app-${{ needs.Generate-Tag.outputs.vfull }}.dmg
           name: mac-x64-morpheus-app-${{ needs.Generate-Tag.outputs.vfull }}.dmg
@@ -1764,20 +1764,20 @@ jobs:
     steps:
       - name: Clone
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: "yarn"
           cache-dependency-path: ui-desktop/yarn.lock
 
       - name: Cache Electron binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~\AppData\Local\electron
@@ -1787,7 +1787,7 @@ jobs:
             ${{ runner.os }}-electron-
 
       - name: Cache Chocolatey packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             C:\ProgramData\chocolatey\lib
@@ -1827,7 +1827,7 @@ jobs:
           yarn build:win-x64
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: ./ui-desktop/dist/win-x64-morpheus-app-${{ needs.Generate-Tag.outputs.vfull }}.exe
           name: win-x64-morpheus-app-${{ needs.Generate-Tag.outputs.vfull }}.exe
@@ -1852,14 +1852,14 @@ jobs:
     steps:
       - name: Clone
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Download artifacts
         id: download-artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ./artifact
           merge-multiple: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -591,6 +591,29 @@ jobs:
           docker buildx imagetools create -t $TEE_IMAGE:$LATEST_TAG $TEE_IMAGE:$BUILDTAG || (echo "❌ Failed to create TEE :$LATEST_TAG tag" && exit 1)
           echo "✅ TEE Image tag pushed: $TEE_IMAGE:$LATEST_TAG"
 
+      - name: Deploy to SecretVM test instance
+        if: ${{ secrets.SECRETVM_API_KEY != '' && secrets.SECRETVM_TEST_VM_UUID != '' && secrets.SECRETVM_TEST_ENV != '' }}
+        env:
+          SECRETVM_API_KEY: ${{ secrets.SECRETVM_API_KEY }}
+          SECRETVM_TEST_VM_UUID: ${{ secrets.SECRETVM_TEST_VM_UUID }}
+          SECRETVM_TEST_ENV_B64: ${{ secrets.SECRETVM_TEST_ENV }}
+        run: |
+          npm install --global secretvm-cli
+
+          echo "$SECRETVM_TEST_ENV_B64" | base64 -d > /tmp/secretvm-test.env
+
+          echo "🚀 Updating SecretVM test instance ${SECRETVM_TEST_VM_UUID:0:8}..." >> $GITHUB_STEP_SUMMARY
+
+          secretvm-cli -k "$SECRETVM_API_KEY" vm edit "$SECRETVM_TEST_VM_UUID" \
+            --docker-compose /tmp/docker-compose.tee.deployed.yml \
+            --env /tmp/secretvm-test.env
+
+          rm -f /tmp/secretvm-test.env
+
+          echo "✅ SecretVM test instance updated with new TEE image" >> $GITHUB_STEP_SUMMARY
+          echo "   Compose: \`docker-compose-tee-deployed-${{ needs.Generate-Tag.outputs.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "   Expected RTMR3: \`${{ steps.compute-rtmr3.outputs.rtmr3 }}\`" >> $GITHUB_STEP_SUMMARY
+
   Build-Service-Executables:
     name: Build Service Executables
     if: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -634,6 +634,80 @@ jobs:
           echo "   Compose: \`docker-compose-tee-deployed-${{ needs.Generate-Tag.outputs.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
           echo "   Expected RTMR3: \`${{ needs.GHCR-Build-and-Push-TEE.outputs.rtmr3 }}\`" >> $GITHUB_STEP_SUMMARY
 
+      - name: Verify attestation after deploy
+        env:
+          SECRETVM_API_KEY: ${{ secrets.SECRETVM_API_KEY }}
+          SECRETVM_TEST_VM_UUID: ${{ secrets.SECRETVM_TEST_VM_UUID }}
+          EXPECTED_RTMR3: ${{ needs.GHCR-Build-and-Push-TEE.outputs.rtmr3 }}
+        run: |
+          if [ -z "$SECRETVM_API_KEY" ] || [ -z "$SECRETVM_TEST_VM_UUID" ] || [ -z "$EXPECTED_RTMR3" ]; then
+            echo "⏭️  Skipping attestation verify (missing secrets or RTMR3)" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          echo "⏳ Waiting for VM to reboot with new image..." >> $GITHUB_STEP_SUMMARY
+
+          # vm attestation returns raw TDX quote hex; extract RTMR3 from known offset
+          # TDX Quote v4: 48-byte header + TD Report Body
+          # RTMR3 at body offset 472 bytes (48 bytes long)
+          RTMR3_HEX_START=$(( (48 + 472) * 2 ))
+          RTMR3_HEX_LEN=96
+
+          MAX_ATTEMPTS=12
+          SLEEP_SECS=30
+          MATCHED=false
+
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            echo "  Attestation poll attempt $i/$MAX_ATTEMPTS..."
+
+            RAW_QUOTE=$(secretvm-cli -k "$SECRETVM_API_KEY" vm attestation "$SECRETVM_TEST_VM_UUID" 2>/dev/null) || true
+
+            LIVE_RTMR3=$(echo "$RAW_QUOTE" | python3 -c "
+          import sys, json
+          try:
+              data = json.load(sys.stdin)
+              raw = data.get('result', '')
+              rtmr3 = raw[$RTMR3_HEX_START:$RTMR3_HEX_START+$RTMR3_HEX_LEN]
+              if len(rtmr3) == $RTMR3_HEX_LEN:
+                  print(rtmr3)
+              else:
+                  print('')
+          except:
+              print('')
+          " 2>/dev/null)
+
+            if [ -n "$LIVE_RTMR3" ]; then
+              echo "  Got RTMR3: ${LIVE_RTMR3:0:16}..."
+
+              if [ "$LIVE_RTMR3" = "$EXPECTED_RTMR3" ]; then
+                MATCHED=true
+                echo "🎉 **RTMR3 MATCH** — attestation verified!" >> $GITHUB_STEP_SUMMARY
+                echo "   Live RTMR3:     \`$LIVE_RTMR3\`" >> $GITHUB_STEP_SUMMARY
+                echo "   Expected RTMR3: \`$EXPECTED_RTMR3\`" >> $GITHUB_STEP_SUMMARY
+                break
+              else
+                echo "  RTMR3 mismatch (VM may still be rebooting)"
+                echo "    live:     $LIVE_RTMR3"
+                echo "    expected: $EXPECTED_RTMR3"
+              fi
+            else
+              echo "  No attestation data yet (VM may still be starting)"
+            fi
+
+            if [ "$i" -lt "$MAX_ATTEMPTS" ]; then
+              sleep $SLEEP_SECS
+            fi
+          done
+
+          if [ "$MATCHED" = false ]; then
+            echo "⚠️ **RTMR3 mismatch after ${MAX_ATTEMPTS} attempts** (${SLEEP_SECS}s × ${MAX_ATTEMPTS} = $(( SLEEP_SECS * MAX_ATTEMPTS ))s)" >> $GITHUB_STEP_SUMMARY
+            echo "   Live RTMR3:     \`${LIVE_RTMR3:-unavailable}\`" >> $GITHUB_STEP_SUMMARY
+            echo "   Expected RTMR3: \`$EXPECTED_RTMR3\`" >> $GITHUB_STEP_SUMMARY
+            echo "   This may indicate the VM is still rebooting, or there is a genuine mismatch." >> $GITHUB_STEP_SUMMARY
+            echo "   Check manually: \`secretvm-cli vm attestation $SECRETVM_TEST_VM_UUID\`" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
   Build-Service-Executables:
     name: Build Service Executables
     # TEMPORARILY DISABLED — re-enable when merging to main/test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.22.x"
+          go-version: "1.23.x"
           cache-dependency-path: |
             proxy-router/go.sum
             cli/go.sum
@@ -604,7 +604,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.22.x"
+          go-version: "1.23.x"
           cache-dependency-path: |
             proxy-router/go.sum
             cli/go.sum

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -388,6 +388,54 @@ jobs:
           cosign sign --yes "$TEE_IMAGE@$DIGEST"
           echo "🔏 TEE image signed: \`$TEE_IMAGE@$DIGEST\`" >> $GITHUB_STEP_SUMMARY
 
+      - name: Load SecretVM artifact config
+        id: secretvm-config
+        run: |
+          source .github/tee/secretvm.env
+          echo "release=$SECRETVM_RELEASE" >> $GITHUB_OUTPUT
+          echo "rootfs_url=$SECRETVM_ROOTFS_TDX_URL" >> $GITHUB_OUTPUT
+          echo "rootfs_sha256=$SECRETVM_ROOTFS_TDX_SHA256" >> $GITHUB_OUTPUT
+
+      - name: Cache SecretVM rootfs
+        id: cache-rootfs
+        uses: actions/cache@v4
+        with:
+          path: /tmp/secretvm-artifacts
+          key: secretvm-${{ steps.secretvm-config.outputs.release }}-rootfs-dev-tdx
+
+      - name: Download SecretVM rootfs
+        if: steps.cache-rootfs.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/secretvm-artifacts
+          echo "⬇️  Downloading SecretVM rootfs (${{ steps.secretvm-config.outputs.release }})..."
+          curl -L --retry 3 --retry-delay 5 -o /tmp/secretvm-artifacts/rootfs-dev-tdx.iso \
+            "${{ steps.secretvm-config.outputs.rootfs_url }}"
+          echo "${{ steps.secretvm-config.outputs.rootfs_sha256 }}  /tmp/secretvm-artifacts/rootfs-dev-tdx.iso" | sha256sum -c -
+          echo "✅ SecretVM rootfs downloaded and verified" >> $GITHUB_STEP_SUMMARY
+
+      - name: Generate deployed compose with immutable digest
+        id: generate-compose
+        run: |
+          TEE_IMAGE="${{ needs.Generate-Tag.outputs.image_name }}-tee"
+          DIGEST=${{ steps.capture-digest.outputs.digest }}
+          
+          sed "s|image: .*|image: ${TEE_IMAGE}@${DIGEST}|" \
+            proxy-router/docker-compose.tee.yml > /tmp/docker-compose.tee.deployed.yml
+          
+          echo "📋 Generated deployed compose (digest-pinned):" >> $GITHUB_STEP_SUMMARY
+          echo '```yaml' >> $GITHUB_STEP_SUMMARY
+          cat /tmp/docker-compose.tee.deployed.yml >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Compute RTMR3 (Intel TDX)
+        id: compute-rtmr3
+        run: |
+          RTMR3=$(python3 proxy-router/scripts/compute-rtmr3.py \
+            /tmp/docker-compose.tee.deployed.yml \
+            /tmp/secretvm-artifacts/rootfs-dev-tdx.iso)
+          echo "rtmr3=$RTMR3" >> $GITHUB_OUTPUT
+          echo "🔐 Expected RTMR3: \`$RTMR3\`" >> $GITHUB_STEP_SUMMARY
+
       - name: Generate and attach SBOM
         run: |
           TEE_IMAGE="${{ needs.Generate-Tag.outputs.image_name }}-tee"
@@ -404,30 +452,39 @@ jobs:
           BASE_IMAGE=${{ needs.Generate-Tag.outputs.image_name }}
           BASE_DIGEST=${{ needs.GHCR-Build-and-Push.outputs.digest }}
           BUILDTAG=${{ needs.Generate-Tag.outputs.tag_name }}
+          RTMR3=${{ steps.compute-rtmr3.outputs.rtmr3 }}
+          SECRETVM_RELEASE=${{ steps.secretvm-config.outputs.release }}
+          ROOTFS_SHA256=${{ steps.secretvm-config.outputs.rootfs_sha256 }}
           
-          COMPOSE_SHA="sha256:$(sha256sum proxy-router/docker-compose.tee.yml | cut -d' ' -f1)"
+          COMPOSE_SHA="sha256:$(sha256sum /tmp/docker-compose.tee.deployed.yml | cut -d' ' -f1)"
           DOCKERFILE_SHA="sha256:$(sha256sum proxy-router/Dockerfile.tee | cut -d' ' -f1)"
           TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           
           jq -n \
-            --arg tee_image "${TEE_IMAGE}:${BUILDTAG}" \
+            --arg tee_image "${TEE_IMAGE}@${TEE_DIGEST}" \
+            --arg tee_image_tag "${TEE_IMAGE}:${BUILDTAG}" \
             --arg tee_digest "$TEE_DIGEST" \
             --arg base_image "${BASE_IMAGE}:${BUILDTAG}" \
             --arg base_digest "$BASE_DIGEST" \
             --arg compose_sha "$COMPOSE_SHA" \
+            --arg compose_image_ref "${TEE_IMAGE}@${TEE_DIGEST}" \
             --arg dockerfile_sha "$DOCKERFILE_SHA" \
             --arg commit "${{ github.sha }}" \
             --arg ref "${{ github.ref }}" \
             --arg run_id "${{ github.run_id }}" \
             --arg run_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --arg timestamp "$TIMESTAMP" \
+            --arg rtmr3 "$RTMR3" \
+            --arg secretvm_release "$SECRETVM_RELEASE" \
+            --arg rootfs_sha256 "$ROOTFS_SHA256" \
             '{
               tee_image: $tee_image,
+              tee_image_tag: $tee_image_tag,
               tee_image_digest: $tee_digest,
               base_image: $base_image,
               base_image_digest: $base_digest,
-              compose_file: "proxy-router/docker-compose.tee.yml",
               compose_sha256: $compose_sha,
+              compose_image_reference: $compose_image_ref,
               dockerfile_tee_sha256: $dockerfile_sha,
               build: {
                 commit: $commit,
@@ -457,7 +514,16 @@ jobs:
                 ENVIRONMENT: "production"
               },
               measurements: {
-                note: "RTMR/SEV values will be populated when reproduce-mr is integrated (Phase 1b)"
+                intel_tdx: {
+                  rtmr3: $rtmr3,
+                  secretvm_release: $secretvm_release,
+                  rootfs_variant: "rootfs-dev-tdx",
+                  rootfs_sha256: $rootfs_sha256,
+                  note: "RTMR0-2 require full reproduce-mr with firmware/kernel/templates (Phase 1b follow-up)"
+                },
+                amd_sev_snp: {
+                  note: "SEV measurement computation not yet integrated"
+                }
               }
             }' > tee-attestation-manifest.json
           
@@ -475,6 +541,12 @@ jobs:
             --type https://morpheusais.github.io/tee-attestation/v1 \
             "$TEE_IMAGE@$DIGEST"
           echo "🔏 TEE attestation manifest signed and attached to \`$TEE_IMAGE@$DIGEST\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload deployed compose as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-compose-tee-deployed-${{ needs.Generate-Tag.outputs.tag_name }}
+          path: /tmp/docker-compose.tee.deployed.yml
 
       - name: Push TEE Latest Tags
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test' }}

--- a/docs/02.3-proxy-router-tee.md
+++ b/docs/02.3-proxy-router-tee.md
@@ -72,7 +72,7 @@ volumes:
 
 **Why digest instead of tag?** Tags are mutable — someone could push a different image to the same tag. A digest (`@sha256:...`) is an immutable content hash. Using the digest in the compose file guarantees that the RTMR3 measurement is cryptographically bound to one specific image binary.
 
-> **Important: Exact byte content matters.** The compose file must end with exactly one newline after `proxy_data: null` (standard POSIX line ending, no trailing blank line). RTMR3 is computed from the exact byte content of the compose file — a single extra or missing byte produces a completely different hash. When pasting into the SecretVM portal, ensure no trailing blank lines are added.
+> **Important: Exact byte content matters.** The compose file must end with exactly one newline after `proxy_data: null` (standard POSIX line ending, no trailing blank line). RTMR3 is computed from the exact byte content of the compose file — a single extra or missing byte produces a completely different hash. The SecretVM portal normalizes trailing whitespace (strips extra blank lines down to a single newline), so pasting as-is is safe.
 
 Published images and digests are listed at:
 https://github.com/orgs/MorpheusAIs/packages?repo_name=Morpheus-Lumerin-Node
@@ -108,7 +108,18 @@ For **SecretVM** you can either use the web portal (https://secretai.scrtlabs.co
 1. Navigate to the SecretVM creation page
 2. Paste the contents of `docker-compose.tee.yml` into the compose configuration
 3. Enter your 5 secret values in the encrypted secrets section
-4. Select your hardware preference (Intel TDX or AMD SEV-SNP)
+4. Under **Advanced features**, configure:
+
+| Setting | Recommended | Impact on RTMR3 |
+|---------|-------------|-----------------|
+| **Additional Files** | Leave empty | Uploading a `.tar` archive adds a third hash to the RTMR3 chain, changing the expected value. Secrets are passed via env vars, not files. |
+| **Platform** | Intel TDX | Must match the rootfs variant pinned in CI/CD (`rootfs-prod-tdx`). Selecting AMD SEV uses a different rootfs ISO with a different measurement. |
+| **Hide Runtime Info** | Off (for verification) | Does not affect RTMR3, but disabling it blocks the `/docker-compose` endpoint used for debugging. |
+| **Enable Persistence** | On (recommended) | Does not affect RTMR3. |
+| **Enable Upgrades** | On (recommended) | Does not affect RTMR3. |
+| **Enable zkVerify** | Optional | Does not affect RTMR3. Increases startup time. |
+| **Generate App Certificate** | Optional | Does not affect RTMR3 (cert goes into `reportdata`). |
+
 5. Deploy the VM
 
 #### Option B: Using the SecretVM CLI

--- a/docs/02.3-proxy-router-tee.md
+++ b/docs/02.3-proxy-router-tee.md
@@ -276,15 +276,22 @@ If all three layers pass, the provider is running exactly the software that was 
 You can recompute RTMR3 yourself using the script in the repository:
 
 ```bash
-# Download the same rootfs used by CI/CD (version pinned in .github/tee/secretvm.env)
-curl -L -o rootfs-dev-tdx.iso \
-  https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.23/rootfs-dev-v0.0.23-tdx.iso
+# Check the pinned version and rootfs variant used by CI/CD
+cat .github/tee/secretvm.env
+# → SECRETVM_RELEASE=v0.0.25
+# → SECRETVM_ROOTFS_VARIANT=rootfs-prod-tdx
+
+# Download the same rootfs used by CI/CD
+curl -L -o rootfs-prod-tdx.iso \
+  "$(grep SECRETVM_ROOTFS_TDX_URL .github/tee/secretvm.env | cut -d= -f2-)"
 
 # Compute RTMR3 from the deployed compose + rootfs
-python3 proxy-router/scripts/compute-rtmr3.py docker-compose.tee.deployed.yml rootfs-dev-tdx.iso
+python3 proxy-router/scripts/compute-rtmr3.py docker-compose.tee.deployed.yml rootfs-prod-tdx.iso
 ```
 
 The output should match `measurements.intel_tdx.rtmr3` from the attestation manifest.
+
+> **Note:** The rootfs version and variant are pinned in [`.github/tee/secretvm.env`](../.github/tee/secretvm.env). If your RTMR3 doesn't match, check that you're using the same rootfs version as the CI/CD build. See the "Upgrading SecretVM Artifacts" section below.
 
 ---
 
@@ -301,6 +308,52 @@ The output should match `measurements.intel_tdx.rtmr3` from the attestation mani
 * The model backend (LLM) that the proxy-router connects to is not yet attested separately. In future versions, the proxy-router and LLM will run in the same TEE VM.
 * Manual verification is required today. Future C-Node releases will automate this for models tagged `tee` on the blockchain.
 * RTMR0-2 (firmware, kernel, initramfs layers) and AMD SEV-SNP measurements are not yet computed in CI/CD. RTMR3 (the software layer — our image + compose) is computed and published in the attestation manifest.
+
+---
+
+## Upgrading SecretVM Artifacts
+
+When SCRT Labs publishes a new SecretVM release (e.g., `v0.0.25` → `v0.0.26`), the rootfs changes and all RTMR3 values must be recomputed. The CI/CD pipeline is fully variablized so that updating requires only editing a single config file.
+
+### When to Upgrade
+
+SCRT Labs publishes releases at [github.com/scrtlabs/secret-vm-build/releases](https://github.com/scrtlabs/secret-vm-build/releases). There is no push notification; check the releases page periodically or watch the repository for new releases. You can also query the GitHub API:
+
+```bash
+curl -s https://api.github.com/repos/scrtlabs/secret-vm-build/releases \
+  | jq '[.[] | {tag: .tag_name, prerelease: .prerelease, date: .published_at}] | .[0:5]'
+```
+
+> **Note:** SCRT Labs sometimes marks newer releases as **pre-release** on GitHub while already deploying them to the SecretVM portal (e.g., `v0.0.25` is a pre-release on GitHub but the portal runs "artifacts v0.0.25, environment prod"). The `/releases/latest` API endpoint only returns non-prerelease versions, so always check the full releases list.
+
+### How to Upgrade
+
+All SecretVM-specific configuration is in [`.github/tee/secretvm.env`](../.github/tee/secretvm.env). To update:
+
+1. **Edit `secretvm.env`** — change these three values:
+   ```bash
+   SECRETVM_RELEASE=v0.0.26                    # ← new version
+   SECRETVM_ROOTFS_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.26/rootfs-prod-v0.0.26-tdx.iso
+   SECRETVM_ROOTFS_TDX_SHA256=                  # ← clear; will be captured on first build
+   ```
+   The `SECRETVM_ROOTFS_VARIANT` stays `rootfs-prod-tdx` unless the naming convention changes.
+
+2. **Push and let CI/CD run.** The pipeline will:
+   - Download the new rootfs (and cache it)
+   - If `SECRETVM_ROOTFS_TDX_SHA256` is empty, compute and report the actual SHA-256 in the step summary
+   - Compute the new RTMR3 and embed it in the signed attestation manifest
+
+3. **Pin the rootfs SHA-256.** After the first successful build, copy the reported SHA-256 from the GitHub Actions step summary back into `secretvm.env`:
+   ```bash
+   SECRETVM_ROOTFS_TDX_SHA256=<sha256-from-step-summary>
+   ```
+   This pins the exact rootfs for all subsequent builds.
+
+4. **Rebuild providers.** Providers running older SecretVM versions will have mismatched RTMR3 values. They should redeploy on the current SecretVM release to match the latest attestation manifest.
+
+### Important: Always Use the `prod` Rootfs Variant
+
+SecretVM runs "environment prod" even for developer portal deployments. Using the `dev` rootfs variant produces a wrong RTMR3. Always use `rootfs-prod-*` in the config.
 
 ---
 

--- a/docs/02.3-proxy-router-tee.md
+++ b/docs/02.3-proxy-router-tee.md
@@ -42,12 +42,16 @@ Because the configuration is frozen in the image, when it runs inside a TEE (Int
 
 ### Step 1: Prepare the Docker Compose File
 
-The canonical compose file for TEE deployment is [`proxy-router/docker-compose.tee.yml`](../proxy-router/docker-compose.tee.yml):
+Each CI/CD build produces a **deployed compose file** that references the TEE image by its immutable SHA-256 digest (not a mutable tag). This is critical for attestation — the RTMR3 measurement is computed from the exact compose content.
+
+Download the deployed compose for your target version from the GitHub Actions build artifacts, or use the template at [`proxy-router/docker-compose.tee.yml`](../proxy-router/docker-compose.tee.yml) and replace the image reference.
+
+The deployed compose looks like this (the digest will differ per version):
 
 ```yaml
 services:
   proxy-router:
-    image: ghcr.io/morpheusais/morpheus-lumerin-node-tee:v5.14.6-test
+    image: ghcr.io/morpheusais/morpheus-lumerin-node-tee@sha256:<digest>
     restart: unless-stopped
     ports:
       - 8082:8082
@@ -66,7 +70,9 @@ volumes:
   proxy_data: null
 ```
 
-Update the `image:` tag to the version you want to deploy. Published images are listed at:
+**Why digest instead of tag?** Tags are mutable — someone could push a different image to the same tag. A digest (`@sha256:...`) is an immutable content hash. Using the digest in the compose file guarantees that the RTMR3 measurement is cryptographically bound to one specific image binary.
+
+Published images and digests are listed at:
 https://github.com/orgs/MorpheusAIs/packages?repo_name=Morpheus-Lumerin-Node
 
 ### Step 2: Prepare Your Secrets
@@ -219,9 +225,12 @@ This returns a JSON object. Key fields to check:
 
 | Field | What to Look For |
 |---|---|
+| `tee_image` | Full image reference with `@sha256:` digest — immutable |
 | `tee_image_digest` | The immutable `sha256:...` digest of this exact image |
-| `base_image_digest` | The digest of the standard image this TEE image was built on |
-| `compose_sha256` | Hash of the canonical `docker-compose.tee.yml` |
+| `compose_sha256` | Hash of the deployed compose file (digest-pinned) |
+| `compose_image_reference` | The exact `image@sha256:` reference inside the compose file |
+| `measurements.intel_tdx.rtmr3` | Expected RTMR3 value — compare against the live hardware attestation quote |
+| `measurements.intel_tdx.secretvm_release` | Which SecretVM release the RTMR3 was computed against |
 | `build.commit` | The Git commit that produced this image — you can inspect the source |
 | `build.run_url` | Direct link to the GitHub Actions run that built it |
 | `baked_env.PROXY_STORE_CHAT_CONTEXT` | Should be `"false"` — confirms chat logging is disabled |
@@ -256,7 +265,24 @@ The verification checks three layers:
 * **VM layer** — the firmware, kernel, and initramfs match a known SecretVM release
 * **Software layer (RTMR3)** — the rootfs and Docker Compose match what was deployed
 
+The expected RTMR3 value is published in the signed attestation manifest (Step 2 above) at `measurements.intel_tdx.rtmr3`. Compare it against the RTMR3 reported by the hardware attestation quote to confirm the provider is running the exact image+compose combination that was built by CI/CD.
+
 If all three layers pass, the provider is running exactly the software that was published by the official CI/CD — inside genuine TEE hardware — with no ability to modify the configuration at runtime.
+
+### Step 5: Verify RTMR3 Independently (Optional)
+
+You can recompute RTMR3 yourself using the script in the repository:
+
+```bash
+# Download the same rootfs used by CI/CD (version pinned in .github/tee/secretvm.env)
+curl -L -o rootfs-dev-tdx.iso \
+  https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.23/rootfs-dev-v0.0.23-tdx.iso
+
+# Compute RTMR3 from the deployed compose + rootfs
+python3 proxy-router/scripts/compute-rtmr3.py docker-compose.tee.deployed.yml rootfs-dev-tdx.iso
+```
+
+The output should match `measurements.intel_tdx.rtmr3` from the attestation manifest.
 
 ---
 
@@ -272,7 +298,7 @@ If all three layers pass, the provider is running exactly the software that was 
 **Current limitations (to be addressed in future phases):**
 * The model backend (LLM) that the proxy-router connects to is not yet attested separately. In future versions, the proxy-router and LLM will run in the same TEE VM.
 * Manual verification is required today. Future C-Node releases will automate this for models tagged `tee` on the blockchain.
-* Hardware attestation measurement values (RTMR3/SEV measurement) are not yet computed in CI/CD. The attestation manifest includes compose and Dockerfile hashes, which are the inputs to the measurement computation.
+* RTMR0-2 (firmware, kernel, initramfs layers) and AMD SEV-SNP measurements are not yet computed in CI/CD. RTMR3 (the software layer — our image + compose) is computed and published in the attestation manifest.
 
 ---
 
@@ -281,7 +307,10 @@ If all three layers pass, the provider is running exactly the software that was 
 | Resource | Link |
 |---|---|
 | TEE images on GHCR | https://github.com/orgs/MorpheusAIs/packages?repo_name=Morpheus-Lumerin-Node |
+| RTMR3 computation script | [`proxy-router/scripts/compute-rtmr3.py`](../proxy-router/scripts/compute-rtmr3.py) |
+| SecretVM artifact config | [`.github/tee/secretvm.env`](../.github/tee/secretvm.env) |
 | Sigstore cosign | https://github.com/sigstore/cosign |
+| SCRT Labs reproduce-mr | https://github.com/scrtlabs/reproduce-mr |
 | SecretVM documentation | https://docs.scrt.network/secret-network-documentation/secretvm-confidential-virtual-machines |
 | SecretVM attestation portal | https://secretai.scrtlabs.com/attestation |
 | Model configuration format | [models-config.json.md](models-config.json.md) |

--- a/docs/02.3-proxy-router-tee.md
+++ b/docs/02.3-proxy-router-tee.md
@@ -72,7 +72,7 @@ volumes:
 
 **Why digest instead of tag?** Tags are mutable — someone could push a different image to the same tag. A digest (`@sha256:...`) is an immutable content hash. Using the digest in the compose file guarantees that the RTMR3 measurement is cryptographically bound to one specific image binary.
 
-> **Important: Trailing newline.** The compose file **must** end with a blank line (two newlines after `proxy_data: null`). SecretVM appends a trailing newline to compose content, and the RTMR3 value is computed from the exact byte content including that newline. If you copy-paste from the CI/CD artifact, ensure the trailing blank line is preserved — a single missing byte will produce a completely different RTMR3.
+> **Important: Exact byte content matters.** The compose file must end with exactly one newline after `proxy_data: null` (standard POSIX line ending, no trailing blank line). RTMR3 is computed from the exact byte content of the compose file — a single extra or missing byte produces a completely different hash. When pasting into the SecretVM portal, ensure no trailing blank lines are added.
 
 Published images and digests are listed at:
 https://github.com/orgs/MorpheusAIs/packages?repo_name=Morpheus-Lumerin-Node
@@ -258,7 +258,7 @@ This shows:
 If the provider is running on SecretVM, you can verify the hardware attestation:
 
 1. Go to https://secretai.scrtlabs.com/attestation
-2. Paste the `docker-compose.tee.yml` contents (ensure the trailing blank line is included — see note in Step 1)
+2. Paste the `docker-compose.tee.yml` contents (ensure exact byte content — no extra trailing blank lines; see note in Step 1)
 3. Enter the provider's VM URL or paste their attestation quote
 4. Click **Verify**
 

--- a/docs/02.3-proxy-router-tee.md
+++ b/docs/02.3-proxy-router-tee.md
@@ -72,6 +72,8 @@ volumes:
 
 **Why digest instead of tag?** Tags are mutable — someone could push a different image to the same tag. A digest (`@sha256:...`) is an immutable content hash. Using the digest in the compose file guarantees that the RTMR3 measurement is cryptographically bound to one specific image binary.
 
+> **Important: Trailing newline.** The compose file **must** end with a blank line (two newlines after `proxy_data: null`). SecretVM appends a trailing newline to compose content, and the RTMR3 value is computed from the exact byte content including that newline. If you copy-paste from the CI/CD artifact, ensure the trailing blank line is preserved — a single missing byte will produce a completely different RTMR3.
+
 Published images and digests are listed at:
 https://github.com/orgs/MorpheusAIs/packages?repo_name=Morpheus-Lumerin-Node
 
@@ -256,7 +258,7 @@ This shows:
 If the provider is running on SecretVM, you can verify the hardware attestation:
 
 1. Go to https://secretai.scrtlabs.com/attestation
-2. Paste the `docker-compose.tee.yml` contents
+2. Paste the `docker-compose.tee.yml` contents (ensure the trailing blank line is included — see note in Step 1)
 3. Enter the provider's VM URL or paste their attestation quote
 4. Click **Verify**
 

--- a/docs/02.3-proxy-router-tee.md
+++ b/docs/02.3-proxy-router-tee.md
@@ -315,9 +315,12 @@ The output should match `measurements.intel_tdx.rtmr3` from the attestation mani
 * The blockchain configuration (contracts, chain ID) is immutable
 * The image has not been tampered with between build and deployment
 
+**CI/CD automated verification:**
+* On every push to `test` (or `cicd/*` branches), the pipeline automatically deploys the new TEE image to a test SecretVM instance and verifies the live RTMR3 attestation matches the CI-computed value. This catches measurement mismatches before they reach providers.
+
 **Current limitations (to be addressed in future phases):**
 * The model backend (LLM) that the proxy-router connects to is not yet attested separately. In future versions, the proxy-router and LLM will run in the same TEE VM.
-* Manual verification is required today. Future C-Node releases will automate this for models tagged `tee` on the blockchain.
+* Manual verification is required today for end-users. Future C-Node releases will automate this for models tagged `tee` on the blockchain — the consumer node will verify the provider's attestation before opening a session.
 * RTMR0-2 (firmware, kernel, initramfs layers) and AMD SEV-SNP measurements are not yet computed in CI/CD. RTMR3 (the software layer — our image + compose) is computed and published in the attestation manifest.
 
 ---
@@ -378,6 +381,7 @@ SecretVM runs "environment prod" even for developer portal deployments. Using th
 | Sigstore cosign | https://github.com/sigstore/cosign |
 | SCRT Labs reproduce-mr | https://github.com/scrtlabs/reproduce-mr |
 | SecretVM documentation | https://docs.scrt.network/secret-network-documentation/secretvm-confidential-virtual-machines |
+| SecretVM CLI docs | https://docs.scrt.network/secret-network-documentation/secretvm-confidential-virtual-machines/secretvm-cli |
 | SecretVM attestation portal | https://secretai.scrtlabs.com/attestation |
 | Model configuration format | [models-config.json.md](models-config.json.md) |
 | Provider offer setup | [03-provider-offer.md](03-provider-offer.md) |

--- a/proxy-router/docker-compose.tee.yml
+++ b/proxy-router/docker-compose.tee.yml
@@ -17,3 +17,4 @@ services:
       - usr/.env
 volumes:
   proxy_data: null
+

--- a/proxy-router/docker-compose.tee.yml
+++ b/proxy-router/docker-compose.tee.yml
@@ -17,4 +17,3 @@ services:
       - usr/.env
 volumes:
   proxy_data: null
-

--- a/proxy-router/scripts/compute-rtmr3.py
+++ b/proxy-router/scripts/compute-rtmr3.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+Compute expected RTMR3 (Intel TDX) for a SecretVM deployment.
+
+RTMR3 = replayRTMR(sha256(docker-compose), sha256(rootfs) [, sha256(docker-files)])
+
+Algorithm matches scrtlabs/reproduce-mr  (internal/mr.go  lines 642-657).
+Only requires the compose file and rootfs — no firmware/kernel/templates needed.
+
+Usage:
+    python3 compute-rtmr3.py <docker-compose.yaml> <rootfs.iso> [docker-files]
+
+Output (stdout):
+    96-char lowercase hex RTMR3 value  (SHA-384, 48 bytes)
+"""
+import hashlib
+import json
+import sys
+
+
+def sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(1 << 16)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def replay_rtmr(entries: list[str]) -> str:
+    """Replay the RTMR extension chain.
+
+    Each entry is a hex-encoded SHA-256 hash (64 hex chars = 32 bytes).
+    The register starts at 48 zero bytes.  For each entry:
+        content = decode_hex(entry), right-padded to 48 bytes
+        mr      = SHA-384(mr || content)
+    """
+    mr = bytes(48)
+    for entry_hex in entries:
+        content = bytes.fromhex(entry_hex)
+        if len(content) < 48:
+            content += bytes(48 - len(content))
+        h = hashlib.sha384()
+        h.update(mr + content)
+        mr = h.digest()
+    return mr.hex()
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print(
+            f"Usage: {sys.argv[0]} <docker-compose.yaml> <rootfs.iso> [docker-files]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    compose_path = sys.argv[1]
+    rootfs_path = sys.argv[2]
+
+    compose_hash = sha256_file(compose_path)
+    rootfs_hash = sha256_file(rootfs_path)
+
+    entries = [compose_hash, rootfs_hash]
+
+    if len(sys.argv) > 3:
+        docker_files_hash = sha256_file(sys.argv[3])
+        entries.append(docker_files_hash)
+
+    rtmr3 = replay_rtmr(entries)
+
+    if "--json" in sys.argv:
+        result = {
+            "rtmr3": rtmr3,
+            "compose_sha256": compose_hash,
+            "rootfs_sha256": rootfs_hash,
+        }
+        if len(sys.argv) > 3 and sys.argv[3] != "--json":
+            result["docker_files_sha256"] = sha256_file(sys.argv[3])
+        json.dump(result, sys.stdout, indent=2)
+        print()
+    else:
+        print(rtmr3)
+
+
+if __name__ == "__main__":
+    main()

--- a/proxy-router/scripts/compute-rtmr3.py
+++ b/proxy-router/scripts/compute-rtmr3.py
@@ -49,35 +49,39 @@ def replay_rtmr(entries: list[str]) -> str:
 
 
 def main() -> None:
-    if len(sys.argv) < 3:
+    json_output = "--json" in sys.argv
+    positional = [a for a in sys.argv[1:] if not a.startswith("--")]
+
+    if len(positional) < 2:
         print(
-            f"Usage: {sys.argv[0]} <docker-compose.yaml> <rootfs.iso> [docker-files]",
+            f"Usage: {sys.argv[0]} <docker-compose.yaml> <rootfs.iso> [docker-files] [--json]",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    compose_path = sys.argv[1]
-    rootfs_path = sys.argv[2]
+    compose_path = positional[0]
+    rootfs_path = positional[1]
 
     compose_hash = sha256_file(compose_path)
     rootfs_hash = sha256_file(rootfs_path)
 
     entries = [compose_hash, rootfs_hash]
 
-    if len(sys.argv) > 3:
-        docker_files_hash = sha256_file(sys.argv[3])
+    docker_files_hash = None
+    if len(positional) > 2:
+        docker_files_hash = sha256_file(positional[2])
         entries.append(docker_files_hash)
 
     rtmr3 = replay_rtmr(entries)
 
-    if "--json" in sys.argv:
+    if json_output:
         result = {
             "rtmr3": rtmr3,
             "compose_sha256": compose_hash,
             "rootfs_sha256": rootfs_hash,
         }
-        if len(sys.argv) > 3 and sys.argv[3] != "--json":
-            result["docker_files_sha256"] = sha256_file(sys.argv[3])
+        if docker_files_hash:
+            result["docker_files_sha256"] = docker_files_hash
         json.dump(result, sys.stdout, indent=2)
         print()
     else:


### PR DESCRIPTION
## Summary
- Adds RTMR3 (Intel TDX software-layer measurement) computation to the TEE build pipeline
- Expected RTMR3 is signed into the GHCR attestation manifest so consumers can verify against live hardware quotes — without trusting the P-Node itself
- Deployed compose file now references images by immutable `@sha256:` digest instead of mutable tag

## What Changed

### New files
- `proxy-router/scripts/compute-rtmr3.py` — standalone RTMR3 computation matching `scrtlabs/reproduce-mr` algorithm
- `.github/tee/secretvm.env` — pins SecretVM release (v0.0.23) and rootfs SHA-256

### Modified files
- `.github/workflows/build.yml` — TEE job now: downloads rootfs (cached), generates digest-pinned compose, computes RTMR3, populates `measurements.intel_tdx` in attestation manifest, uploads deployed compose as artifact
- `docs/02.3-proxy-router-tee.md` — updated for digest-based compose, RTMR3 verification, independent recomputation instructions

## Design Decisions
- **Digest over tag**: compose references `image@sha256:DIGEST` (immutable) — any image change produces a different RTMR3
- **RTMR3 published in GHCR manifest, not in the image**: avoids chicken-and-egg; consumer fetches expected value from signed manifest, actual value from hardware attestation
- **RTMR3 only (not RTMR0-2)**: RTMR3 is the software layer we control; RTMR0-2 are SCRT Labs platform layers requiring ACPI templates not yet available
- **Rootfs cached**: ~464MB SecretVM rootfs cached by release version in GitHub Actions

## Test plan
- [ ] CI/CD build triggers on push to `cicd/scrt-generate-rtmr3`
- [ ] Rootfs downloads and hash verifies
- [ ] Deployed compose generated with correct `@sha256:` digest
- [ ] RTMR3 value appears in step summary and attestation manifest JSON
- [ ] Attestation manifest passes `cosign verify-attestation`
- [ ] Deployed compose uploaded as build artifact


Made with [Cursor](https://cursor.com)