### PR TITLE
docs: SecretVM quick-start guide + publish deployed compose in releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2025,6 +2025,7 @@ jobs:
       )
     needs:
       - Generate-Tag
+      - GHCR-Build-and-Push-TEE
       - UI-macOS-latest-arm64
       - UI-macOS-15-intel-x64
       - UI-Ubuntu-22-x64
@@ -2118,6 +2119,27 @@ jobs:
           |-----|-------------|
           | `TAG` | This specific release |
           | `LATEST_TAG` | Rolling tag (auto-updates with new releases) |
+          
+          ---
+          
+          ### 🔒 TEE Provider (Confidential VM Deployment)
+          *For providers running inside a Trusted Execution Environment (Intel TDX / SecretVM)*
+          
+          The deployed compose file below is digest-pinned to this exact TEE image build. Download it and paste directly into the SecretVM portal or use with `secretvm-cli`:
+          
+          | File | Description |
+          |------|-------------|
+          | [`docker-compose.tee.deployed.yml`](../../releases/download/TAG/docker-compose.tee.deployed.yml) | Ready-to-use compose with immutable `@sha256:` image digest |
+          
+          ```bash
+          # Deploy with secretvm-cli
+          secretvm-cli -k <your_api_key> vm create \
+            --name morpheus-provider \
+            --docker-compose docker-compose.tee.deployed.yml \
+            --env .env --platform tdx --persistence --upgradeability
+          ```
+          
+          See the [TEE Quick-Start Guide](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/blob/main/docs/02.4-proxy-router-secretvm-quickstart.md) for full setup instructions.
           
           ---
           

