### PR TITLE
fix: re-verify provider on quote hash mismatch instead of failing

### DIFF
--- a/proxy-router/internal/attestation/verifier.go
+++ b/proxy-router/internal/attestation/verifier.go
@@ -311,7 +311,7 @@ func (v *Verifier) VerifyProviderQuick(ctx context.Context, providerEndpoint str
 
 	if currentHash != cached.quoteHash {
 		v.log.Warnf("quick attestation: quote hash MISMATCH for %s (cached=%s, live=%s)", providerEndpoint, cached.quoteHash, currentHash)
-		return fmt.Errorf("TEE attestation quote changed since session was opened (provider %s)", providerEndpoint)
+		return v.fullVerifyWithPing(ctx, providerEndpoint, providerAddr)
 	}
 
 	v.log.Infof("quick attestation: quote hash matches cached value for %s", providerEndpoint)


### PR DESCRIPTION
## Summary

- When quick attestation detects a TEE quote hash mismatch (e.g. provider restarted or rotated its enclave), the verifier now falls back to a full re-verification instead of returning an error. This avoids unnecessarily rejecting providers whose attestation is still valid but has changed since the session was opened.

## Test plan

- [ ] Simulate a provider quote rotation mid-session and confirm the consumer re-verifies successfully instead of erroring out
- [ ] Verify that a genuinely invalid/tampered quote still fails full verification