### PR TITLE
fix: re-enable service/UI builds on main and test branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -710,15 +710,12 @@ jobs:
 
   Build-Service-Executables:
     name: Build Service Executables
-    # TEMPORARILY DISABLED — re-enable when merging to main/test
-    # Disabling this cascades: all UI-* build jobs and UI-Release are skipped.
-    if: false
-    # if: |
-    #   github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
-    #   (
-    #     (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
-    #     (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true') 
-    #   )
+    if: |
+      github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      (
+        (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true') 
+      )
     needs:
       - Generate-Tag
       - Go-Module-Verify


### PR DESCRIPTION
## Summary

- Re-enables `Build-Service-Executables` (was set to `if: false` during CI/CD pipeline work)
- Removes `cicd/*` from the branch trigger — service executables and all 5 desktop UI builds now only run on `main` and `test` pushes (plus `workflow_dispatch`)
- `cicd/*` branches still build Docker images, TEE images, and run the deploy+verify loop — just not the desktop clients, saving ~30min of runner time per push

## Test plan
- [ ] Merge to dev → push to test → confirm service executables and UI builds run
- [ ] Push to a cicd/* branch → confirm service/UI builds are skipped

Made with [Cursor](https://cursor.com)