### PR TITLE
fix(storage): switch activity tracking to per-entry Badger keys and i…

### DIFF
--- a/proxy-router/internal/proxyapi/capacity_manager_test.go
+++ b/proxy-router/internal/proxyapi/capacity_manager_test.go
@@ -1,0 +1,49 @@
+package proxyapi
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/config"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/storages"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdleTimeoutCapacityManager_HasCapacity(t *testing.T) {
+	now := time.Now().Unix()
+	storage := storages.NewTestStorage()
+	sessionStorage := storages.NewSessionStorage(storage)
+
+	session := &storages.Session{
+		Id:       "0xsession1",
+		ModelID:  "0xmodel1",
+		EndsAt:   big.NewInt(now + 3600),
+		UserAddr: "0xuser",
+	}
+	require.NoError(t, sessionStorage.AddSession(session))
+
+	modelCfg := &config.ModelConfig{
+		ConcurrentSlots: 1,
+		CapacityPolicy:  "idle_timeout",
+	}
+	manager := NewIdleTimeoutCapacityManager(modelCfg, sessionStorage, &lib.LoggerMock{})
+
+	// Recent activity should count as active, filling the single slot.
+	require.NoError(t, sessionStorage.AddActivity(session.ModelID, &storages.PromptActivity{
+		SessionID: session.Id,
+		StartTime: now - 30,
+		EndTime:   now - 10,
+	}))
+	require.False(t, manager.HasCapacity(session.ModelID))
+
+	// Remove old activity and add stale one that is outside 15m idle timeout.
+	require.NoError(t, sessionStorage.RemoveOldActivities(session.ModelID, now))
+	require.NoError(t, sessionStorage.AddActivity(session.ModelID, &storages.PromptActivity{
+		SessionID: session.Id,
+		StartTime: now - 2000,
+		EndTime:   now - 1800,
+	}))
+	require.True(t, manager.HasCapacity(session.ModelID))
+}

--- a/proxy-router/internal/storages/session_storage.go
+++ b/proxy-router/internal/storages/session_storage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -162,99 +163,73 @@ func (s *SessionStorage) GetSessionsForModel(modelID string) ([]string, error) {
 	return sessionIDs, nil
 }
 
