### PR TITLE
fix: scope image digest replacement to proxy-router only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -432,7 +432,7 @@ jobs:
           TEE_IMAGE="${{ needs.Generate-Tag.outputs.image_name }}-tee"
           DIGEST=${{ steps.capture-digest.outputs.digest }}
           
-          sed "s|image: .*|image: ${TEE_IMAGE}@${DIGEST}|" \
+          sed "s|image: ghcr.io/morpheusais/morpheus-lumerin-node-tee:.*|image: ${TEE_IMAGE}@${DIGEST}|" \
             proxy-router/docker-compose.tee.yml > /tmp/docker-compose.tee.deployed.yml
           
           COMPOSE_BYTES=$(wc -c < /tmp/docker-compose.tee.deployed.yml | tr -d ' ')


### PR DESCRIPTION
## Summary

- The `sed` command in the TEE compose generation step was matching **all** `image:` lines, replacing both `proxy-router` and `traefik:v2.10` with the TEE image digest
- Narrows the match to only `image: ghcr.io/morpheusais/morpheus-lumerin-node-tee:.*` so sidecar images are left untouched

## Test plan
- [ ] Merge to dev → push to test → confirm the deployed compose has `traefik:v2.10` intact and only proxy-router gets the `@sha256:` digest

Made with [Cursor](https://cursor.com)