### PR TITLE
fix: align CLI and UI desktop API clients with current proxy-router endpoints

### DIFF
--- a/cli/chat/client/client.go
+++ b/cli/chat/client/client.go
@@ -230,8 +230,11 @@ func (c *ApiGatewayClient) PromptStream(ctx context.Context, message string, mes
 }
 
 func (c *ApiGatewayClient) GetLatestBlock(ctx context.Context) (result uint64, err error) {
-	err = c.getRequest(ctx, "/blockchain/latestBlock", &result)
-	return result, err
+	var response struct {
+		Block uint64 `json:"block"`
+	}
+	err = c.getRequest(ctx, "/blockchain/latestBlock", &response)
+	return response.Block, err
 }
 
 func (c *ApiGatewayClient) GetAllProviders(ctx context.Context) (result map[string]interface{}, err error) {
@@ -260,11 +263,11 @@ func (c *ApiGatewayClient) CreateNewProvider(ctx context.Context, addStake uint6
 
 func (c *ApiGatewayClient) CreateNewModel(ctx context.Context, name string, ipfsID string, stake uint64, fee uint64, tags []string) (result map[string]interface{}, err error) {
 	request := struct {
-		Stake  uint64
-		IpfsID string
-		Name   string
-		Fee    uint64
-		Tags   []string
+		Stake  uint64   `json:"stake"`
+		IpfsID string   `json:"ipfsID"`
+		Name   string   `json:"name"`
+		Fee    uint64   `json:"fee"`
+		Tags   []string `json:"tags"`
 	}{stake, ipfsID, name, fee, tags}
 
 	err = c.postRequest(ctx, "/blockchain/models", &request, &result)
@@ -278,7 +281,7 @@ func (c *ApiGatewayClient) CreateNewModel(ctx context.Context, name string, ipfs
 
 func (c *ApiGatewayClient) CreateNewProviderBid(ctx context.Context, model string, pricePerSecond uint64) (result map[string]interface{}, err error) {
 	request := struct {
-		Model          string `json:"modelId"`
+		Model          string `json:"modelID"`
 		PricePerSecond uint64 `json:"pricePerSecond"`
 	}{model, pricePerSecond}
 
@@ -395,7 +398,7 @@ func (c *ApiGatewayClient) ApproveAllowance(ctx context.Context, spender string,
 }
 
 func (c *ApiGatewayClient) CreateWallet(ctx context.Context, privateKey string) error {
-	return c.postRequest(ctx, "/wallet", &WalletRequest{PrivateKey: privateKey}, nil)
+	return c.postRequest(ctx, "/wallet/privateKey", &WalletRequest{PrivateKey: privateKey}, nil)
 }
 
 type WalletResponse struct {

--- a/cli/chat/client/interfaces.go
+++ b/cli/chat/client/interfaces.go
@@ -18,7 +18,7 @@ type SessionStakeRequest struct {
 }
 
 type Session struct {
-	SessionId string `json:"sessionId"`
+	SessionId string `json:"sessionID"`
 }
 
 type CloseSessionRequest struct {
@@ -26,8 +26,8 @@ type CloseSessionRequest struct {
 }
 
 type SessionListItem struct {
-	Bid             string `json:"BidId"`
-	Sesssion        string `json:"Id"`
+	Bid             string `json:"BidID"`
+	Session         string `json:"Id"`
 	ModelORAgent    string `json:"ModelAgentId"`
 	PricePerSecond  uint64 `json:"PricePerSecond"`
 	Provider        string `json:"Provider"`

--- a/cli/main.go
+++ b/cli/main.go
@@ -639,7 +639,7 @@ func (a *actions) listBlockchainSessions(cCtx *cli.Context) error {
 			isActive = true
 		}
 
-		fmt.Println("\n", "Session: ", item.Sesssion)
+		fmt.Println("\n", "Session: ", item.Session)
 		fmt.Println("\t- provider: ", item.ModelORAgent)
 		fmt.Println("\t- price per second: ", item.PricePerSecond)
 		fmt.Println("\t- closed: ", !isActive)

--- a/ui-desktop/src/main/src/client/subscriptions/handlers.ts
+++ b/ui-desktop/src/main/src/client/subscriptions/handlers.ts
@@ -194,7 +194,7 @@ export const sendEth = async (payload: {
       headers: await getAuthHeaders()
     })
     const data = await response.json()
-    return data.txHash
+    return data.tx
   } catch (e) {
     console.log('Error', e)
     return undefined
@@ -216,7 +216,7 @@ export const sendMor = async (payload: {
       headers: await getAuthHeaders()
     })
     const data = await response.json()
-    return data.txHash
+    return data.tx
   } catch (e) {
     console.log('Error', e)
     return undefined
@@ -545,18 +545,17 @@ export const getIpfsVersion = async (): Promise<{ version: string } | null> => {
 }
 
 export const getIpfsFile = async ({
-  cid,
+  cidHash,
   destinationPath
 }: {
-  cid: string
+  cidHash: string
   destinationPath: string
 }): Promise<ResultResponse | null> => {
   try {
-    const path = `${config.chain.localProxyRouterUrl}/ipfs/download/${cid}`
+    const path = `${config.chain.localProxyRouterUrl}/ipfs/download/${cidHash}?dest=${encodeURIComponent(destinationPath)}`
     const response = await fetch(path, {
       headers: await getAuthHeaders(),
-      method: 'POST',
-      body: JSON.stringify({ destinationPath })
+      method: 'GET'
     })
     const body = await response.json()
     return body
@@ -566,13 +565,13 @@ export const getIpfsFile = async ({
   }
 }
 
-export const pinIpfsFile = async ({ cid }: { cid: string }): Promise<ResultResponse | null> => {
+export const pinIpfsFile = async ({ cidHash }: { cidHash: string }): Promise<ResultResponse | null> => {
   try {
     const path = `${config.chain.localProxyRouterUrl}/ipfs/pin`
     const response = await fetch(path, {
       method: 'POST',
       headers: await getAuthHeaders(),
-      body: JSON.stringify({ cid })
+      body: JSON.stringify({ cidHash })
     })
     const body = await response.json()
     return body
@@ -582,13 +581,13 @@ export const pinIpfsFile = async ({ cid }: { cid: string }): Promise<ResultRespo
   }
 }
 
-export const unpinIpfsFile = async ({ cid }: { cid: string }): Promise<ResultResponse | null> => {
+export const unpinIpfsFile = async ({ cidHash }: { cidHash: string }): Promise<ResultResponse | null> => {
   try {
-    const path = `${config.chain.localProxyRouterUrl}/ipfs/unpin    `
+    const path = `${config.chain.localProxyRouterUrl}/ipfs/unpin`
     const response = await fetch(path, {
       method: 'POST',
       headers: await getAuthHeaders(),
-      body: JSON.stringify({ cid })
+      body: JSON.stringify({ cidHash })
     })
     const body = await response.json()
     return body
@@ -602,14 +601,19 @@ export const addFileToIpfs = async ({
   filePath
 }: {
   filePath: string
-}): Promise<{ hash: string; cid: string } | null> => {
+}): Promise<{
+  fileCID: string
+  metadataCID: string
+  fileCIDHash: string
+  metadataCIDHash: string
+} | null> => {
   try {
     const path = `${config.chain.localProxyRouterUrl}/ipfs/add`
     const response = await fetch(path, {
       method: 'POST',
       headers: await getAuthHeaders(),
       body: JSON.stringify({ filePath }),
-      signal: AbortSignal.timeout(10 * 60 * 1000) // 10 minutes timeout, because ipfs add can take a long time
+      signal: AbortSignal.timeout(10 * 60 * 1000)
     })
     const body = await response.json()
     return body
@@ -619,9 +623,19 @@ export const addFileToIpfs = async ({
   }
 }
 
-export const getIpfsPinnedFiles = async (): Promise<{
-  files: { cid: string; hash: string }[]
-} | null> => {
+export const getIpfsPinnedFiles = async (): Promise<
+  {
+    fileName: string
+    fileSize: number
+    fileCID: string
+    fileCIDHash: string
+    tags: string[]
+    id: string
+    modelName: string
+    metadataCID: string
+    metadataCIDHash: string
+  }[] | null
+> => {
   try {
     const path = `${config.chain.localProxyRouterUrl}/ipfs/pin`
     const response = await fetch(path, { headers: await getAuthHeaders() })
@@ -694,7 +708,7 @@ export const onboardingCompleted = async (data, core: Core) => {
     } else {
       const pKeyResp = await fetch(`${proxyUrl}/wallet/privateKey`, {
         method: 'POST',
-        body: JSON.stringify({ PrivateKey: String(data.privateKey) }),
+        body: JSON.stringify({ privateKey: String(data.privateKey) }),
         headers: await getAuthHeaders()
       })
       if (!pKeyResp.ok) {

--- a/ui-desktop/src/renderer/src/store/hocs/withModelsState.jsx
+++ b/ui-desktop/src/renderer/src/store/hocs/withModelsState.jsx
@@ -56,13 +56,13 @@ const withModelsState = WrappedComponent => {
       return response;
     }
 
-    pinFile = async (cid) => {
-      const response = await this.props.client.pinIpfsFile({ cid });
+    pinFile = async (cidHash) => {
+      const response = await this.props.client.pinIpfsFile({ cidHash });
       return response;
     }
 
-    unpinFile = async (cid) => {
-      const response = await this.props.client.unpinIpfsFile({ cid });
+    unpinFile = async (cidHash) => {
+      const response = await this.props.client.unpinIpfsFile({ cidHash });
       return response;
     }
 


### PR DESCRIPTION
## Summary

- **CLI and UI desktop API clients have drifted** from the proxy-router's current API surface over several months of proxy-router evolution, causing multiple runtime failures for end users who download and try to use the apps.
- This PR realigns all CLI and UI HTTP calls with the actual proxy-router request/response contracts — fixing broken onboarding, IPFS operations, session management, model/bid creation, and send transactions.
- No proxy-router changes; only client-side fixes in `cli/` and `ui-desktop/`.

### CLI fixes (`cli/chat/client/client.go`, `interfaces.go`, `main.go`)
- `CreateWallet`: `POST /wallet` → `POST /wallet/privateKey`
- `GetLatestBlock`: decode `{"block": N}` wrapper instead of raw `uint64`
- `OpenSession`: response key `sessionId` → `sessionID`
- `CreateNewModel`: add json tags so fields serialize as camelCase (`stake`, `ipfsID`, `name`, `fee`, `tags`)
- `CreateNewProviderBid`: fix json tag `modelId` → `modelID`
- `SessionListItem`: fix json tag `BidId` → `BidID`, fix `Sesssion` typo → `Session`

### UI Desktop fixes (`ui-desktop/src/main/src/client/subscriptions/handlers.ts`, `withModelsState.jsx`)
- **Onboarding**: fix private key body casing `PrivateKey` → `privateKey`
- **IPFS download**: `POST` → `GET`, body `{destinationPath}` → query `?dest=`, param `cid` → `cidHash`
- **IPFS pin/unpin**: fix body key `cid` → `cidHash`, remove trailing spaces from unpin URL
- **IPFS add**: update return type to match `AddIpfsFileRes` (`fileCID`, `metadataCID`, `fileCIDHash`, `metadataCIDHash`)
- **IPFS pinned files**: update return type from `{files: [...]}` to raw `PinnedFileRes[]` array
- **sendEth / sendMor**: fix response field `data.txHash` → `data.tx`

## Test plan

- [ ] Verify UI onboarding flow works with both private key and mnemonic
- [ ] Verify send ETH / send MOR transactions show the correct tx hash in UI
- [ ] Verify IPFS pin, unpin, add, download, and list pinned files work in the Models tab
- [ ] Verify CLI can create wallet, open session, and stream chat completions
- [ ] Verify CLI can list sessions, create models, and create bids without errors


Made with [Cursor](https://cursor.com)