### PR TITLE
feat: per-prompt TEE attestation with TLS binding and quote caching

### DIFF
--- a/proxy-router/cmd/main.go
+++ b/proxy-router/cmd/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/walletapi"
 
 	docs "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/docs"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 var (
@@ -293,6 +294,13 @@ func start() error {
 
 	blockchainApi := blockchainapi.NewBlockchainService(ethClient, multicallBackend, *cfg.Marketplace.DiamondContractAddress, *cfg.Marketplace.MorTokenAddress, explorer, wallet, proxyRouterApi, sessionRepo, scorer, authCfg, appLog, rpcLog, cfg.Blockchain.EthLegacyTx, teeVerifier)
 	proxyRouterApi.SetSessionService(blockchainApi)
+	proxyRouterApi.SetAttestationVerifier(teeVerifier)
+	if teeVerifier != nil {
+		teeVerifier.SetPingFunc(func(ctx context.Context, providerEndpoint string, providerAddr string) (string, error) {
+			_, version, err := proxyRouterApi.Ping(ctx, providerEndpoint, common.HexToAddress(providerAddr))
+			return version, err
+		})
+	}
 
 	modelConfigLoader := config.NewModelConfigLoader(cfg.Proxy.ModelsConfigPath, cfg.Proxy.ModelsConfigContent, valid, blockchainApi, &aiengine.ConnectionChecker{}, appLog)
 	err = modelConfigLoader.Init()

--- a/proxy-router/internal/attestation/golden.go
+++ b/proxy-router/internal/attestation/golden.go
@@ -207,6 +207,7 @@ func (g *GoldenSource) verifyAndExtract(ctx context.Context, version string) (*G
 	for _, refDesc := range indexManifest.Manifests {
 		values, err := g.processReferrer(ctx, ref.Context(), refDesc.Digest, sev, certID)
 		if err != nil {
+			g.log.Debugf("skipping referrer %s: %s", refDesc.Digest, err)
 			continue
 		}
 		if values != nil {
@@ -296,6 +297,7 @@ func (g *GoldenSource) verifyBundleLayer(
 	}
 
 	if stmt.GetPredicateType() != teePredicateType {
+		g.log.Debugf("skipping attestation with predicate type %s", stmt.GetPredicateType())
 		return nil, nil
 	}
 

--- a/proxy-router/internal/attestation/golden.go
+++ b/proxy-router/internal/attestation/golden.go
@@ -207,7 +207,6 @@ func (g *GoldenSource) verifyAndExtract(ctx context.Context, version string) (*G
 	for _, refDesc := range indexManifest.Manifests {
 		values, err := g.processReferrer(ctx, ref.Context(), refDesc.Digest, sev, certID)
 		if err != nil {
-			g.log.Debugf("skipping referrer %s: %s", refDesc.Digest, err)
 			continue
 		}
 		if values != nil {
@@ -297,7 +296,6 @@ func (g *GoldenSource) verifyBundleLayer(
 	}
 
 	if stmt.GetPredicateType() != teePredicateType {
-		g.log.Debugf("skipping attestation with predicate type %s", stmt.GetPredicateType())
 		return nil, nil
 	}
 

--- a/proxy-router/internal/attestation/verifier.go
+++ b/proxy-router/internal/attestation/verifier.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
@@ -107,12 +108,26 @@ type AttestationResult struct {
 	ReportData string
 }
 
+type verifiedQuoteEntry struct {
+	quoteHash      string
+	tlsFingerprint string
+}
+
+// PingFunc obtains the provider's software version by pinging its endpoint.
+// providerAddr is the hex-encoded provider address required for signature verification.
+// Used by VerifyProviderQuick on cache miss to perform a full verification.
+type PingFunc func(ctx context.Context, providerEndpoint string, providerAddr string) (version string, err error)
+
 type Verifier struct {
 	portalClient      *http.Client
 	attestationClient *http.Client
 	portalURL         string
 	goldenSrc         *GoldenSource
 	log               lib.ILogger
+	pingFunc          PingFunc
+
+	mu         sync.RWMutex
+	quoteCache map[string]*verifiedQuoteEntry
 }
 
 func NewVerifier(portalURL string, imageRepo string, log lib.ILogger) *Verifier {
@@ -142,16 +157,21 @@ func NewVerifier(portalURL string, imageRepo string, log lib.ILogger) *Verifier 
 		portalURL:         portalURL,
 		goldenSrc:         NewGoldenSource(imageRepo, log),
 		log:               log,
+		quoteCache:        make(map[string]*verifiedQuoteEntry),
 	}
 }
 
+func (v *Verifier) SetPingFunc(f PingFunc) {
+	v.pingFunc = f
+}
+
 // VerifyProvider performs TEE attestation verification for a provider.
-// 1. Fetches the raw attestation quote from the provider's :29343/cpu endpoint
-//    and captures the TLS certificate fingerprint of the connection
-// 2. Sends it to the SecretAI Portal parse-quote API for cryptographic verification
-// 3. Verifies that the TLS certificate fingerprint matches the reportdata field
-//    in the quote (anti-spoofing: proves the quote belongs to this server)
-// 4. Compares all available registers from the parsed quote against golden values
+//  1. Fetches the raw attestation quote from the provider's :29343/cpu endpoint
+//     and captures the TLS certificate fingerprint of the connection
+//  2. Sends it to the SecretAI Portal parse-quote API for cryptographic verification
+//  3. Verifies that the TLS certificate fingerprint matches the reportdata field
+//     in the quote (anti-spoofing: proves the quote belongs to this server)
+//  4. Compares all available registers from the parsed quote against golden values
 func (v *Verifier) VerifyProvider(ctx context.Context, providerEndpoint string, version string) error {
 	attestationURL, err := deriveAttestationURL(providerEndpoint)
 	if err != nil {
@@ -197,6 +217,16 @@ func (v *Verifier) VerifyProvider(ctx context.Context, providerEndpoint string, 
 	}
 
 	v.log.Infof("all TEE register values match golden values for version %s", version)
+
+	quoteHash := fmt.Sprintf("%x", sha256.Sum256([]byte(hexQuote)))
+	v.mu.Lock()
+	v.quoteCache[attestationURL] = &verifiedQuoteEntry{
+		quoteHash:      quoteHash,
+		tlsFingerprint: tlsFingerprint,
+	}
+	v.mu.Unlock()
+	v.log.Infof("cached verified quote for %s", attestationURL)
+
 	return nil
 }
 
@@ -234,6 +264,89 @@ func (v *Verifier) verifyTLSBinding(tlsFingerprint string, reportData string) er
 	return nil
 }
 
+// VerifyProviderQuick performs a fast per-request attestation check.
+//
+// Cache hit: fetches the quote from :29343/cpu (~50-150ms TLS handshake),
+// computes sha256(quote) and compares it (plus the TLS fingerprint) against
+// the cached values from the last full verification. If both match the
+// provider is the same TEE -- return nil.
+//
+// Cache miss (e.g. after process restart): performs a full VerifyProvider
+// (ping for version + portal verification + golden values) and populates
+// the cache. This is slower (~250-650ms) but only happens once per provider.
+//
+// If isTee is false the check is a no-op.
+func (v *Verifier) VerifyProviderQuick(ctx context.Context, providerEndpoint string, providerAddr string, isTee bool) error {
+	if !isTee {
+		v.log.Debugf("quick attestation: skipping non-TEE session for %s", providerEndpoint)
+		return nil
+	}
+
+	v.log.Infof("quick attestation: starting check for provider %s", providerEndpoint)
+
+	attestationURL, err := deriveAttestationURL(providerEndpoint)
+	if err != nil {
+		return fmt.Errorf("failed to derive attestation URL: %w", err)
+	}
+
+	v.mu.RLock()
+	cached, hasCached := v.quoteCache[attestationURL]
+	v.mu.RUnlock()
+
+	if !hasCached {
+		v.log.Infof("quick attestation: no cached quote for %s, falling back to full verification", attestationURL)
+		return v.fullVerifyWithPing(ctx, providerEndpoint, providerAddr)
+	}
+
+	v.log.Infof("quick attestation: cache hit for %s, fetching live quote", attestationURL)
+
+	hexQuote, tlsFingerprint, err := v.loadAttestationQuote(ctx, attestationURL)
+	if err != nil {
+		return fmt.Errorf("quick attestation check failed: %w", err)
+	}
+
+	v.log.Infof("quick attestation: fetched live quote from %s, TLS fingerprint: %s", attestationURL, tlsFingerprint)
+
+	currentHash := fmt.Sprintf("%x", sha256.Sum256([]byte(hexQuote)))
+
+	if currentHash != cached.quoteHash {
+		v.log.Warnf("quick attestation: quote hash MISMATCH for %s (cached=%s, live=%s)", providerEndpoint, cached.quoteHash, currentHash)
+		return fmt.Errorf("TEE attestation quote changed since session was opened (provider %s)", providerEndpoint)
+	}
+
+	v.log.Infof("quick attestation: quote hash matches cached value for %s", providerEndpoint)
+
+	if !strings.EqualFold(tlsFingerprint, cached.tlsFingerprint) {
+		v.log.Warnf("quick attestation: TLS fingerprint MISMATCH for %s (cached=%s, live=%s)", providerEndpoint, cached.tlsFingerprint, tlsFingerprint)
+		return fmt.Errorf("TLS certificate changed since session was opened (provider %s)", providerEndpoint)
+	}
+
+	v.log.Infof("quick attestation: TLS fingerprint matches cached value for %s — provider verified", providerEndpoint)
+	return nil
+}
+
+// fullVerifyWithPing pings the provider to obtain its version, then performs
+// a full VerifyProvider which populates the quote cache on success.
+func (v *Verifier) fullVerifyWithPing(ctx context.Context, providerEndpoint string, providerAddr string) error {
+	if v.pingFunc == nil {
+		return fmt.Errorf("cannot perform full verification: no ping function configured")
+	}
+
+	v.log.Infof("full verification: pinging provider %s (addr %s) for version", providerEndpoint, providerAddr)
+
+	version, err := v.pingFunc(ctx, providerEndpoint, providerAddr)
+	if err != nil {
+		return fmt.Errorf("TEE ping failed for provider %s: %w", providerEndpoint, err)
+	}
+	if version == "" {
+		return fmt.Errorf("TEE provider %s did not report a version", providerEndpoint)
+	}
+
+	v.log.Infof("full verification: provider %s reported version %s, proceeding with full attestation", providerEndpoint, version)
+
+	return v.VerifyProvider(ctx, providerEndpoint, version)
+}
+
 // compareRegisters checks every register present in the golden values against
 // the values extracted from the provider's attestation quote.
 func (v *Verifier) compareRegisters(result *AttestationResult, golden *GoldenValues) error {
@@ -263,6 +376,7 @@ func (v *Verifier) compareRegisters(result *AttestationResult, golden *GoldenVal
 	var mismatches []string
 	for _, p := range pairs {
 		if p.golden == "" {
+			v.log.Debugf("register %s: golden value empty, skipping", p.name)
 			continue
 		}
 		if p.actual == "" {
@@ -271,6 +385,8 @@ func (v *Verifier) compareRegisters(result *AttestationResult, golden *GoldenVal
 		}
 		if !strings.EqualFold(p.golden, p.actual) {
 			mismatches = append(mismatches, fmt.Sprintf("%s: expected %s, got %s", p.name, p.golden, p.actual))
+		} else {
+			v.log.Infof("register %s: matches golden value", p.name)
 		}
 	}
 
@@ -278,6 +394,7 @@ func (v *Verifier) compareRegisters(result *AttestationResult, golden *GoldenVal
 		return fmt.Errorf("register mismatch: %s", strings.Join(mismatches, "; "))
 	}
 
+	v.log.Infof("all checked registers match golden values")
 	return nil
 }
 
@@ -285,6 +402,8 @@ func (v *Verifier) compareRegisters(result *AttestationResult, golden *GoldenVal
 // provider and returns the SHA-256 fingerprint of the peer's TLS certificate.
 func (v *Verifier) loadAttestationQuote(ctx context.Context, attestationBaseURL string) (hexQuote string, tlsFingerprint string, err error) {
 	cpuURL := attestationBaseURL + "/cpu"
+
+	v.log.Infof("fetching attestation quote from %s", cpuURL)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cpuURL, nil)
 	if err != nil {
@@ -304,6 +423,8 @@ func (v *Verifier) loadAttestationQuote(ctx context.Context, attestationBaseURL 
 	if resp.TLS != nil && len(resp.TLS.PeerCertificates) > 0 {
 		hash := sha256.Sum256(resp.TLS.PeerCertificates[0].Raw)
 		tlsFingerprint = hex.EncodeToString(hash[:])
+	} else {
+		v.log.Warnf("no TLS peer certificate received from %s", cpuURL)
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -316,12 +437,16 @@ func (v *Verifier) loadAttestationQuote(ctx context.Context, attestationBaseURL 
 		return "", "", fmt.Errorf("empty attestation quote from provider")
 	}
 
+	v.log.Infof("received attestation quote from %s (%d bytes)", cpuURL, len(hexQuote))
+
 	return hexQuote, tlsFingerprint, nil
 }
 
 // verifyQuote sends the hex attestation quote to the SecretAI Portal parse-quote API
 // for cryptographic verification and field extraction.
 func (v *Verifier) verifyQuote(ctx context.Context, hexQuote string) (*AttestationResult, error) {
+	v.log.Infof("sending quote to SecretAI portal for cryptographic verification (%s)", v.portalURL)
+
 	reqBody := ParseQuoteRequest{Quote: hexQuote}
 	body, err := json.Marshal(reqBody)
 	if err != nil {
@@ -355,8 +480,11 @@ func (v *Verifier) verifyQuote(ctx context.Context, hexQuote string) (*Attestati
 	}
 
 	if parsed.Error != "" {
+		v.log.Warnf("portal returned error: %s", parsed.Error)
 		return &AttestationResult{Valid: false, Error: parsed.Error}, nil
 	}
+
+	v.log.Infof("portal verified quote successfully, parsing fields")
 
 	q := parsed.Quote
 	mrtd := qf(q, "mr_td")

--- a/proxy-router/internal/blockchainapi/controller.go
+++ b/proxy-router/internal/blockchainapi/controller.go
@@ -577,7 +577,7 @@ func (c *BlockchainController) openSession(ctx *gin.Context) {
 	}
 	usernameStr := username.(string)
 
-	sessionId, err := c.service.OpenSession(ctx, reqPayload.Approval, reqPayload.ApprovalSig, reqPayload.Stake.Unpack(), reqPayload.DirectPayment, usernameStr)
+	sessionId, err := c.service.OpenSession(ctx, reqPayload.Approval, reqPayload.ApprovalSig, reqPayload.Stake.Unpack(), reqPayload.DirectPayment, usernameStr, false)
 	if err != nil {
 		c.log.Error(err)
 		ctx.JSON(http.StatusInternalServerError, structs.ErrRes{Error: err.Error()})

--- a/proxy-router/internal/blockchainapi/service.go
+++ b/proxy-router/internal/blockchainapi/service.go
@@ -318,7 +318,7 @@ func (s *BlockchainService) rateBids(bidIds [][32]byte, bids []m.IBidStorageBid,
 	return scoredBids
 }
 
-func (s *BlockchainService) OpenSession(ctx context.Context, approval, approvalSig []byte, stake *big.Int, directPayment bool, agentUsername string) (common.Hash, error) {
+func (s *BlockchainService) OpenSession(ctx context.Context, approval, approvalSig []byte, stake *big.Int, directPayment bool, agentUsername string, isTee bool) (common.Hash, error) {
 	isAgent, err := s.authConfig.IsAllowanceEnough(agentUsername, s.morTokenAddr.Hex(), stake)
 	if err != nil {
 		return common.Hash{}, lib.WrapError(ErrAgentUserAllowance, err)
@@ -424,6 +424,7 @@ func (s *BlockchainService) OpenSession(ctx context.Context, approval, approvalS
 	}
 
 	session.SetAgentUsername(agentUsername)
+	session.SetIsTee(isTee)
 
 	err = s.sessionRepo.SaveSession(ctx, session)
 	if err != nil {
@@ -1229,20 +1230,11 @@ func (s *BlockchainService) tryOpenSession(ctx context.Context, bid *structs.Bid
 	}
 
 	if isTeeSession && s.attestationVerifier != nil {
-		_, version, err := s.proxyService.Ping(ctx, provider.Endpoint, bid.Provider)
-		if err != nil {
-			s.log.Warnf("TEE ping failed for provider %s: %s", bid.Provider, err)
-			return common.Hash{}, true, fmt.Errorf("TEE ping failed: %w", err)
-		}
-		if version == "" {
-			s.log.Warnf("TEE provider %s did not report a version, cannot verify attestation", bid.Provider)
-			return common.Hash{}, true, fmt.Errorf("TEE provider %s did not report a version", bid.Provider)
-		}
-		if err := s.attestationVerifier.VerifyProvider(ctx, provider.Endpoint, version); err != nil {
+		if err := s.attestationVerifier.VerifyProviderQuick(ctx, provider.Endpoint, bid.Provider.Hex(), true); err != nil {
 			s.log.Warnf("TEE attestation failed for provider %s: %s", bid.Provider, err)
 			return common.Hash{}, true, fmt.Errorf("TEE attestation failed: %w", err)
 		}
-		s.log.Infof("TEE attestation passed for provider %s (version %s)", bid.Provider, version)
+		s.log.Infof("TEE attestation passed for provider %s", bid.Provider)
 	}
 
 	sessionCost := (&big.Int{}).Mul(&bid.PricePerSecond.Int, duration)
@@ -1269,7 +1261,7 @@ func (s *BlockchainService) tryOpenSession(ctx context.Context, bid *structs.Bid
 		return common.Hash{}, true, lib.WrapError(ErrInitSession, err)
 	}
 
-	hash, err := s.OpenSession(ctx, initRes.Approval, initRes.ApprovalSig, amountTransferred, directPayment, agentUsername)
+	hash, err := s.OpenSession(ctx, initRes.Approval, initRes.ApprovalSig, amountTransferred, directPayment, agentUsername, isTeeSession)
 	if err != nil {
 		return common.Hash{}, false, err
 	}

--- a/proxy-router/internal/proxyapi/proxy_sender.go
+++ b/proxy-router/internal/proxyapi/proxy_sender.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/attestation"
 	gcs "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/chatstorage/genericchatstorage"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/interfaces"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
@@ -64,6 +65,7 @@ type ProxyServiceSender struct {
 	cnodePnodeTimeout         time.Duration     // Per-attempt timeout waiting for PNode first response
 	cnodePnodeMaxRetries      int               // Max retries on read timeout from PNode (chat/embeddings)
 	cnodePnodeAudioMaxRetries int               // Max retries on read timeout from PNode (audio)
+	attestationVerifier       *attestation.Verifier
 	log                       lib.ILogger
 }
 
@@ -85,6 +87,10 @@ func NewProxySender(chainID *big.Int, privateKey interfaces.PrKeyProvider, logSt
 
 func (p *ProxyServiceSender) SetSessionService(service SessionService) {
 	p.sessionService = service
+}
+
+func (p *ProxyServiceSender) SetAttestationVerifier(v *attestation.Verifier) {
+	p.attestationVerifier = v
 }
 
 func (p *ProxyServiceSender) Ping(ctx context.Context, providerURL string, providerAddr common.Address) (time.Duration, string, error) {
@@ -531,6 +537,13 @@ func (p *ProxyServiceSender) validateSession(ctx context.Context, sessionID comm
 	return session, provider, nil
 }
 
+func (p *ProxyServiceSender) verifyTEEAttestation(ctx context.Context, providerURL string, providerAddr string, isTee bool) error {
+	if p.attestationVerifier == nil {
+		return nil
+	}
+	return p.attestationVerifier.VerifyProviderQuick(ctx, providerURL, providerAddr, isTee)
+}
+
 // prepareRequest creates and prepares an RPC request for the provider
 func (p *ProxyServiceSender) prepareRequest(ctx context.Context, sessionID common.Hash, payload interface{}, providerPubKey string) (*msgs.RPCMessage, lib.HexString, error) {
 	requestID := lib.RequestIDFromContext(ctx)
@@ -621,6 +634,11 @@ func (p *ProxyServiceSender) SendPromptV2(ctx context.Context, sessionID common.
 	session, provider, err := p.validateSession(ctx, sessionID)
 	if err != nil {
 		return nil, err
+	}
+
+	if err := p.verifyTEEAttestation(ctx, provider.Url, provider.Addr, session.IsTee()); err != nil {
+		log.Warnf("TEE attestation check failed: %s", err)
+		return nil, lib.WrapError(ErrProvider, err)
 	}
 
 	// Acquire session semaphore to ensure only 1 concurrent request per session
@@ -1152,6 +1170,11 @@ func (p *ProxyServiceSender) SendAudioTranscriptionV2(ctx context.Context, sessi
 		return nil, err
 	}
 
+	if err := p.verifyTEEAttestation(ctx, provider.Url, provider.Addr, session.IsTee()); err != nil {
+		log.Warnf("TEE attestation check failed: %s", err)
+		return nil, lib.WrapError(ErrProvider, err)
+	}
+
 	// Acquire session semaphore to ensure only 1 concurrent request per session
 	log.Infof("acquiring session semaphore for session %s (audio transcription)", sessionID.Hex())
 	if err := p.sessionSema.Acquire(ctx, sessionID); err != nil {
@@ -1433,6 +1456,11 @@ func (p *ProxyServiceSender) SendAudioSpeech(ctx context.Context, sessionID comm
 		return nil, err
 	}
 
+	if err := p.verifyTEEAttestation(ctx, provider.Url, provider.Addr, session.IsTee()); err != nil {
+		log.Warnf("TEE attestation check failed: %s", err)
+		return nil, lib.WrapError(ErrProvider, err)
+	}
+
 	// Acquire session semaphore to ensure only 1 concurrent request per session
 	log.Infof("acquiring session semaphore for session %s (audio speech)", sessionID.Hex())
 	if err := p.sessionSema.Acquire(ctx, sessionID); err != nil {
@@ -1501,6 +1529,11 @@ func (p *ProxyServiceSender) SendEmbeddings(ctx context.Context, sessionID commo
 	session, provider, err := p.validateSession(ctx, sessionID)
 	if err != nil {
 		return nil, err
+	}
+
+	if err := p.verifyTEEAttestation(ctx, provider.Url, provider.Addr, session.IsTee()); err != nil {
+		log.Warnf("TEE attestation check failed: %s", err)
+		return nil, lib.WrapError(ErrProvider, err)
 	}
 
 	// Acquire session semaphore to ensure only 1 concurrent request per session

--- a/proxy-router/internal/repositories/session/session_model.go
+++ b/proxy-router/internal/repositories/session/session_model.go
@@ -20,6 +20,7 @@ type SessionModel struct {
 	outputTokens     int
 	failoverEnabled  bool
 	directPayment    bool
+	isTee            bool
 }
 
 func (s *SessionModel) ID() common.Hash {
@@ -80,4 +81,12 @@ func (s *SessionModel) SetFailoverEnabled(enabled bool) {
 
 func (s *SessionModel) SetAgentUsername(username string) {
 	s.agentUsername = username
+}
+
+func (s *SessionModel) IsTee() bool {
+	return s.isTee
+}
+
+func (s *SessionModel) SetIsTee(v bool) {
+	s.isTee = v
 }

--- a/proxy-router/internal/repositories/session/session_repo.go
+++ b/proxy-router/internal/repositories/session/session_repo.go
@@ -118,6 +118,7 @@ func (r *SessionRepositoryCached) getSessionFromCache(id common.Hash) (*SessionM
 		outputTokens:     ses.OutputTokens,
 		failoverEnabled:  ses.FailoverEnabled,
 		agentUsername:    ses.AgentUsername,
+		isTee:           ses.IsTee,
 	}, nil
 }
 
@@ -135,5 +136,6 @@ func (r *SessionRepositoryCached) saveSessionToCache(ses *SessionModel) error {
 		FailoverEnabled:  ses.failoverEnabled,
 		DirectPayment:    ses.directPayment,
 		AgentUsername:    ses.agentUsername,
+		IsTee:           ses.isTee,
 	})
 }

--- a/proxy-router/internal/storages/structs.go
+++ b/proxy-router/internal/storages/structs.go
@@ -20,6 +20,7 @@ type Session struct {
 	OutputTokens     int
 	FailoverEnabled  bool
 	DirectPayment    bool
+	IsTee            bool
 }
 
 type User struct {


### PR DESCRIPTION
### Summary

- Verifies TEE attestation on **every prompt**, not just at session open, ensuring the provider hasn't changed mid-session
- Uses quote hash caching so the common-case cost is ~50-150ms (TLS handshake only), not the full ~250-650ms portal round-trip
- Unifies session-open and per-prompt attestation into a single `VerifyProviderQuick` code path

### How it works

| Scenario | What happens | Latency |
|---|---|---|
| **Cache hit** (every prompt) | Fetch quote from `:29343/cpu`, compare `sha256(quote)` + TLS fingerprint against cached | ~50-150ms |
| **Cache miss** (first prompt) | Full verification: ping for version, portal crypto check, golden value comparison, populate cache | ~250-650ms |
| **Quote changed** (TEE rebooted) | Cache hit but hash mismatch → error → triggers failover | ~250-650ms |
| **Non-TEE session** | No-op | ~0ms |
