### PR TITLE
fix: add Traefik TLS sidecar to TEE compose template

### DIFF
--- a/proxy-router/docker-compose.tee.yml
+++ b/proxy-router/docker-compose.tee.yml
@@ -1,9 +1,8 @@
 services:
   proxy-router:
-    image: ghcr.io/morpheusais/morpheus-lumerin-node-tee:v5.14.6-test
+    image: ghcr.io/morpheusais/morpheus-lumerin-node-tee:latest
     restart: unless-stopped
     ports:
-      - 8082:8082
       - 3333:3333
     volumes:
       - proxy_data:/app/data
@@ -11,9 +10,54 @@ services:
       - WALLET_PRIVATE_KEY=${WALLET_PRIVATE_KEY}
       - ETH_NODE_ADDRESS=${ETH_NODE_ADDRESS}
       - MODELS_CONFIG_CONTENT=${MODELS_CONFIG_CONTENT}
-      - WEB_PUBLIC_URL=${WEB_PUBLIC_URL:-http://localhost:8082}
+      - WEB_PUBLIC_URL=${WEB_PUBLIC_URL:-https://localhost}
       - COOKIE_CONTENT=${COOKIE_CONTENT:-admin:admin}
+    env_file:
+      - usr/.env
+    networks:
+      - traefik
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.proxy-router.rule=PathPrefix(`/`)
+      - traefik.http.routers.proxy-router.entrypoints=websecure
+      - traefik.http.routers.proxy-router.tls=true
+      - traefik.http.services.proxy-router.loadbalancer.server.port=8082
+  traefik:
+    image: traefik:v2.10
+    command:
+      - --api.insecure=false
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.websecure.address=:443
+      - --entrypoints.websecure.http.tls.options=default@file
+      - --providers.file.directory=/etc/traefik/dynamic
+      - --providers.file.watch=true
+    ports:
+      - 443:443
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /mnt/secure/cert:/certs:ro
+    networks:
+      - traefik
+    configs:
+      - source: tls_config
+        target: /etc/traefik/dynamic/tls.yml
     env_file:
       - usr/.env
 volumes:
   proxy_data: null
+networks:
+  traefik:
+    driver: bridge
+configs:
+  tls_config:
+    content: |-
+      tls:
+        certificates:
+          - certFile: /certs/secret_vm_fullchain.pem
+            keyFile: /certs/secret_vm_private.pem
+        stores:
+          default:
+            defaultCertificate:
+              certFile: /certs/secret_vm_fullchain.pem
+              keyFile: /certs/secret_vm_private.pem


### PR DESCRIPTION
## Summary

- Adds a Traefik v2.10 reverse proxy sidecar to terminate TLS on :443 for the P-Node API (port 8082), using SecretVM's auto-provisioned certificates
- Removes direct :8082 port exposure — the API and `/healthcheck` are now only reachable via HTTPS
- Port 3333 remains as direct TCP for the proxy router protocol (unchanged)
- Uses `PathPrefix(/)` catch-all routing since there's a single backend service
- Updates `WEB_PUBLIC_URL` default from `http://localhost:8082` to `https://localhost`
- Operators set `WEB_PUBLIC_URL=https://<their-hostname>` in their env vars after VM creation

**Note**: This changes the compose content and therefore the RTMR3 hash. The CI/CD pipeline recomputes it automatically on the next build.

## Test plan
- [ ] Merge to dev → push to test → confirm CI/CD builds and RTMR3 recomputes
- [ ] Deploy to SecretVM → verify :443 serves HTTPS with valid cert
- [ ] Verify :8082 is not reachable from outside the VM
- [ ] Verify :3333 still works as direct TCP

Made with [Cursor](https://cursor.com)