### PR TITLE
fix: parse env files with grep instead of source to handle spaces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -351,7 +351,10 @@ jobs:
             NETWORK="testnet"
           fi
 
-          source "$ENV_FILE"
+          DIAMOND_ADDRESS=$(grep '^DIAMOND_ADDRESS=' "$ENV_FILE" | cut -d= -f2-)
+          TOKEN_ADDRESS=$(grep '^TOKEN_ADDRESS=' "$ENV_FILE" | cut -d= -f2-)
+          BLOCKSCOUT_API_URL=$(grep '^BLOCKSCOUT_API_URL=' "$ENV_FILE" | cut -d= -f2-)
+          CHAIN_ID=$(grep '^CHAIN_ID=' "$ENV_FILE" | cut -d= -f2-)
 
           echo "diamond_contract_address=$DIAMOND_ADDRESS" >> $GITHUB_OUTPUT
           echo "mor_token_address=$TOKEN_ADDRESS" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- `CHAIN_NAME=Base Sepolia` in `test.env` broke the `source` command in the TEE build's "Load network configuration" step because the unquoted space was interpreted as a command (`Sepolia: command not found`)
- Replaced `source "$ENV_FILE"` with targeted `grep` extraction of only the 4 needed variables (`DIAMOND_ADDRESS`, `TOKEN_ADDRESS`, `BLOCKSCOUT_API_URL`, `CHAIN_ID`)
- This is a one-line fix to unblock the TEE build on the `test` branch (failed run: [#23219091979](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/23219091979))

## Test plan
- [ ] Merge to dev, then dev → test — verify "Load network configuration" step succeeds
- [ ] Verify TEE build completes with testnet values and deploys to SecretVM test instance

Made with [Cursor](https://cursor.com)