-// AddActivity atomically reads the existing activities, appends the new one, and writes back
-// in a single BadgerDB transaction to prevent race conditions.
+func formatActivityPrefix(modelID string) []byte {
+	return []byte(fmt.Sprintf("activity:%s:", strings.ToLower(modelID)))
+}
+
+func formatActivityKey(modelID string, endTime int64, sessionID string) []byte {
+	return []byte(fmt.Sprintf("activity:%s:%d:%s", strings.ToLower(modelID), endTime, strings.ToLower(sessionID)))
+}
+
+func parseActivityKeyTimestamp(key []byte) (int64, error) {
+	parts := strings.Split(string(key), ":")
+	if len(parts) < 4 {
+		return 0, fmt.Errorf("invalid activity key format: %s", string(key))
+	}
+	return strconv.ParseInt(parts[2], 10, 64)
+}
+
+// AddActivity stores each activity as an individual key-value entry.
 func (s *SessionStorage) AddActivity(modelID string, activity *PromptActivity) error {
 	modelID = strings.ToLower(modelID)
-	key := []byte(fmt.Sprintf("activity:%s", modelID))
-
-	return s.db.RunInTransaction(func(txn *badger.Txn) error {
-		var activities []*PromptActivity
-
-		item, err := txn.Get(key)
-		if err != nil && !errors.Is(err, badger.ErrKeyNotFound) {
-			return fmt.Errorf("error reading activities for model %s: %w", modelID, err)
-		}
-		if err == nil {
-			var existingJson []byte
-			existingJson, err = item.ValueCopy(nil)
-			if err != nil {
-				return fmt.Errorf("error copying activity value for model %s: %w", modelID, err)
-			}
-			if err := json.Unmarshal(existingJson, &activities); err != nil {
-				return fmt.Errorf("error unmarshaling activities for model %s: %w", modelID, err)
-			}
-		}
-
-		activities = append(activities, activity)
-		activitiesJson, err := json.Marshal(activities)
-		if err != nil {
-			return err
-		}
-
-		entry := badger.NewEntry(key, activitiesJson).WithTTL(ActivityTTL)
-		return txn.SetEntry(entry)
-	})
+	key := formatActivityKey(modelID, activity.EndTime, activity.SessionID)
+	activityJSON, err := json.Marshal(activity)
+	if err != nil {
+		return err
+	}
+	return s.db.SetWithTTL(key, activityJSON, ActivityTTL)
 }
 
 func (s *SessionStorage) GetActivities(modelID string) ([]*PromptActivity, error) {
 	modelID = strings.ToLower(modelID)
-	key := fmt.Sprintf("activity:%s", modelID)
-
-	activitiesJson, err := s.db.Get([]byte(key))
+	_, values, err := s.db.GetPrefixWithValues(formatActivityPrefix(modelID))
 	if err != nil {
-		if errors.Is(err, badger.ErrKeyNotFound) {
-			return []*PromptActivity{}, nil
-		}
 		return nil, fmt.Errorf("error reading activities for model %s: %w", modelID, err)
 	}
 
-	var activities []*PromptActivity
-	if err := json.Unmarshal(activitiesJson, &activities); err != nil {
-		return nil, fmt.Errorf("error unmarshaling activities for model %s: %w", modelID, err)
+	activities := make([]*PromptActivity, 0, len(values))
+	for _, activityJSON := range values {
+		var activity PromptActivity
+		if err := json.Unmarshal(activityJSON, &activity); err != nil {
+			return nil, fmt.Errorf("error unmarshaling activity for model %s: %w", modelID, err)
+		}
+		activities = append(activities, &activity)
 	}
 
 	return activities, nil
 }
 
-// RemoveOldActivities atomically reads, filters, and writes back activities in a single transaction.
+// RemoveOldActivities removes individual activity keys older than beforeTime.
 func (s *SessionStorage) RemoveOldActivities(modelID string, beforeTime int64) error {
 	modelID = strings.ToLower(modelID)
-	key := []byte(fmt.Sprintf("activity:%s", modelID))
+	keys, err := s.db.GetPrefix(formatActivityPrefix(modelID))
+	if err != nil {
+		return fmt.Errorf("error reading activity keys for model %s: %w", modelID, err)
+	}
 
 	return s.db.RunInTransaction(func(txn *badger.Txn) error {
-		item, err := txn.Get(key)
-		if err != nil {
-			if errors.Is(err, badger.ErrKeyNotFound) {
-				return nil
+		for _, key := range keys {
+			endTime, err := parseActivityKeyTimestamp(key)
+			if err != nil {
+				continue
 			}
-			return fmt.Errorf("error reading activities for model %s: %w", modelID, err)
-		}
-
-		existingJson, err := item.ValueCopy(nil)
-		if err != nil {
-			return fmt.Errorf("error copying activity value for model %s: %w", modelID, err)
-		}
-
-		var activities []*PromptActivity
-		if err := json.Unmarshal(existingJson, &activities); err != nil {
-			return fmt.Errorf("error unmarshaling activities for model %s: %w", modelID, err)
-		}
-
-		var updatedActivities []*PromptActivity
-		for _, activity := range activities {
-			if activity.EndTime > beforeTime {
-				updatedActivities = append(updatedActivities, activity)
+			if endTime <= beforeTime {
+				if err := txn.Delete(key); err != nil {
+					return fmt.Errorf("error deleting activity key %s: %w", string(key), err)
+				}
 			}
 		}
-
-		activitiesJson, err := json.Marshal(updatedActivities)
-		if err != nil {
-			return err
-		}
-
-		entry := badger.NewEntry(key, activitiesJson).WithTTL(ActivityTTL)
-		return txn.SetEntry(entry)
+		return nil
 	})
 }
 

--- a/proxy-router/internal/storages/session_storage_test.go
+++ b/proxy-router/internal/storages/session_storage_test.go
@@ -1,8 +1,10 @@
 package storages
 
 import (
+	"encoding/json"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -63,4 +65,65 @@ func TestRemoveSession(t *testing.T) {
 	sessionIds, err := sessionStorage.GetSessionsForModel(session.ModelID)
 	require.NoError(t, err)
 	require.Empty(t, sessionIds)
+}
+
+func TestActivityStorage_AddAndGetActivities(t *testing.T) {
+	storage := NewTestStorage()
+	sessionStorage := NewSessionStorage(storage)
+
+	modelID := "0xabc"
+	a1 := &PromptActivity{SessionID: "0x1", StartTime: 100, EndTime: 101}
+	a2 := &PromptActivity{SessionID: "0x2", StartTime: 200, EndTime: 201}
+
+	require.NoError(t, sessionStorage.AddActivity(modelID, a1))
+	require.NoError(t, sessionStorage.AddActivity(modelID, a2))
+
+	activities, err := sessionStorage.GetActivities(modelID)
+	require.NoError(t, err)
+	require.Len(t, activities, 2)
+
+	got := map[string]PromptActivity{}
+	for _, a := range activities {
+		got[a.SessionID] = *a
+	}
+	require.Equal(t, *a1, got[a1.SessionID])
+	require.Equal(t, *a2, got[a2.SessionID])
+}
+
+func TestActivityStorage_RemoveOldActivities(t *testing.T) {
+	storage := NewTestStorage()
+	sessionStorage := NewSessionStorage(storage)
+
+	modelID := "0xdef"
+	oldActivity := &PromptActivity{SessionID: "0xold", StartTime: 100, EndTime: 110}
+	newActivity := &PromptActivity{SessionID: "0xnew", StartTime: 200, EndTime: 210}
+
+	require.NoError(t, sessionStorage.AddActivity(modelID, oldActivity))
+	require.NoError(t, sessionStorage.AddActivity(modelID, newActivity))
+
+	require.NoError(t, sessionStorage.RemoveOldActivities(modelID, 150))
+
+	activities, err := sessionStorage.GetActivities(modelID)
+	require.NoError(t, err)
+	require.Len(t, activities, 1)
+	require.Equal(t, newActivity.SessionID, activities[0].SessionID)
+	require.Equal(t, newActivity.EndTime, activities[0].EndTime)
+}
+
+func TestActivityStorage_IgnoresLegacyArrayKey(t *testing.T) {
+	storage := NewTestStorage()
+	sessionStorage := NewSessionStorage(storage)
+
+	modelID := "0xlegacy"
+	legacyValue, err := json.Marshal([]*PromptActivity{
+		{SessionID: "0xlegacy", StartTime: 1, EndTime: 2},
+	})
+	require.NoError(t, err)
+
+	legacyKey := []byte("activity:" + modelID)
+	require.NoError(t, storage.SetWithTTL(legacyKey, legacyValue, time.Hour))
+
+	activities, err := sessionStorage.GetActivities(modelID)
+	require.NoError(t, err)
+	require.Empty(t, activities)
 }

--- a/proxy-router/internal/storages/storage.go
+++ b/proxy-router/internal/storages/storage.go
@@ -16,7 +16,7 @@ import (
 // Default configuration values for BadgerDB
 const (
 	DefaultGCInterval      = 5 * time.Minute
-	DefaultGCRatio         = 0.5
+	DefaultGCRatio         = 0.3
 	DefaultMetricsInterval = 5 * time.Minute
 )
 
@@ -39,6 +39,7 @@ func NewStorage(log lib.ILogger, path string) (*Storage, error) {
 	opts.Logger = storageLogger
 	opts.NumVersionsToKeep = 1
 	opts.CompactL0OnClose = true
+	opts.ValueLogFileSize = 128 << 20
 
 	db, err := badger.Open(opts)
 	if err != nil {


### PR DESCRIPTION
…mprove GC reclaim

This MR fixes BadgerDB value-log growth caused by rewriting a single growing activity blob on every prompt.
Activity records are now stored as individual TTL keys, enabling efficient expiration and much better garbage collection behavior.

It also tunes Badger GC settings and adds focused tests to ensure capacity logic remains correct with the new storage layout.