### PR TITLE
fix: use version-sorted tag list instead of git describe for VLAST

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,12 @@ jobs:
           VMIN_NEW=0
           VPAT_NEW=0
           set +o pipefail
-          VLAST=$(git describe --tags --abbrev=0 --match='v[1-9]*' refs/remotes/origin/main 2>/dev/null | cut -c2-)
+
+          # Find the last production tag (clean semver only, no -test/-dev suffix).
+          # Uses git tag -l + version sort instead of git describe, which can
+          # pick a wrong tag when multiple tags (e.g. v6.0.0 and v5.14.30-test)
+          # sit on the same commit.
+          VLAST=$(git tag -l "v[0-9]*" | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -n 1 | cut -c2-)
 
           if [ -n "$VLAST" ]; then
               eval $(echo "$VLAST" | awk -F '.' '{print "VMAJ="$1" VMIN="$2" VPAT="$3}')


### PR DESCRIPTION
## Problem

Every main build keeps emitting `v6.0.0` instead of incrementing to `v6.1.0`.

**Root cause:** `git describe --tags --abbrev=0 --match='v[1-9]*' refs/remotes/origin/main` returns `v5.14.30-test` instead of `v6.0.0` because both tags sit on the same commit (`3751bfd`) and `git describe` tie-breaks unpredictably (it picks `v5.14.30-test`). This causes `VMAJ` to parse as `5`, the `VMAJ_NEW(6) > 5` check is always true, and the version resets to `v6.0.0` on every build.

## Fix

Replace `git describe` with `git tag -l | grep | sort -V | tail`:

```bash
# Before (broken)
VLAST=$(git describe --tags --abbrev=0 --match='v[1-9]*' refs/remotes/origin/main 2>/dev/null | cut -c2-)

# After (reliable)
VLAST=$(git tag -l "v[0-9]*" | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -n 1 | cut -c2-)
```

Key improvements:
- **Filters to clean semver only** — `grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$"` excludes `-test`, `-dev` suffix tags
- **Version sorts** — `sort -V` correctly ranks `6.0.0` above `5.14.30`
- **No ancestry dependency** — doesn't rely on `git describe`'s reachability walk or tie-breaking rules

## Verification (local)

```
OLD (git describe):  5.14.30-test  ← WRONG
NEW (git tag -l):    6.0.0         ← CORRECT

Simulated next main build: v6.1.0  ✓
```

## Urgency

This needs to merge through to `main` quickly — the current in-progress build (run #23263787342) will produce another `v6.0.0` release that collides with the existing one.


Made with [Cursor](https://cursor.com)