--- a/docs/02.3-proxy-router-tee.md
+++ b/docs/02.3-proxy-router-tee.md
@@ -54,9 +54,9 @@ Because the configuration is frozen in the image, when it runs inside a TEE (Int
 
 Each CI/CD build produces a **deployed compose file** that references the TEE image by its immutable SHA-256 digest (not a mutable tag). This is critical for attestation — the RTMR3 measurement is computed from the exact compose content.
 
-Download the deployed compose for your target version from the GitHub Actions build artifacts, or use the template at [`proxy-router/docker-compose.tee.yml`](../proxy-router/docker-compose.tee.yml) and replace the image reference.
+Download `docker-compose.tee.deployed.yml` from the [GitHub Release](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases) for your target version — it has the correct digest already filled in. Alternatively, use the template at [`proxy-router/docker-compose.tee.yml`](../proxy-router/docker-compose.tee.yml) and replace the image tag with the digest yourself.
 
-The deployed compose looks like this (the digest will differ per version):
+The deployed compose looks like this (the digest will differ per version). It includes a Traefik reverse proxy sidecar that serves the API over HTTPS (port 443) using SecretVM's auto-generated TLS certificates:
 
 ```yaml
 services:
@@ -64,7 +64,6 @@ services:
     image: ghcr.io/morpheusais/morpheus-lumerin-node-tee@sha256:<digest>
     restart: unless-stopped
     ports:
-      - 8082:8082
       - 3333:3333
     volumes:
       - proxy_data:/app/data
@@ -72,13 +71,60 @@ services:
       - WALLET_PRIVATE_KEY=${WALLET_PRIVATE_KEY}
       - ETH_NODE_ADDRESS=${ETH_NODE_ADDRESS}
       - MODELS_CONFIG_CONTENT=${MODELS_CONFIG_CONTENT}
-      - WEB_PUBLIC_URL=${WEB_PUBLIC_URL:-http://localhost:8082}
+      - WEB_PUBLIC_URL=${WEB_PUBLIC_URL:-https://localhost}
       - COOKIE_CONTENT=${COOKIE_CONTENT:-admin:admin}
+    env_file:
+      - usr/.env
+    networks:
+      - traefik
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.proxy-router.rule=PathPrefix(`/`)
+      - traefik.http.routers.proxy-router.entrypoints=websecure
+      - traefik.http.routers.proxy-router.tls=true
+      - traefik.http.services.proxy-router.loadbalancer.server.port=8082
+  traefik:
+    image: traefik:v2.10
+    command:
+      - --api.insecure=false
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.websecure.address=:443
+      - --entrypoints.websecure.http.tls.options=default@file
+      - --providers.file.directory=/etc/traefik/dynamic
+      - --providers.file.watch=true
+    ports:
+      - 443:443
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /mnt/secure/cert:/certs:ro
+    networks:
+      - traefik
+    configs:
+      - source: tls_config
+        target: /etc/traefik/dynamic/tls.yml
     env_file:
       - usr/.env
 volumes:
   proxy_data: null
+networks:
+  traefik:
+    driver: bridge
+configs:
+  tls_config:
+    content: |-
+      tls:
+        certificates:
+          - certFile: /certs/secret_vm_fullchain.pem
+            keyFile: /certs/secret_vm_private.pem
+        stores:
+          default:
+            defaultCertificate:
+              certFile: /certs/secret_vm_fullchain.pem
+              keyFile: /certs/secret_vm_private.pem
 ```
+
+The **only line that changes between versions** is the proxy-router image digest on line 3 (`@sha256:<digest>`). The Traefik sidecar, TLS config, and network setup remain constant.
 
 **Why digest instead of tag?** Tags are mutable — someone could push a different image to the same tag. A digest (`@sha256:...`) is an immutable content hash. Using the digest in the compose file guarantees that the RTMR3 measurement is cryptographically bound to one specific image binary.
 
@@ -168,7 +214,7 @@ For other TEE platforms, consult their documentation for deploying Docker Compos
 Once deployed, check the health endpoint:
 
 ```bash
-curl https://<your-node-url>:8082/healthcheck
+curl https://<your-node-url>/healthcheck
 ```
 
 Expected response:

--- a/docs/02.4-proxy-router-secretvm-quickstart.md
+++ b/docs/02.4-proxy-router-secretvm-quickstart.md
@@ -1,0 +1,295 @@
+# TEE Provider Quick-Start: Deploying on SecretVM
+
+This guide walks you through deploying a Morpheus TEE-hardened provider node on [SecretVM](https://secretai.scrtlabs.com) (SCRT Labs' confidential VM platform). By the end, you'll have a provider running inside a hardware-secured Intel TDX enclave that consumers can cryptographically verify before sending prompts.
+
+For deeper technical details (cosign verification, RTMR3 recomputation, attestation manifest inspection), see the [full TEE reference guide](02.3-proxy-router-tee.md).
+
+---
+
+## What You'll Need
+
+Before you start, make sure you have:
+
+- [ ] A **funded wallet** with MOR and ETH on Base Mainnet (or Base Sepolia for testnet)
+- [ ] The wallet's **private key** (this stays encrypted inside the TEE — it never leaves the enclave)
+- [ ] An **RPC endpoint** for Base Mainnet (e.g., `wss://base-mainnet.g.alchemy.com/v2/<your_key>`) or Base Sepolia for testnet
+- [ ] Your **AI model backend** accessible via a private URL (e.g., `http://my-model:8080/v1/chat/completions`)
+- [ ] A **SecretVM account** at https://secretai.scrtlabs.com — sign up and get your API key
+- [ ] **secretvm-cli** installed (optional but recommended): `sudo npm install --global secretvm-cli`
+
+---
+
+## Step 1: Get the Docker Compose File
+
+Each CI/CD build produces a **deployed compose file** that pins the TEE image by its immutable SHA-256 digest. This is what SecretVM uses to compute the RTMR3 measurement that proves your node is running untampered software.
+
+Download `docker-compose.tee.deployed.yml` from the [latest GitHub Release](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases) — it's ready to use with the correct digest already filled in. You can also use the template at [`proxy-router/docker-compose.tee.yml`](../proxy-router/docker-compose.tee.yml) in the repo and replace the image tag with the digest yourself.
+
+The compose file includes a Traefik TLS reverse proxy sidecar that uses SecretVM's auto-generated certificates to serve the API over HTTPS on port 443:
+
+```yaml
+services:
+  proxy-router:
+    image: ghcr.io/morpheusais/morpheus-lumerin-node-tee@sha256:<digest>
+    restart: unless-stopped
+    ports:
+      - 3333:3333
+    volumes:
+      - proxy_data:/app/data
+    environment:
+      - WALLET_PRIVATE_KEY=${WALLET_PRIVATE_KEY}
+      - ETH_NODE_ADDRESS=${ETH_NODE_ADDRESS}
+      - MODELS_CONFIG_CONTENT=${MODELS_CONFIG_CONTENT}
+      - WEB_PUBLIC_URL=${WEB_PUBLIC_URL:-https://localhost}
+      - COOKIE_CONTENT=${COOKIE_CONTENT:-admin:admin}
+    env_file:
+      - usr/.env
+    networks:
+      - traefik
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.proxy-router.rule=PathPrefix(`/`)
+      - traefik.http.routers.proxy-router.entrypoints=websecure
+      - traefik.http.routers.proxy-router.tls=true
+      - traefik.http.services.proxy-router.loadbalancer.server.port=8082
+  traefik:
+    image: traefik:v2.10
+    command:
+      - --api.insecure=false
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.websecure.address=:443
+      - --entrypoints.websecure.http.tls.options=default@file
+      - --providers.file.directory=/etc/traefik/dynamic
+      - --providers.file.watch=true
+    ports:
+      - 443:443
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /mnt/secure/cert:/certs:ro
+    networks:
+      - traefik
+    configs:
+      - source: tls_config
+        target: /etc/traefik/dynamic/tls.yml
+    env_file:
+      - usr/.env
+volumes:
+  proxy_data: null
+networks:
+  traefik:
+    driver: bridge
+configs:
+  tls_config:
+    content: |-
+      tls:
+        certificates:
+          - certFile: /certs/secret_vm_fullchain.pem
+            keyFile: /certs/secret_vm_private.pem
+        stores:
+          default:
+            defaultCertificate:
+              certFile: /certs/secret_vm_fullchain.pem
+              keyFile: /certs/secret_vm_private.pem
+```
+
+**The only thing you change between versions is the image digest on line 3** (`@sha256:<digest>`). Everything else — Traefik config, TLS certificates, networks — stays the same. The Traefik sidecar (`traefik:v2.10`) is not pinned by digest because it's not part of the TEE measurement.
+
+> **Use the digest-pinned version.** Tags like `:latest` are mutable — the digest (`@sha256:...`) is not. Using the digest ensures the RTMR3 attestation measurement will match the CI/CD-computed golden value.
+
+---
+
+## Step 2: Prepare Your Secrets
+
+Create a `.env` file with your 5 provider-specific secrets. These are the **only** values you control — everything else (contract addresses, chain ID, logging config) is baked into the image and cannot be changed.
+
+```bash
+WALLET_PRIVATE_KEY=<your_private_key>
+ETH_NODE_ADDRESS=wss://base-mainnet.g.alchemy.com/v2/<your_alchemy_key>
+MODELS_CONFIG_CONTENT={"models":[{"modelId":"0x<your_model_id>","modelName":"your-model-name","apiType":"openai","apiUrl":"http://your-model:8080/v1/chat/completions","concurrentSlots":6,"capacityPolicy":"simple"}]}
+WEB_PUBLIC_URL=https://your-public-domain.com
+COOKIE_CONTENT=admin:<your_secure_password>
+```
+
+`MODELS_CONFIG_CONTENT` must be a single-line JSON string. See [models-config.json.md](models-config.json.md) for the full schema.
+
+---
+
+## Step 3: Deploy on SecretVM
+
+You have two options: the web portal or the CLI.
+
+### Option A: Web Portal
+
+1. Go to https://secretai.scrtlabs.com/secret-vms/create
+2. **Docker Compose**: paste the contents of your compose file
+3. **Encrypted Secrets**: enter your 5 environment variables from Step 2
+4. **Advanced Features**:
+
+| Setting | Recommended | Notes |
+|---------|-------------|-------|
+| **Platform** | Intel TDX | Required for attestation to match CI/CD golden values |
+| **Additional Files** | Leave empty | Adding files changes the RTMR3 measurement |
+| **Enable Persistence** | On | Preserves data across reboots |
+| **Enable Upgrades** | On | Allows updating without reprovisioning |
+| **Hide Runtime Info** | Off | Keeps the `/docker-compose` debug endpoint accessible |
+
+5. Click **Deploy**
+
+### Option B: CLI (recommended)
+
+```bash
+# Authenticate
+secretvm-cli auth login
+
+# Deploy
+secretvm-cli -k <your_api_key> vm create \
+  --name morpheus-provider \
+  --type small \
+  --persistence \
+  --upgradeability \
+  --docker-compose proxy-router/docker-compose.tee.yml \
+  --env path/to/your/.env \
+  --platform tdx
+
+# Check status
+secretvm-cli -k <your_api_key> vm list
+```
+
+Full CLI reference: [SecretVM CLI docs](https://docs.scrt.network/secret-network-documentation/secretvm-confidential-virtual-machines/secretvm-cli)
+
+---
+
+## Step 4: Verify Your Node is Running
+
+Once the VM is provisioned (usually 2-3 minutes), check the health endpoint:
+
+```bash
+curl https://<your-secretvm-url>/healthcheck
+```
+
+The API is served over HTTPS on port 443 via the Traefik TLS sidecar (no port number needed in the URL).
+
+You should see:
+
+```json
+{
+  "status": "healthy",
+  "version": "v6.0.0",
+  "uptime": "1m30s"
+}
+```
+
+And verify the attestation endpoint is responding (this is on a separate port, directly from SecretVM):
+
+```bash
+curl -k https://<your-secretvm-url>:29343/cpu | head -c 100
+```
+
+This should return a long hex string — that's your hardware-signed TDX attestation quote.
+
+---
+
+## Step 5: Register as a TEE Provider
+
+Now register your provider, model, and bid on-chain — the same process as a standard provider, with one critical addition: **tag your model with `tee`**.
+
+1. Start the Swagger UI at `https://<your-secretvm-url>/swagger/index.html`
+2. Follow the standard provider setup in [03-provider-offer.md](03-provider-offer.md):
+   - Approve the Diamond contract to spend MOR on your behalf
+   - Create your provider with your public endpoint (`your-secretvm-url:3333`)
+   - Create your model — **include the `tee` tag** so consumers know this is a TEE provider
+   - Create a bid for your model
+
+The `tee` tag is what triggers consumer-side attestation verification. Without it, consumers treat you as a standard provider.
+
+---
+
+## Step 6: Verify Your Attestation
+
+Confirm that your deployment will pass consumer verification:
+
+### Quick Check (SecretVM Portal)
+
+1. Go to https://secretai.scrtlabs.com/attestation
+2. Paste your compose file contents
+3. Enter your VM URL
+4. Click **Verify**
+
+All three layers should pass:
+- **Hardware** — genuine Intel TDX enclave
+- **VM** — known SecretVM firmware/kernel
+- **Software (RTMR3)** — your image + compose matches what CI/CD built
+
+### Programmatic Check (cosign)
+
+```bash
+# Verify the image signature (proves it was built by the official CI/CD)
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'MorpheusAIs/Morpheus-Lumerin-Node' \
+  ghcr.io/morpheusais/morpheus-lumerin-node-tee:<your-version>
+
+# Inspect the attestation manifest (see what's baked in)
+cosign verify-attestation \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'MorpheusAIs/Morpheus-Lumerin-Node' \
+  --type https://morpheusais.github.io/tee-attestation/v1 \
+  ghcr.io/morpheusais/morpheus-lumerin-node-tee:<your-version> \
+  2>/dev/null | jq -r '.payload' | base64 -d | jq '.predicate'
+```
+
+---
+
+## What Consumers See
+
+When a consumer's C-Node (v6.0.0+) opens a session with your TEE-tagged model, it automatically:
+
+1. **Fetches your attestation quote** from `:29343/cpu`
+2. **Verifies the quote** via the SecretAI Portal — confirms genuine TEE hardware
+3. **Checks TLS binding** — compares the SHA-256 fingerprint of your TLS certificate against the `reportdata` in the quote, proving the quote belongs to your server (not replayed from elsewhere)
+4. **Compares RTMR3** against the CI/CD-signed golden values — confirms you're running the exact official image
+
+If any check fails, the session is rejected and no prompts are sent. This all happens transparently — the consumer doesn't need to do anything manually.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| Healthcheck returns nothing | VM still provisioning | Wait 2-3 min, check `secretvm-cli vm list` |
+| Attestation quote empty | Port 29343 not exposed | SecretVM exposes this automatically — check your VM status |
+| RTMR3 mismatch | Wrong compose content or rootfs version | Ensure you're using the exact deployed compose from CI/CD artifacts (byte-for-byte) |
+| TLS binding fails | Using a proxy/CDN that terminates TLS | The consumer must connect directly to the SecretVM — no TLS-terminating intermediaries on port 29343 |
+| `tee` model not getting sessions | Consumers on older versions | Consumers need v6.0.0+ to be TEE-aware |
+
+---
+
+## Updating Your Node
+
+When a new TEE image is released:
+
+1. Download the new deployed compose (with updated digest) from GitHub Actions artifacts
+2. Update your SecretVM:
+
+```bash
+secretvm-cli -k <your_api_key> vm edit <your_vm_uuid> \
+  --docker-compose path/to/new/docker-compose.tee.yml
+```
+
+3. The VM reboots with the new image. Verify with `/healthcheck` and the attestation portal.
+
+---
+
+## Further Reading
+
+| Resource | Link |
+|----------|------|
+| Full TEE reference (cosign, RTMR3, attestation manifest) | [02.3-proxy-router-tee.md](02.3-proxy-router-tee.md) |
+| Model configuration format | [models-config.json.md](models-config.json.md) |
+| Provider/model/bid registration | [03-provider-offer.md](03-provider-offer.md) |
+| Standard Docker setup (non-TEE) | [02.1-proxy-router-docker.md](02.1-proxy-router-docker.md) |
+| SecretVM documentation | [docs.scrt.network](https://docs.scrt.network/secret-network-documentation/secretvm-confidential-virtual-machines) |
+| SecretVM CLI | [CLI docs](https://docs.scrt.network/secret-network-documentation/secretvm-confidential-virtual-machines/secretvm-cli) |
+| TEE images on GHCR | [GitHub Packages](https://github.com/orgs/MorpheusAIs/packages?repo_name=Morpheus-Lumerin-Node) |


### PR DESCRIPTION
## Summary

- **New `docs/02.4-proxy-router-secretvm-quickstart.md`** — focused step-by-step guide for deploying a TEE provider on SecretVM, covering prerequisites, compose file, secrets, portal/CLI deployment, provider registration with the `tee` tag, attestation verification, troubleshooting, and updating
- **Updated compose snippets** in `02.3` and `02.4` to show the current Traefik TLS sidecar template (the old single-service snippet was outdated since PR #659 added the sidecar)
- **Fixed healthcheck URLs** from `:8082` to port 443 (API now served via Traefik)
- **Publish deployed compose in GitHub Releases** — added `GHCR-Build-and-Push-TEE` as a dependency of `UI-Release` so the digest-pinned `docker-compose.tee.deployed.yml` artifact is available when the release is created
- **TEE Provider section in release notes** — providers can now one-click download the ready-to-use compose from the Releases page instead of digging through Actions artifacts

## Files changed

| File | Change |
|------|--------|
| `docs/02.4-proxy-router-secretvm-quickstart.md` | New quick-start guide |
| `docs/02.3-proxy-router-tee.md` | Updated compose snippet + healthcheck URL |
| `.github/workflows/build.yml` | TEE dependency for release job + release notes template |

## Test plan
- [ ] Merge to dev, then test — verify CI passes
- [ ] Verify release on test branch includes `docker-compose.tee.deployed.yml` as an asset
- [ ] Verify release notes contain the "TEE Provider" section with working download link

Made with [Cursor](https://cursor.com)