### PR TITLE
fix: fail TEE attestation when golden values unavailable and include …

### DIFF
--- a/proxy-router/internal/attestation/verifier.go
+++ b/proxy-router/internal/attestation/verifier.go
@@ -161,8 +161,7 @@ func (v *Verifier) VerifyProvider(ctx context.Context, providerEndpoint string, 
 
 	golden, err := v.goldenSrc.FetchGoldenValues(ctx, version)
 	if err != nil {
-		v.log.Warnf("failed to fetch golden values for version %s, skipping register comparison: %s", version, err)
-		return nil
+		return fmt.Errorf("failed to fetch golden values for version %s: %w", version, err)
 	}
 
 	v.log.Infof("Got golden values: %+v", golden)

--- a/proxy-router/internal/blockchainapi/service.go
+++ b/proxy-router/internal/blockchainapi/service.go
@@ -1136,11 +1136,18 @@ func (s *BlockchainService) OpenSessionByModelId(ctx context.Context, modelID co
 		return common.Hash{}, fmt.Errorf("failed to get min stake: %w", err)
 	}
 
+	type providerFailure struct {
+		Provider string `json:"provider"`
+		Reason   string `json:"reason"`
+	}
+	var failures []providerFailure
+
 	scoredBids := s.rateBids(bidIDs, bids, providerStats, providers, modelStats, minStake, s.log)
 	for i, bid := range scoredBids {
 		providerAddr := bid.Bid.Provider
 		if providerAddr == omitProvider {
 			s.log.Infof("skipping provider #%d %s", i, providerAddr.String())
+			failures = append(failures, providerFailure{Provider: providerAddr.String(), Reason: "skipped: omitted provider"})
 			continue
 		}
 
@@ -1155,6 +1162,7 @@ func (s *BlockchainService) OpenSessionByModelId(ctx context.Context, modelID co
 		hash, tryNext, err := s.tryOpenSession(ctx, &bid.Bid, durationCopy, supply, budget, userAddr, directPayment, isFailoverEnabled, agentUsername, isTee)
 		if err != nil {
 			s.log.Errorf("failed to open session with provider %s: %s", bid.Bid.Provider.String(), err.Error())
+			failures = append(failures, providerFailure{Provider: providerAddr.String(), Reason: err.Error()})
 			if tryNext {
 				continue
 			} else {
@@ -1165,7 +1173,8 @@ func (s *BlockchainService) OpenSessionByModelId(ctx context.Context, modelID co
 		return hash, nil
 	}
 
-	return common.Hash{}, fmt.Errorf("no provider accepting session")
+	failuresJSON, _ := json.Marshal(failures)
+	return common.Hash{}, fmt.Errorf("no provider accepting session: %s", string(failuresJSON))
 }
 
 func (s *BlockchainService) GetAllBidsWithRating(ctx context.Context, modelAgentID [32]byte) ([][32]byte, []m.IBidStorageBid, []sr.IStatsStorageProviderModelStats, []pr.IProviderStorageProvider, error) {


### PR DESCRIPTION
…per-provider failure reasons

 ## Summary
 - **Strict golden value enforcement**: Previously, if golden values could not be fetched for a provider's version (e.g. unknown Docker image tag like `v5.14.777-test`), TEE attestation silently passed by skipping register comparison. Now it correctly fails with a descriptive error.
 - **Detailed session-open errors**: The `"no provider accepting session"` error now includes a JSON array of per-provider failure reasons (provider address + error message), making it much easier to diagnose why no session could be opened.