### PR TITLE
fix: apply VMAJ_NEW version override to dev/test branch tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,10 @@ jobs:
               VFULL=${VMAJ}.${VMIN}.${VPAT}
               VTAG=v$VFULL
           else
+              if [ "$VMAJ_NEW" -gt "$VMAJ" ]; then
+                  VMAJ=$VMAJ_NEW
+                  VMIN=$VMIN_NEW
+              fi
               MB=$(git merge-base refs/remotes/origin/main HEAD)
               VPAT=$(git rev-list --count --no-merges ${MB}..HEAD)
               VFULL=${VMAJ}.${VMIN}.${VPAT}


### PR DESCRIPTION
## Summary

Non-main branches (dev, test) derive their major.minor version from the last tag on `origin/main`. Since v6.0.0 hasn't been tagged on main yet (PR #673 hasn't merged), dev/test builds still show `v5.14.X-dev` even though `VMAJ_NEW=6`.

This adds the same `VMAJ_NEW > VMAJ` check to the non-main branch path so dev and test builds immediately reflect the intended version.

## Before / After

| Branch | Before | After |
|--------|--------|-------|
| `dev` | `v5.14.X-dev` | `v6.0.X-dev` |
| `test` | `v5.14.X-test` | `v6.0.X-test` |
| `main` | `v6.0.0` (unchanged) | `v6.0.0` (unchanged) |

## Change

4 lines added in `.github/workflows/build.yml` — applies `VMAJ_NEW`/`VMIN_NEW` override in the `else` (non-main) branch of the tag generation logic.

## Test plan
- [ ] Merge to dev — verify build tags as `v6.0.X-dev`
- [ ] Merge dev → test — verify build tags as `v6.0.X-test`

Made with [Cursor](https://cursor.com)