### PR TITLE
chore: bump major version to v6.0.0 for TEE attestation release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
         shell: bash
         run: |
           IMAGE_NAME="ghcr.io/morpheusais/morpheus-lumerin-node"
-          VMAJ_NEW=5
+          VMAJ_NEW=6
           VMIN_NEW=0
           VPAT_NEW=0
           set +o pipefail


### PR DESCRIPTION
## Summary

- Bumps `VMAJ_NEW` from `5` to `6` in the build tag generation logic
- When merged to `main` (via PR #673), the version check `6 > 5` triggers a major version reset, producing **v6.0.0** instead of v5.15.0
- Signals the first mainnet release of TEE capability: hardware-backed attestation, anti-spoofing TLS binding, supply-chain hardened images

## Change

Single line in `.github/workflows/build.yml`:
```
- VMAJ_NEW=5
+ VMAJ_NEW=6
```

## Version impact

| Branch | Before | After |
|--------|--------|-------|
| `test` | `v5.0.X-test` | `v6.0.X-test` |
| `main` | `v5.15.0` | **`v6.0.0`** |

## Test plan
- [ ] Merge to dev — no version tag generated (dev doesn't deploy)
- [ ] Merge dev → test — verify build tags as `v6.0.X-test`
- [ ] Merge test → main (PR #673) — verify build produces `v6.0.0`

Made with [Cursor](https://cursor.com)