### PR TITLE
fix(cicd): ECS deploy wait timing + v7.0.0 release docs + version bump

### DIFF
--- a/.ai-docs/TEE_Attestation_Architecture.md
+++ b/.ai-docs/TEE_Attestation_Architecture.md
@@ -1,7 +1,16 @@
 # TEE Attestation Architecture — Verifiable Provider Compute
 
-**Status:** v1.0 — Full automated loop: build → sign → deploy → verify attestation  
-**Last updated:** 2026-03-11
+**Status:** v2.0 — Full two-hop trust chain shipped. Phase 1 (consumer → P-Node) in v6.0.0+; Phase 2 (P-Node → backend LLM) in v7.0.0+.
+**Last updated:** 2026-04-22
+
+> **Shipping summary (as of v7.0.0):**
+> - **Phase 1a (CI/CD supply-chain hardening)** — DONE (v6.0.0)
+> - **Phase 1b (RTMR3 computation + automated deployment + post-deploy attestation)** — DONE (v6.0.0)
+> - **Phase 1c (proxy-router code: consumer verifies P-Node)** — DONE (v6.0.0, refined through v6.2.x)
+> - **Phase 2a (P-Node verifies backend LLM: CPU quote, TLS pinning, RTMR3 replay, CPU-GPU binding, NRAS)** — DONE (v7.0.0, PR #699 and follow-ups #700, #703/#704, #705, #708/#709)
+> - **Phase 2b (verifiable per-message signing, local quote verification, co-located CPU+GPU TDX VM)** — still future work
+>
+> The `tee` on-chain model tag is the single switch that turns on **both** hops: consumer-side P-Node verification (Phase 1) and P-Node-side backend verification (Phase 2). A v6.0.0+ consumer paired with a v7.0.0+ provider gets the full chain transparently with no client-side upgrade.
 
 ---
 
@@ -16,25 +25,52 @@ A consumer node should be able to **cryptographically verify**, before sending a
 
 ---
 
-## 2. Scope — What We're Doing Now (Phase 1)
+## 2. Scope — What Shipped
 
-**In scope (CI/CD supply-chain hardening — our work):**
-- Cosign keyless image signing (both standard and TEE images)
-- Image digest capture and export
-- SBOM generation and attachment (syft)
-- Signed TEE attestation manifest (Option 5B — stored in GHCR as OCI artifact)
-- Support both Intel TDX and AMD SEV-SNP from day one
+### Phase 1 — DONE (v6.0.0)
 
-**In scope (proxy-router code — developer work, later):**
-- `IsTEEModel()` helper for on-chain tag detection
-- Consumer-side attestation verification before session creation (fetches quote from SecretVM host endpoint at `:29343`)
-- Consumer UI: TEE badge and verification status
+**CI/CD supply-chain hardening:**
+- Cosign keyless image signing (both standard and TEE images) — **DONE**
+- Image digest capture and export — **DONE**
+- SBOM generation and attachment (syft) — **DONE**
+- Signed TEE attestation manifest (Option 5B — stored in GHCR as OCI artifact) — **DONE**
+- Intel TDX RTMR3 computed in CI and published in the signed manifest — **DONE**
+- Auto-deploy to SecretVM test instance + post-deploy RTMR3 verification gate — **DONE**
+- AMD SEV-SNP measurement path — still TODO (blocked on upstream tooling)
 
-**Out of scope for Phase 1:**
-- On-chain oracle / DAO governance for measurements
-- Model backend (LLM) attestation (accepted gap — later phases co-locate proxy + LLM in same TEE)
+**Proxy-router code (consumer verifies P-Node):**
+- `IsTeeModel()` helper for on-chain tag detection — **DONE** (`blockchainapi/model_tags.go`)
+- Consumer-side attestation verification before session creation (fetches quote from SecretVM host endpoint at `:29343`, verifies via SecretAI portal, compares to manifest) — **DONE** (`attestation/verifier.go`, called from `blockchainapi/service.go` and `proxyapi/proxy_sender.go`)
+- Per-prompt `VerifyProviderQuick` fast-path re-check — **DONE** (hash + TLS fingerprint compare)
+- Consumer UI: TEE badge and verification status — **DONE**
+
+### Phase 2 — DONE (v7.0.0, PR #699 + #700)
+
+**P-Node verifies its own backend LLM** (the gap previously "accepted" for Phase 1 is now closed without co-locating):
+
+- `BackendVerifier.AttestBackend` at startup — **DONE**
+  - Fetch backend CPU quote from `:29343/cpu`; verify via SecretAI portal
+  - TLS binding: compare TLS cert SHA-256 with CPU quote `reportData[0:32]`
+  - Workload verification: parse TDX quote, look up MRTD + RTMR0-2 in the published SecretVM TDX artifact registry CSV, replay RTMR3 using SHA-384 extend chain over `SHA-256(docker-compose)` + rootfs data
+  - GPU attestation: fetch from `:29343/gpu`, verify CPU-GPU binding via `reportData[32:64] == GPU nonce`
+  - NVIDIA NRAS v4 API: submit GPU evidence for independent hardware validation (non-fatal if unreachable)
+- `BackendVerifier.FastVerifyBackend` on every prompt — **DONE**
+  - Always re-fetches CPU quote (~50 ms), compares hash + TLS fingerprint against cached snapshot
+  - Mismatch on hash → trigger full re-attestation
+  - Mismatch on TLS fingerprint → immediate hard fail (MITM signal)
+- Pinned-cert HTTP client for onward inference traffic (`PinnedHTTPClient`) — **DONE**
+  - Custom `VerifyPeerCertificate` refuses any TLS cert whose SHA-256 doesn't match the attested fingerprint
+- Artifact registry auto-refresh (`ArtifactRegistry`) — **DONE** (configurable via `ARTIFACT_REGISTRY_URL`, `ARTIFACT_REGISTRY_REFRESH_INTERVAL`)
+- Health endpoint `GET /v1/models/attestation` — **DONE**
+
+### Still out of scope (future)
+
+- On-chain oracle / DAO governance for golden-measurement updates (cosign keyless via GHA OIDC remains the signer)
+- Verifiable per-message signing using a TEE-bound key (§7.6) — slipped to Phase 2b
+- Local quote verification in Go (today we still call SCRT Labs `quote-parse`)
+- Co-located proxy-router + LLM in a single TDX VM (would collapse both hops into one RTMR3)
 - Rating system integration
-- CVE scanning gate (later)
+- CVE scanning gate
 
 ### Design Decisions (from review)
 
@@ -43,7 +79,7 @@ A consumer node should be able to **cryptographically verify**, before sending a
 | 1 | Oracle governance | **Automated by CI/CD** — cosign keyless signing via GitHub Actions OIDC. No multi-sig/DAO for now. |
 | 2 | SCRT Labs coupling | **Yes, couple** — use their quote-parse API and `reproduce-mr` tool. They control the VM layer; we need their artifacts. See §3. |
 | 3 | AMD SEV support | **Both platforms from day one** if feasible; if `reproduce-mr` only handles TDX, compute what we can and extend for SEV in a fast follow. |
-| 4 | Model backend trust | **Gap accepted for Phase 1.** Later phases co-locate proxy-router + LLM on the same TEE VM (CPU for proxy, GPU for inference), making RTMR3 cover both. |
+| 4 | Model backend trust | **Closed in Phase 2 (v7.0.0).** Instead of co-locating, the P-Node actively verifies the backend LLM over the network: CPU quote + TLS pinning + RTMR3 replay of the backend's `docker-compose.yaml` + CPU-GPU nonce binding + NVIDIA NRAS. See §7.7. Co-location (single TDX VM for proxy-router + LLM) remains a future simplification that would collapse both hops into one measurement chain. |
 | 5 | RTMR computation in CI/CD | **Attempt to integrate** `reproduce-mr` using SCRT Labs release artifacts from GitHub. If not available in CI, publish all inputs so it can be run independently. |
 | 6 | Attestation freshness | **Version-based, not clock-based.** Support current version and N-2 prior versions. When a new version publishes, the oldest attestation manifest becomes stale. This is a release-cadence policy. |
 | 7 | Consumer opt-out | **No opt-out.** If a consumer selects a TEE-tagged model, verification is mandatory. Failure = hard error, no prompt sent. |
@@ -491,15 +527,15 @@ The `secretvm-cli vm attestation <uuid>` command also returns the same data (use
 
 The attestation endpoint at `:29343` is served by the TEE host, not the proxy-router container. Even a compromised application cannot fake or suppress it — strong separation of concerns.
 
-### 7.3 `IsTEEModel()` helper and model tag convention
+### 7.3 `IsTeeModel()` helper and model tag convention — DONE
 
 **File:** `proxy-router/internal/blockchainapi/model_tags.go`
 
-**What:** Add a helper function to detect TEE models from their on-chain tags. The `ModelRegistry` contract already has `string[] tags` — providers registering TEE models add `"tee"` as a tag.
+**What shipped:** Helper function that detects the `tee` tag on an on-chain model's `tags` array. The `ModelRegistry` contract already has `string[] tags` — providers registering TEE models add `"tee"` as a tag. This single tag drives **both** hops of the trust chain: the consumer uses it to decide whether to verify the P-Node (Phase 1), and the P-Node uses it to decide whether to verify its own backend on every prompt (Phase 2).
 
-**Implementation:**
+**Implementation (current):**
 ```go
-func IsTEEModel(tags []string) bool {
+func IsTeeModel(tags []string) bool {
     for _, raw := range tags {
         if strings.ToLower(raw) == "tee" {
             return true
@@ -509,68 +545,166 @@ func IsTEEModel(tags []string) bool {
 }
 ```
 
-**Convention:** The canonical tag string is `"tee"` (lowercase). Document this for providers in the model registration guide.
+**Convention:** The canonical tag string is `"tee"` (matched case-insensitively). The v7 "tee tag for everything" refactor (PR #708, #709) removed the local `isTee` field from `models-config.json` entirely — the on-chain tag is now the sole source of truth.
 
-**Effort:** S
+**Effort:** S — **DONE**
 
-### 7.4 Consumer-side attestation verification in session flow
+### 7.4 Consumer-side attestation verification in session flow — DONE (v6.0.0, refined v6.2.x)
 
-**File:** `proxy-router/internal/blockchainapi/service.go` (`OpenSessionByModelId`, `tryOpenSession`)
+**Files:**
+- `proxy-router/internal/attestation/verifier.go` — core `Verifier`, `VerifyProvider` (full), `VerifyProviderQuick` (fast path)
+- `proxy-router/internal/blockchainapi/service.go` — calls `VerifyProvider` from `tryOpenSession` when `IsTeeSession` is true
+- `proxy-router/internal/proxyapi/proxy_sender.go` — calls `verifyTEEAttestation` (→ `VerifyProviderQuick`) before every `SendPrompt`, `SendTranscription`, `SendSpeech`, and session-init handshake
 
-**What:** Before creating a session with a TEE-tagged model, verify the provider's image and hardware attestation. This is the core of the trust loop.
+**What shipped:** When the consumer's C-Node picks a bid whose model carries the `tee` tag, it verifies the provider's P-Node attestation before opening the session and re-verifies on every prompt. Failure means fail-over to the next bid at session open, or a hard prompt-level error once a session is live.
 
-**Flow (inserted into the existing bid-ranking loop in `tryOpenSession`):**
+**Actual flow in `tryOpenSession` (v6+):**
 ```
-if IsTEEModel(model.Tags):
-    1. cosign.VerifyImageAttestations() → fetch signed manifest from GHCR
-       - Verify signature chain (OIDC issuer = GitHub Actions)
-       - Extract predicate: compose_sha256, baked_env, measurements
-    2. Confirm baked_env.PROXY_STORE_CHAT_CONTEXT == "false"
-    3. Confirm baked_env.ENVIRONMENT == "production"
-    4. GET provider attestation endpoint (https://{vm-domain}:29343/cpu.html)
-       → get raw TDX quote hex
-    5. Extract RTMR3 from TDX quote at byte offset 520 (48 bytes)
-       (same extraction logic used in CI/CD verification step)
-    6. Compare RTMR3 against expected value from signed manifest
-    7. Optionally: verify reportdata contains TLS certificate fingerprint (anti-MITM)
-    8. If all pass → proceed with InitiateSession
-    9. If any fail → log reason, skip this provider, try next bid
-   10. If all providers fail → hard error to user: "No verified TEE providers available"
+if IsTeeSession && attestationVerifier != nil:
+    1. Derive attestation VM domain from provider's Url
+    2. Verifier.VerifyProvider(vmDomain, providerAddr):
+       a. Fetch cosign-signed attestation manifest from GHCR for the `-tee` image
+          (cosign Go library, GitHub-Actions OIDC identity pattern,
+           type https://morpheusais.github.io/tee-attestation/v1)
+       b. Extract expected RTMR3 + baked_env from manifest predicate
+       c. Confirm baked_env.PROXY_STORE_CHAT_CONTEXT == "false",
+          ENVIRONMENT == "production", correct ETH_NODE_CHAIN_ID for network
+       d. GET https://{vm-domain}:29343/cpu → raw TDX quote hex
+       e. POST quote to TEE_PORTAL_URL (SecretAI quote-parse) — confirms genuine TDX
+       f. Extract RTMR3 from quote at byte offset 520 (48 bytes), compare to manifest
+       g. Extract reportData[0:32], compare to SHA-256 of the connection's
+          peer TLS certificate — anti-MITM
+       h. Cache snapshot (quote hash, TLS fingerprint, expiry-free)
+    3. If pass → InitiateSession / continue
+       If fail → skip this provider, try next bid; all fail → hard error
 ```
 
-**Note:** The attestation endpoint is provided by the SecretVM host (port 29343), not the proxy-router container. The consumer needs to derive the VM domain from the provider's public URL to reach it.
+**Per-prompt fast path (`VerifyProviderQuick`, called from `proxy_sender.go` before every forwarded prompt):**
+```
+1. Look up cached snapshot for providerAddr; no cache → re-run full VerifyProvider
+2. Re-fetch :29343/cpu, compute SHA-256 of the quote
+3. If quote hash == cached hash AND TLS fingerprint == cached fingerprint → pass
+4. If quote hash changed → trigger full re-attestation
+5. If TLS fingerprint changed → hard fail (MITM signal), refuse to forward
+```
 
-**Dependencies:**
-- `github.com/sigstore/cosign/v2/pkg/cosign` Go library for programmatic verification
-- Need to confirm compatibility with Go 1.23.x and impact on binary size (`FROM scratch` image)
-- Alternative: shell out to `cosign` binary (simpler but requires adding cosign to the image)
+**Dependencies (resolved):**
+- `github.com/sigstore/cosign/v2/pkg/cosign` — in-process Go verification, no shell-out, no binary added to image. Binary size impact acceptable for the `-tee` image (consumer proxy-router uses the same library).
+- Go 1.25.x (per CI/CD)
 
-**Effort:** L
+**Effort:** L — **DONE**
 
-### 7.5 Consumer UI: TEE badge and verification status
+### 7.5 Consumer UI: TEE badge and verification status — DONE
 
 **File:** `ui-desktop/src/renderer/src/components/` (model list, session views)
 
-**What:** Visual indicators for TEE models in the desktop UI.
+**What shipped:** Visual indicators for TEE models in the desktop UI.
 
 **Elements:**
 - TEE badge/icon on models tagged `"tee"` in the model browser
-- Verification status indicator during session creation ("Verifying TEE attestation...")
-- Success state: "Verified — running in TEE enclave"
-- Failure state: "Attestation verification failed — provider rejected"
+- Verification status indicator during session creation
+- Success and failure states
 
-**Effort:** M
+**Effort:** M — **DONE**
 
-### 7.6 Verifiable message signing (Phase 2, lower priority)
+### 7.6 Verifiable per-message signing — DEFERRED to Phase 2b
 
-**File:** New code in proxy-router
+**File:** New code in proxy-router (not yet added)
 
 **What:** Use SecretVM's internal signing service (`http://172.17.0.1:49153/sign`) to sign every response with a TEE-bound key. The public key is embedded in the attestation quote's `reportdata`, so consumers can verify that each response genuinely came from inside the TEE.
 
-**Why this matters:** Steps 7.1-7.5 verify attestation at session start. Per-message signing provides continuous proof throughout the session — not just "this provider was in a TEE when the session started" but "this specific response came from the TEE."
+**Why this matters:** Per-prompt fast-verify (§7.4) already re-checks the provider's CPU quote and TLS fingerprint on every request, so a compromise between session-open and the first prompt is detected before any inference ships. Per-message signing would tighten that further — prove that the response payload itself was produced inside the enclave, not just that the connection terminated there.
 
-**Effort:** L  
-**Priority:** Phase 2
+**Status:** Not shipped in v7.0.0. Deferred as "Phase 2b, lower priority" because the combination of TLS pinning (§7.7) + per-prompt fast-verify makes the practical attack window too narrow to justify the added per-response overhead at release time.
+
+**Effort:** L
+**Priority:** Phase 2b (post-v7)
+
+### 7.7 Phase 2 — P-Node verifies its own backend LLM — DONE (v7.0.0, PR #699)
+
+This is the Phase 2 capability that makes v7 the "full TEE" release. It closes the model-backend gap previously accepted in Phase 1 (Design Decision §2.4) without requiring CPU+GPU co-location in a single TDX VM.
+
+**Files (all under `proxy-router/internal/attestation/`):**
+- `backend_verifier.go` — `BackendVerifier.AttestBackend` (full) and `FastVerifyBackend` (per-prompt fast path)
+- `workload_verifier.go` — registry lookup + RTMR3 recalculation for the backend
+- `artifacts_registry.go` — downloads and caches the SecretVM TDX artifact registry CSV on a configurable interval (`ARTIFACT_REGISTRY_URL`, `ARTIFACT_REGISTRY_REFRESH_INTERVAL`)
+- `nras_verifier.go` — NVIDIA NRAS v4 API integration; validates the returned JWT Entity Attestation Token
+- `tdx_quote.go` — parses raw TDX quotes to extract MRTD + RTMR0-3 + reportData
+- `rtmr.go` — SHA-384 extend chain implementation used to replay expected RTMR3
+
+**Integration points:**
+- `proxy-router/cmd/main.go` — wires `BackendVerifier` into startup; calls `AttestBackend` once per `tee`-tagged model
+- `proxy-router/internal/proxyapi/proxy_receiver.go` — calls `FastVerifyBackend` in `SessionPrompt` before forwarding any inference for `tee`-tagged model sessions (hot path)
+- `proxy-router/internal/aiengine/ai_engine.go` — returns a `PinnedHTTPClient` for TEE models; the client's `VerifyPeerCertificate` callback refuses any onward TLS cert whose SHA-256 doesn't match the attested fingerprint
+- `proxy-router/internal/proxyapi/controller_http.go` — `GET /v1/models/attestation` returns per-model attestation state (verified / pending / failed + workload-match / last-success timestamp / error detail)
+
+**Backend attestation endpoints (derived from each TEE model's `apiUrl` host + standard port 29343):**
+- `:29343/cpu` — raw TDX CPU quote hex
+- `:29343/gpu` — JSON containing `nonce`, `arch`, `evidence_list`
+- `:29343/docker-compose` — exact `docker-compose.yaml` loaded into the backend VM (used for RTMR3 replay)
+
+**Full attestation sequence (`AttestBackend`):**
+```
+1. GET :29343/cpu            → raw TDX quote
+2. POST quote to TEE_PORTAL_URL (quote-parse) → portal verification
+3. Extract reportData[0:32]   → compare with SHA-256 of live TLS cert
+                                   → TLS binding proven
+4. if ArtifactRegistry loaded:
+     GET :29343/docker-compose
+     Parse TDX quote: MRTD + RTMR0-3 + reportData
+     Lookup (MRTD, RTMR0, RTMR1, RTMR2) in registry CSV → rootfs_data + secretvm_release
+     Replay RTMR3 = SHA-384-extend-chain( SHA-256(docker-compose) + rootfs_data )
+     if replayed RTMR3 != quote RTMR3 → fail (workload mismatch)
+5. GET :29343/gpu             → {nonce, arch, evidence_list}
+6. Extract reportData[32:64]  → compare with GPU nonce
+                                   → CPU-GPU binding proven
+7. if NRAS configured:
+     POST evidence to NVIDIA NRAS /v2/attest/gpu
+     Validate returned JWT EAT signature + claims
+     (non-fatal on network failure — NRAS outage does not block inference,
+      but CPU-GPU binding is still enforced)
+8. Cache snapshot: {quote_hash, tls_fingerprint, workload_status,
+                    last_verified_ts, compose_sha256}
+```
+
+**Per-prompt fast verify (`FastVerifyBackend`):**
+- No TTL. Runs unconditionally on every inference prompt for a `tee`-tagged model (inside `proxy_receiver.SessionPrompt`, on the hot path).
+- Always re-fetches `:29343/cpu` (~50 ms TLS handshake).
+- `SHA-256(new_quote) == cached_quote_hash` AND `live_tls_fp == cached_tls_fp` → pass.
+- Quote-hash change → run full `AttestBackend` again (backend restart / redeploy).
+- TLS-fingerprint change → immediate hard fail, prompt refused (MITM signal).
+- No cache → reject ("model not attested").
+- Cached status `failed` → reject ("attestation failed").
+
+**Measurement-register semantics (recap):**
+
+| Register | Content | How verified |
+|---|---|---|
+| MRTD | VM firmware measurement (set at launch, immutable) | Artifact registry lookup |
+| RTMR0 | VM configuration | Artifact registry lookup |
+| RTMR1 | Kernel | Artifact registry lookup |
+| RTMR2 | Initramfs | Artifact registry lookup |
+| RTMR3 | Rootfs + docker-compose.yaml | Client-side replay and compared to quote |
+
+**reportData layout (recap):**
+
+| Bytes | Content | Purpose |
+|---|---|---|
+| 0–31 | SHA-256(TLS cert) | Anti-MITM: pins the attested TEE to a specific TLS identity |
+| 32–63 | GPU nonce | CPU-GPU binding: GPU evidence can't be replayed from another box |
+
+**What Phase 2 proves end-to-end:**
+- The backend is genuine Intel TDX hardware running a known SecretVM firmware/kernel/initramfs build.
+- The exact set of loaded models (the `MODELS=...` line in `docker-compose.yaml`) is what the operator declared — swapping any model, port, or env var changes RTMR3 and fails verification.
+- The TLS endpoint serving inference terminates inside the attested enclave (no CDN/reverse-proxy MITM can sit between the P-Node and the backend).
+- The GPU evidence is genuine NVIDIA hardware (per NRAS), and cryptographically bound to the same CPU quote (per `reportData[32:64]`).
+- The backend identity hasn't changed since initial attestation, on a per-prompt basis.
+
+**Effort:** L — **DONE**
+**Priority:** Phase 2a — **shipped in v7.0.0**
+**PRs:** #699 (Phase 2 main), #700 (Phase 2 merge to test), #704 (error wrapping), #705 (request_id in logs), #708 / #709 (consolidate `tee` tag as sole TEE switch)
+
+See also: [`proxy-router/docs/tee-backend-verification.md`](../proxy-router/docs/tee-backend-verification.md) (developer reference with mermaid sequence + trust-chain diagrams).
 
 ---
 
@@ -580,11 +714,13 @@ if IsTEEModel(model.Tags):
 
 2. **~~SecretVM release pinning~~** — **RESOLVED.** Pinned in `.github/tee/secretvm.env`. Attestation manifest includes `secretvm_release` and `rootfs_sha256`. Providers must deploy on the matching release for RTMR3 to match.
 
-3. **Anti-MITM in practice:** The `reportdata` field contains the TLS certificate fingerprint. When the consumer connects to the provider over HTTPS, does it see the VM's TLS cert (proving it's inside the TEE), or does it see a CDN/load-balancer cert (breaking the chain)? If providers use Cloudflare/nginx in front, the anti-MITM guarantee breaks. Need to understand the typical network topology.
+3. **~~Anti-MITM in practice~~** — **RESOLVED in Phase 2.** The approach is now enforced on both hops:
+   - *Consumer → P-Node (Phase 1):* The consumer extracts the peer TLS cert during the `:29343/cpu` fetch and compares its SHA-256 to `reportData[0:32]` of the quote. Mismatch = session refused.
+   - *P-Node → Backend (Phase 2):* Same check at `AttestBackend`, **plus** the `PinnedHTTPClient` used for all onward inference refuses any TLS certificate whose SHA-256 doesn't match the attested fingerprint (in `VerifyPeerCertificate`). This means a TLS-terminating CDN/reverse-proxy in front of the backend *cannot* be used for `tee`-tagged models — the inference connection will refuse to establish. Operators are documented to expose SecretVM's port 443 (Traefik sidecar with SecretVM certs) directly for `tee`-tagged deployments.
 
-4. **Cosign verification in Go:** The consumer proxy-router is written in Go. Cosign has a Go library (`github.com/sigstore/cosign/v2/pkg/cosign`) for programmatic verification. Need to confirm it's compatible with the proxy-router's Go version (1.22.x) and doesn't bloat the binary excessively (relevant for `FROM scratch` image).
+4. **~~Cosign verification in Go~~** — **RESOLVED.** `github.com/sigstore/cosign/v2/pkg/cosign` is compiled into the proxy-router binary (Go 1.25.x). Binary-size impact accepted. Used both for consumer-side Phase 1 attestation manifest verification and for any in-process cosign verification needs.
 
-5. **ACPI templates for full RTMR0-2:** The `reproduce-mr` tool requires `template_qemu_cpu{N}.hex` files for ACPI table generation. These aren't published in the reproduce-mr repo. Need to either obtain from SCRT Labs or generate from a QEMU build. Not blocking — RTMR3 is the critical register for our software layer verification.
+5. **ACPI templates for full RTMR0-2:** The `reproduce-mr` tool requires `template_qemu_cpu{N}.hex` files for ACPI table generation — not needed for Phase 1 CI/CD (we only verify RTMR3 against the published manifest) *nor* for Phase 2 (we verify MRTD + RTMR0-2 by lookup in the published SecretVM TDX artifact registry CSV, not by recomputation). Remaining only if we ever want to recompute RTMR0-2 ourselves.
 
 ---
 
@@ -626,24 +762,45 @@ if IsTEEModel(model.Tags):
 | 1.20 | Temporarily disable service/UI builds on cicd/* branches | S | **DONE** | `Build-Service-Executables` set to `if: false`; cascades to all UI jobs. Re-enable before merge to main |
 | 1.21 | Testnet/mainnet TEE image split | S | **DONE** | `Dockerfile.tee` parameterized via ARG; pipeline sources `test.env` or `main.env` per branch — PR #669 |
 
-### Phase 1c — Proxy-Router Code (Developer Work)
+### Phase 1c — Proxy-Router Code (Consumer verifies P-Node) — DONE (v6.0.0)
 
 | # | Task | Effort | Status | Reference |
 |---|---|---|---|---|
 | ~~1.15~~ | ~~Extend `/healthcheck` with TEE metadata~~ | ~~S~~ | **DROPPED** | Not needed; TEE capability discovered via on-chain tag |
-| ~~1.16~~ | ~~Add `/attestation/quote` proxy endpoint~~ | ~~M~~ | **DROPPED** | Not needed; SecretVM host already exposes `:29343/cpu.html` |
-| 1.17 | `IsTEEModel()` helper in `model_tags.go` | S | TODO | §7.3 |
-| 1.18 | Consumer-side attestation verification in session flow | L | TODO | §7.4 — fetch quote from `:29343`, verify RTMR3 against signed manifest |
-| 1.19 | Consumer UI: TEE badge and verification status | M | TODO | §7.5 — frontend work, after 1.18 |
+| ~~1.16~~ | ~~Add `/attestation/quote` proxy endpoint~~ | ~~M~~ | **DROPPED** | Not needed; SecretVM host already exposes `:29343/cpu` |
+| 1.17 | `IsTeeModel()` helper in `model_tags.go` | S | **DONE** | §7.3 — consolidated in PR #708/#709 as sole TEE switch |
+| 1.18 | Consumer-side attestation verification in session flow | L | **DONE** | §7.4 — `attestation/verifier.go`, called from `blockchainapi/service.go` + `proxyapi/proxy_sender.go` |
+| 1.18a | Per-prompt `VerifyProviderQuick` fast path | M | **DONE** | PR #686 + #689 (quote-mismatch re-verify instead of hard fail) |
+| 1.18b | Storage-layer activity tracking for TEE sessions | S | **DONE** | PR #692/#693 (per-entry Badger keys, improved GC) |
+| 1.18c | Error-wrapping + request_id propagation for TEE failures | S | **DONE** | PR #704, #705 |
+| 1.19 | Consumer UI: TEE badge and verification status | M | **DONE** | §7.5 — renderer components + session-view states |
 
-### Phase 2 — Deeper Guarantees (future)
+### Phase 2a — P-Node verifies Backend LLM — DONE (v7.0.0)
 
-| # | Task | Effort | Status |
-|---|---|---|---|
-| 2.1 | Co-locate proxy-router + LLM in same TEE VM | L | TODO |
-| 2.2 | Verifiable per-message signing (TEE-bound key) | L | TODO |
-| 2.3 | On-chain measurement registry (if needed beyond cosign) | L | TODO |
-| 2.4 | Local quote verification (remove SCRT Labs API dependency) | L | TODO |
+| # | Task | Effort | Status | Reference |
+|---|---|---|---|---|
+| 2a.1 | `BackendVerifier` — full `AttestBackend` at startup | L | **DONE** | `attestation/backend_verifier.go`; PR #699 |
+| 2a.2 | `FastVerifyBackend` per-prompt hot-path check | M | **DONE** | Hooked from `proxy_receiver.SessionPrompt`; PR #699 |
+| 2a.3 | `WorkloadVerifier` — MRTD + RTMR0-2 registry lookup, RTMR3 replay | M | **DONE** | `attestation/workload_verifier.go`, `rtmr.go`, `tdx_quote.go` |
+| 2a.4 | `ArtifactRegistry` — download + cache SecretVM TDX artifact CSV | S | **DONE** | `attestation/artifacts_registry.go`; configurable interval |
+| 2a.5 | `NrasVerifier` — NVIDIA NRAS v4 evidence submission + JWT EAT validation | M | **DONE** | `attestation/nras_verifier.go` |
+| 2a.6 | `PinnedHTTPClient` — refuse onward TLS certs whose fingerprint doesn't match attested value | S | **DONE** | `aiengine/` — custom `VerifyPeerCertificate` |
+| 2a.7 | Health endpoint `GET /v1/models/attestation` | S | **DONE** | `proxyapi/controller_http.go` |
+| 2a.8 | New env config: `TEE_PORTAL_URL`, `TEE_IMAGE_REPO`, `ARTIFACT_REGISTRY_URL`, `ARTIFACT_REGISTRY_REFRESH_INTERVAL` | S | **DONE** | `config/config.go` (§7.7) |
+| 2a.9 | Consolidate `tee` on-chain tag as sole TEE switch (remove `isTee` field from models config schema) | S | **DONE** | PR #708 / #709 |
+| 2a.10 | Test coverage: `backend_verifier_test.go`, `golden_test.go`, `workload_verifier_test.go`, `workload_rytn_test.go`, `nras_verifier_test.go` | M | **DONE** | PR #699 |
+
+### Phase 2b — Deeper Guarantees (future, post-v7)
+
+| # | Task | Effort | Status | Notes |
+|---|---|---|---|---|
+| 2b.1 | Co-locate proxy-router + LLM in same TEE VM (single RTMR3 covers both hops) | L | TODO | Collapses Phase 1 + Phase 2 into one measurement chain |
+| 2b.2 | Verifiable per-message signing (TEE-bound key via SecretVM internal signer) | L | TODO | §7.6; deferred because Phase 2a fast-verify narrows the attack window significantly |
+| 2b.3 | AMD SEV-SNP measurement path in CI/CD | M | TODO | Blocked on upstream tooling; TDX-only today |
+| 2b.4 | Local quote verification in-process (remove SCRT Labs `quote-parse` dependency) | L | TODO | Requires PCK cert chain handling + Intel quote-verification library in Go |
+| 2b.5 | On-chain measurement registry (if ever needed beyond cosign signatures) | L | TODO | Cosign keyless via GHA OIDC is sufficient today |
+| 2b.6 | NRAS alternatives for non-NVIDIA GPU vendors | M | TODO | NVIDIA-only today |
+| 2b.7 | CVE scanning gate in CI/CD (Trivy/Grype) | S | TODO | §6.6 |
 
 ---
 
@@ -654,12 +811,22 @@ if IsTEEModel(model.Tags):
 | **Delivered artifacts** | |
 | Supply-chain hardening doc (in LMN) | `Morpheus-Lumerin-Node/.ai-docs/TEE_CICD_Supply_Chain_Hardening.md` |
 | Provider/consumer TEE guide (in LMN) | `Morpheus-Lumerin-Node/docs/02.3-proxy-router-tee.md` |
+| SecretVM provider quick-start (in LMN) | `Morpheus-Lumerin-Node/docs/02.4-proxy-router-secretvm-quickstart.md` |
+| **Phase 2 developer reference (in LMN)** | `Morpheus-Lumerin-Node/proxy-router/docs/tee-backend-verification.md` |
 | PR #644 — TEE image + BASE migration | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/644 |
 | PR #646 — Supply-chain hardening | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/646 |
 | PR #648 — Compose canonical format | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/648 |
 | PR #650 — User-facing TEE docs | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/650 |
 | PR #652 — SecretVM CLI instructions (from SCRT Labs) | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/652 |
 | PR #669 — Testnet/mainnet TEE image split | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/669 |
+| PR #686 — per-prompt TEE attestation with TLS binding and quote caching | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/686 |
+| PR #689 — re-verify provider on quote hash mismatch instead of failing | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/689 |
+| PR #692 — per-entry Badger activity tracking, improved GC reclaim | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/692 |
+| **PR #699 — Phase 2 TEE backend verification (main)** | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/699 |
+| PR #700 — Phase 2 merge to test | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/700 |
+| PR #703 / #704 — correct error wrapping on P-Node TEE attestation fail | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/704 |
+| PR #705 — request_id propagation in TEE logs | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/705 |
+| PR #708 / #709 — `tee` on-chain tag as sole TEE switch (removed `isTee` from models-config schema) | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/709 |
 | First verified pipeline run (build + sign) | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22920492249 |
 | First end-to-end run (build → sign → deploy → verify attestation) | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22969993910 |
 | **SCRT Labs / TEE platform** | |
@@ -678,8 +845,17 @@ if IsTEEModel(model.Tags):
 | **Proxy-router code references** | |
 | Healthcheck handler | `proxy-router/internal/system/controller.go:72-101` |
 | Healthcheck response struct | `proxy-router/internal/system/structs.go:19-24` |
-| Model tags detection | `proxy-router/internal/blockchainapi/model_tags.go` |
-| Session creation flow | `proxy-router/internal/blockchainapi/service.go` (`OpenSessionByModelId`, `tryOpenSession`) |
-| InitiateSession handshake | `proxy-router/internal/proxyapi/proxy_sender.go`, `proxy_receiver.go` |
+| Model tags detection (`IsTeeModel`) | `proxy-router/internal/blockchainapi/model_tags.go` |
+| Session creation flow + TEE branch | `proxy-router/internal/blockchainapi/service.go` (`OpenSessionByModelId`, `tryOpenSession`, sets `IsTee` on session) |
+| InitiateSession handshake + `VerifyProviderQuick` callsites | `proxy-router/internal/proxyapi/proxy_sender.go`, `proxy_receiver.go` |
+| **Phase 1 consumer verifier** | `proxy-router/internal/attestation/verifier.go` (`Verifier`, `VerifyProvider`, `VerifyProviderQuick`) |
+| **Phase 2 backend verifier** | `proxy-router/internal/attestation/backend_verifier.go` (`BackendVerifier.AttestBackend`, `FastVerifyBackend`) |
+| **Phase 2 workload verifier + RTMR3 replay** | `proxy-router/internal/attestation/workload_verifier.go`, `rtmr.go`, `tdx_quote.go` |
+| **Phase 2 artifact registry** | `proxy-router/internal/attestation/artifacts_registry.go` |
+| **Phase 2 NVIDIA NRAS client** | `proxy-router/internal/attestation/nras_verifier.go` |
+| **Phase 2 pinned TLS client** | `proxy-router/internal/aiengine/ai_engine.go` (returns `PinnedHTTPClient` for TEE models) |
+| **Phase 2 health endpoint** | `proxy-router/internal/proxyapi/controller_http.go` (`GET /v1/models/attestation`) |
+| TEE config struct | `proxy-router/internal/config/config.go` — `TEE` section (lines ~87-92) |
+| Session repository (tracks `IsTee`) | `proxy-router/internal/repositories/session/session_model.go`, `session_repo.go` |
 | ModelRegistry contract | `smart-contracts/contracts/diamond/facets/ModelRegistry.sol` |
 | Model struct (with tags) | `smart-contracts/contracts/interfaces/storage/IModelStorage.sol` |

--- a/.ai-docs/TEE_CICD_Supply_Chain_Hardening.md
+++ b/.ai-docs/TEE_CICD_Supply_Chain_Hardening.md
@@ -1,8 +1,10 @@
 # CI/CD Supply-Chain Hardening for Morpheus Docker Images
 
-**Last updated:** 2026-03-11  
-**First successful run (Phase 1a — signing):** [#22920492249](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22920492249)  
+**Last updated:** 2026-04-22
+**First successful run (Phase 1a — signing):** [#22920492249](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22920492249)
 **First end-to-end run (Phase 1b — deploy + verify):** [#22969993910](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22969993910)
+
+> **v7.0.0 release status.** The CI/CD hardening described here is the foundation that every downstream trust check depends on. Both **Phase 1c** (consumer-side proxy-router verification of the P-Node) and **Phase 2** (P-Node verifies its own backend LLM) have shipped on top of it — see [`TEE_Attestation_Architecture.md`](TEE_Attestation_Architecture.md) §7.4 and §7.7 for the code-level flow. The CI/CD pipeline itself remains unchanged from Phase 1b in this release; v7 is the *consumer* of the artifacts this pipeline produces.
 
 ---
 
@@ -197,37 +199,58 @@ This shows all attached artifacts — signature, attestation, and SBOM — in a 
 
 ---
 
-## What This Enables — The Full Loop
+## What This Enables — The Full Loop (as of v7.0.0)
 
-This CI/CD hardening is the **foundation layer** for the full TEE attestation loop. As of Phase 1b, the pipeline is fully automated end-to-end:
+This CI/CD hardening is the **foundation layer** for the full TEE attestation loop. As of v7.0.0, the loop is complete end-to-end — both consumer-side Phase 1 and P-Node-side Phase 2 are shipped:
 
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
-│                         CI/CD Pipeline (done)                         │
+│                    CI/CD Pipeline (Phase 1a + 1b — DONE)             │
 │                                                                      │
 │  Source Code ──► Build ──► Sign ──► Compute RTMR3 ──► Publish GHCR   │
 │                    │         │           │               │            │
-│                    │     cosign sig    RTMR3 in       ├── image      │
-│                    │     (Sigstore)    manifest        ├── SBOM      │
-│                    │                                   └── manifest  │
-│                    ▼                                                  │
-│                  Deploy to SecretVM ──► Verify live RTMR3 matches     │
-│                  (secretvm-cli)         (polls attestation quote)     │
+│                    │     cosign sig    RTMR3 in        ├── image     │
+│                    │     (Sigstore)    manifest         ├── SBOM     │
+│                    │                                    └── manifest │
+│                    ▼                                                 │
+│                  Deploy to SecretVM ──► Verify live RTMR3 matches    │
+│                  (secretvm-cli)         (polls attestation quote)    │
 └──────────────────────────────────────────────────────────────────────┘
                                               │
                                               ▼
-                              ┌──────────────────────────────┐
-                              │  Consumer Verification       │
-                              │  (proxy-router code, next)   │
-                              │                              │
-                              │  1. Detect "tee" model tag   │
-                              │  2. Fetch manifest from GHCR │
-                              │  3. Fetch quote from :29343  │
-                              │  4. Compare RTMR3            │
-                              │  5. If match → session       │
-                              │     If fail → reject         │
-                              └──────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│     Phase 1c — Consumer verifies P-Node (DONE in v6.0.0)             │
+│                                                                      │
+│  C-Node (v6.0.0+) session open + every prompt:                       │
+│    1. IsTeeModel(on-chain tags) == true                              │
+│    2. cosign fetch signed manifest from GHCR                         │
+│    3. GET provider :29343/cpu → raw TDX quote                        │
+│    4. POST to TEE_PORTAL_URL → quote is genuine                      │
+│    5. Compare RTMR3 against manifest golden value                    │
+│    6. reportData[0:32] == SHA-256(peer TLS cert) → anti-MITM         │
+│    7. Cache snapshot; fast-verify on every prompt                    │
+│  (attestation/verifier.go; PR #686, #689, #699)                      │
+└──────────────────────────────────────────────────────────────────────┘
+                                              │
+                                              ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│     Phase 2  — P-Node verifies its Backend LLM (DONE in v7.0.0)      │
+│                                                                      │
+│  P-Node (-tee image, v7.0.0+) startup + every prompt:                │
+│    1. GET backend :29343/cpu → backend TDX quote (portal-verified)   │
+│    2. TLS pinning via reportData[0:32]                               │
+│    3. Artifact-registry lookup for MRTD + RTMR0-2                    │
+│    4. Replay RTMR3 from backend docker-compose.yaml (SHA-384 chain)  │
+│    5. GET backend :29343/gpu → CPU-GPU binding via reportData[32:64] │
+│    6. NVIDIA NRAS v4 attestation of GPU evidence                     │
+│    7. Fast-verify on every prompt; PinnedHTTPClient for inference    │
+│    8. State exposed at GET /v1/models/attestation                    │
+│  (attestation/backend_verifier.go, workload_verifier.go,             │
+│   nras_verifier.go, artifacts_registry.go; PR #699, #700, #708-#709) │
+└──────────────────────────────────────────────────────────────────────┘
 ```
+
+**Why v6+ consumers are forward-compatible with v7+ providers:** Phase 2 runs **entirely inside the P-Node** — the consumer never talks to the backend LLM and never sees the backend's attestation quote. The consumer trusts Phase 2 transitively because it has already attested (via Phase 1) that the P-Node is running the exact `-tee` binary that enforces Phase 2. No client-side upgrade is required to get Phase 2 guarantees.
 
 **How each artifact feeds the trust chain:**
 
@@ -255,28 +278,46 @@ This CI/CD hardening is the **foundation layer** for the full TEE attestation lo
 
 ## Current Status and Next Steps
 
-### Completed (Phase 1a + 1b)
+### Completed (Phase 1a + 1b — CI/CD)
 
 | Step | Description | Status |
 |---|---|---|
-| **Cosign signing + SBOM** | Keyless signing, digest capture, SPDX SBOM for TEE image | **Done** |
-| **TEE attestation manifest** | Signed JSON with digests, hashes, baked env, build provenance | **Done** |
-| **RTMR3 computation** | Computed in CI/CD from deployed compose + SecretVM rootfs; embedded in signed manifest | **Done** |
-| **Auto-deploy to SecretVM** | `Deploy-SecretVM-Test` job deploys digest-pinned compose to test VM via `secretvm-cli` | **Done** |
-| **Post-deploy verification** | Polls live VM attestation, extracts RTMR3 from raw TDX quote, compares against CI-computed value | **Done** |
+| **Cosign signing + SBOM** | Keyless signing, digest capture, SPDX SBOM for TEE image | **Done** (v6.0.0) |
+| **TEE attestation manifest** | Signed JSON with digests, hashes, baked env, build provenance | **Done** (v6.0.0) |
+| **RTMR3 computation** | Computed in CI/CD from deployed compose + SecretVM rootfs; embedded in signed manifest | **Done** (v6.0.0) |
+| **Auto-deploy to SecretVM** | `Deploy-SecretVM-Test` job deploys digest-pinned compose to test VM via `secretvm-cli` | **Done** (v6.0.0) |
+| **Post-deploy verification** | Polls live VM attestation, extracts RTMR3 from raw TDX quote, compares against CI-computed value | **Done** (v6.0.0) |
+| **ECS deploy timing hardening** | Retry + stabilization-timeout improvements so post-deploy healthchecks don't race ECS | **Done** (PR #694/#695, #701) |
 
-### Remaining (Developer Work — Proxy-Router Code)
-
-| Step | Description | Status |
-|---|---|---|
-| **`IsTEEModel()` helper** | Detect `"tee"` tag on blockchain-registered models | TODO |
-| **Consumer-side verification** | Fetch attestation from `:29343`, verify RTMR3 against signed manifest before opening session | TODO |
-| **Consumer UI TEE badge** | Visual indicator for TEE-verified models | TODO |
-
-### Lower Priority (CI/CD)
+### Completed (Phase 1c — Consumer verifies P-Node, v6.0.0 → v6.2.x)
 
 | Step | Description | Status |
 |---|---|---|
-| **Full RTMR0-2** | Integrate `reproduce-mr` for firmware/kernel layers (blocked on ACPI templates) | TODO |
-| **AMD SEV measurement** | Integrate `sev-snp-measure` for AMD platform | TODO |
-| **CVE scanning** | Trivy/Grype scan as advisory step, then gating | TODO |
+| **`IsTeeModel()` helper** | Detect `"tee"` tag on blockchain-registered models; drives both hops of the trust chain | **Done** — PR #708, #709 (consolidated as sole TEE switch) |
+| **Consumer-side verification** | Fetch attestation from `:29343`, verify quote via SecretAI portal, compare RTMR3 against signed manifest, pin TLS cert — all before opening session | **Done** (`attestation/verifier.go`) |
+| **Per-prompt fast-verify** | Re-fetch quote, compare hash + TLS fingerprint on every forwarded prompt | **Done** — PR #686, #689 |
+| **Consumer UI TEE badge** | Visual indicator for TEE-verified models + session status | **Done** |
+
+### Completed (Phase 2a — P-Node verifies its Backend LLM, v7.0.0)
+
+| Step | Description | Status |
+|---|---|---|
+| **`BackendVerifier.AttestBackend`** | Startup full attestation: portal-verified CPU quote, TLS binding, workload RTMR3 replay, CPU-GPU nonce binding, NRAS | **Done** — PR #699 |
+| **`FastVerifyBackend`** | Per-prompt hot-path re-check with hash + TLS fingerprint; no TTL | **Done** — PR #699 |
+| **`ArtifactRegistry`** | Auto-refreshed SecretVM TDX artifact CSV for MRTD + RTMR0-2 lookup | **Done** — PR #699 |
+| **`NrasVerifier`** | NVIDIA NRAS v4 API integration for GPU attestation | **Done** — PR #699 |
+| **`PinnedHTTPClient`** | Onward inference rejects any TLS cert whose SHA-256 differs from attested fingerprint | **Done** — PR #699 |
+| **`GET /v1/models/attestation`** | Per-model attestation state endpoint for monitoring and forensics | **Done** — PR #699 |
+| **New env vars** | `TEE_PORTAL_URL`, `TEE_IMAGE_REPO`, `ARTIFACT_REGISTRY_URL`, `ARTIFACT_REGISTRY_REFRESH_INTERVAL` | **Done** — PR #699 |
+
+### Remaining (Lower Priority / Future)
+
+| Area | Step | Status |
+|---|---|---|
+| CI/CD | Full RTMR0-2 *recomputation* in CI (today we verify RTMR0-2 by artifact-registry lookup, which is sufficient) | TODO — blocked on ACPI templates |
+| CI/CD | AMD SEV-SNP measurement via `sev-snp-measure` | TODO — TDX-only today |
+| CI/CD | CVE scanning (Trivy/Grype) — advisory then gating | TODO |
+| Proxy-router | Verifiable per-message signing using SecretVM TEE-bound key | Deferred to Phase 2b |
+| Proxy-router | Local in-process quote verification (remove `quote-parse` dependency on SCRT Labs) | Deferred to Phase 2b |
+| Proxy-router | Co-located proxy-router + LLM in a single TDX VM (collapses both hops into one RTMR3) | Deferred to Phase 2b |
+| Proxy-router | NRAS alternatives for non-NVIDIA GPU vendors | Deferred to Phase 2b |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
         shell: bash
         run: |
           IMAGE_NAME="ghcr.io/morpheusais/morpheus-lumerin-node"
-          VMAJ_NEW=6
+          VMAJ_NEW=7
           VMIN_NEW=0
           VPAT_NEW=0
           set +o pipefail

--- a/docs/02.3-proxy-router-tee.md
+++ b/docs/02.3-proxy-router-tee.md
@@ -367,20 +367,50 @@ The output should match `measurements.intel_tdx.rtmr3` from the attestation mani
 
 ## What This Guarantees (and What It Doesn't)
 
-**Guarantees:**
-* The proxy-router binary is the exact binary built by the official CI/CD from a known commit
-* Chat context storage is disabled and cannot be re-enabled
-* Logging is in production mode and cannot be increased to capture prompts
-* The blockchain configuration (contracts, chain ID, blockscout URL) is immutable — frozen at build time for the target network (mainnet or testnet)
-* The image has not been tampered with between build and deployment
+TEE trust is a **two-hop chain**, with each hop attested separately. The on-chain `tee` tag on a model triggers both hops:
 
-**CI/CD automated verification:**
+```
+C-Node (v6.0.0+) ─────Phase 1─────▶ P-Node -tee image (v7.0.0+) ─────Phase 2─────▶ Backend LLM (SecretVM)
+```
+
+* **Phase 1** is what the **consumer's proxy-router** runs against the provider's P-Node. It has shipped since v6.0.0.
+* **Phase 2** is what the **provider's P-Node** (v7.0.0+) runs against its own backend LLM. The consumer never sees Phase 2 directly — it sees Phase 2 *indirectly*, because the v7+ `-tee` image it just attested in Phase 1 is the code that enforces Phase 2.
+* A v6.0.0+ consumer paired with a v7.0.0+ provider gets the full chain transparently — **no consumer-side upgrade is needed** to benefit from Phase 2.
+
+### Phase 1 — Consumer attests the P-Node (v6.0.0+)
+
+When a v6.0.0+ C-Node opens a session (and on every subsequent prompt) for a `tee`-tagged model, the consumer's proxy-router proves the following about the provider's P-Node:
+
+* The proxy-router binary is the exact binary built by the official CI/CD from a known commit (verified via cosign signature on the `-tee` image).
+* Chat context storage is disabled and cannot be re-enabled (baked in at image build; enforced by RTMR3).
+* Logging is in production mode and cannot be increased to capture prompts (baked in; enforced by RTMR3).
+* The blockchain configuration (contracts, chain ID, blockscout URL) is immutable — frozen at build time for the target network (mainnet or testnet).
+* The image has not been tampered with between build and deployment (RTMR3 replay of the published deployed compose against the live TDX quote).
+* The TLS certificate terminating the connection is pinned into the quote's `reportData[0:32]`, so no TLS-terminating proxy or CDN can sit between the consumer and the P-Node.
+* The check runs at session open and is re-checked on every prompt via a ~50 ms fast path (quote hash + TLS fingerprint compare); full re-verification kicks in on drift.
+
+### Phase 2 — P-Node attests its own backend LLM (v7.0.0+)
+
+Phase 2 runs **entirely inside the provider's P-Node**. The consumer does not participate. For each `tee`-tagged model, your v7+ P-Node proves the following about the backend LLM it forwards inference to:
+
+* The backend's CPU TDX quote is independently verified at startup (full `AttestBackend`) and re-checked on **every inference prompt** via the fast path (`FastVerifyBackend` — see [tee-backend-verification.md](../proxy-router/docs/tee-backend-verification.md)). Any quote or TLS drift triggers full re-attestation or a hard fail.
+* The backend's TLS certificate fingerprint is pinned into the CPU quote's `reportData[0:32]`, and the P-Node's onward HTTP client rejects any certificate that doesn't match — no MITM can slip between the P-Node and the backend.
+* The backend's GPU attestation nonce is bound to the CPU quote via `reportData[32:64]`, and GPU evidence is independently verified by **NVIDIA NRAS** (Remote Attestation Service) for genuine hardware.
+* The backend's `docker-compose.yaml` is recovered from `:29343/docker-compose` and **RTMR3 is replayed** against the live TDX quote, proving the exact set of models loaded (e.g., `MODELS='deepseek-r1:70b ...'`) — swapping, adding, or removing any model changes the hash and fails verification.
+* MRTD + RTMR0-2 are looked up in the published SecretVM TDX artifact registry to confirm firmware, VM config, kernel, and initramfs all match a known SecretVM build.
+* Per-model attestation state is exposed on the P-Node's `GET /v1/models/attestation` endpoint for monitoring and forensics.
+
+If Phase 2 fails, the P-Node refuses the session open or the individual prompt locally. The consumer observes this as a standard provider-side failure and can fail over to another provider.
+
+### CI/CD automated verification
+
 * On every push to `test` (or `cicd/*` branches), the pipeline automatically deploys the new TEE image to a test SecretVM instance and verifies the live RTMR3 attestation matches the CI-computed value. This catches measurement mismatches before they reach providers.
 
-**Current limitations (to be addressed in future phases):**
-* The model backend (LLM) that the proxy-router connects to is not yet attested separately. In future versions, the proxy-router and LLM will run in the same TEE VM.
-* Manual verification is required today for end-users. Future C-Node releases will automate this for models tagged `tee` on the blockchain — the consumer node will verify the provider's attestation before opening a session.
-* RTMR0-2 (firmware, kernel, initramfs layers) and AMD SEV-SNP measurements are not yet computed in CI/CD. RTMR3 (the software layer — our image + compose) is computed and published in the attestation manifest.
+### Remaining gaps (future work)
+
+* AMD SEV-SNP measurements are not yet computed in CI/CD. Only Intel TDX RTMR3 is published in the P-Node attestation manifest today.
+* Phase 2 backend verification assumes the LLM runs inside a separate SecretVM with the SecretAI attestation endpoints exposed on port `29343`. A future variant will co-locate proxy-router and LLM in a single TDX VM so one RTMR3 covers both hops.
+* Backend GPU attestation currently targets NVIDIA NRAS v4 API. Other GPU vendors / alternative attestation services are not yet plumbed in.
 
 ---
 

--- a/docs/02.4-proxy-router-secretvm-quickstart.md
+++ b/docs/02.4-proxy-router-secretvm-quickstart.md
@@ -175,7 +175,7 @@ You should see:
 ```json
 {
   "status": "healthy",
-  "version": "v6.0.0",
+  "version": "v7.0.0",
   "uptime": "1m30s"
 }
 ```
@@ -241,16 +241,42 @@ cosign verify-attestation \
 
 ---
 
-## What Consumers See
+## What Consumers See, and What Your P-Node Does
 
-When a consumer's C-Node (v6.0.0+) opens a session with your TEE-tagged model, it automatically:
+TEE verification is a **two-hop trust chain**. The consumer only talks to your P-Node; your P-Node is what reaches out to the backend LLM. Each hop is attested independently, and the on-chain `tee` tag is what turns both hops on.
 
-1. **Fetches your attestation quote** from `:29343/cpu`
-2. **Verifies the quote** via the SecretAI Portal — confirms genuine TEE hardware
-3. **Checks TLS binding** — compares the SHA-256 fingerprint of your TLS certificate against the `reportdata` in the quote, proving the quote belongs to your server (not replayed from elsewhere)
-4. **Compares RTMR3** against the CI/CD-signed golden values — confirms you're running the exact official image
+```
+C-Node (v6.0.0+)    ─verifies──▶    P-Node (your -tee image, v7.0.0+)    ─verifies──▶    Backend LLM (SecretVM)
+                    Phase 1                                               Phase 2
+```
 
-If any check fails, the session is rejected and no prompts are sent. This all happens transparently — the consumer doesn't need to do anything manually.
+### Hop 1 — Consumer (v6.0.0+) verifies your P-Node (Phase 1)
+
+When a consumer's C-Node opens a session with your `tee`-tagged model, the consumer's proxy-router automatically performs these checks against **your P-Node** at session open and on every prompt:
+
+1. **Fetches your P-Node's attestation quote** from `:29343/cpu`
+2. **Verifies the quote** via the SecretAI Portal — confirms genuine Intel TDX hardware
+3. **Checks TLS binding** — compares the SHA-256 fingerprint of your P-Node's TLS certificate against `reportData[0:32]` in the quote, proving the quote belongs to your server (not replayed from elsewhere)
+4. **Compares RTMR3** against the CI/CD-signed golden values published in the `-tee` image's cosign attestation manifest — confirms you're running the exact official `-tee` image
+5. **Fast-path re-check on every prompt** — a ~50 ms hash + TLS-fingerprint compare against the cached snapshot; any drift triggers full re-verification
+
+If any check fails, the consumer refuses to open the session or forward the prompt. This is fully handled inside the consumer's proxy-router (v6.0.0+) — the end user doesn't do anything manually.
+
+> **Forward compatibility:** a v6.0.0+ C-Node only needs to understand Phase 1 — Phase 2 is entirely your P-Node's job. This means **any v6+ consumer works with any v7+ provider**, gaining the Phase 2 guarantees automatically through the trust chain without a client-side upgrade.
+
+### Hop 2 — Your P-Node (v7.0.0+) verifies its own backend LLM (Phase 2)
+
+At startup and on every inference prompt, **your P-Node** (not the consumer) performs these checks against the backend LLM referenced by each `tee`-tagged model's `apiUrl`:
+
+1. **Fetches the backend's CPU quote** from `<apiUrl-host>:29343/cpu` and verifies it via the SecretAI Portal
+2. **TLS pinning** — compares the backend's TLS cert fingerprint against `reportData[0:32]` of its quote, and refuses any onward inference connection whose certificate doesn't match (no MITM can slip between the P-Node and the backend)
+3. **Workload RTMR3 replay** — pulls the backend's `docker-compose.yaml` via `:29343/docker-compose`, recomputes the SHA-384 extend chain using the rootfs data from the SecretVM TDX artifact registry, and compares against the RTMR3 reported in the backend's TDX quote — proving the exact set of models loaded (e.g., `MODELS='deepseek-r1:70b ...'`)
+4. **GPU attestation + CPU-GPU binding** — fetches GPU evidence from `:29343/gpu`, verifies `reportData[32:64]` of the CPU quote equals the GPU nonce (so the GPU evidence can't be replayed from another box), and submits the GPU evidence to **NVIDIA NRAS** for independent hardware validation
+5. **Per-prompt fast verify** — before every forwarded prompt, re-fetches `:29343/cpu` and compares the quote hash + TLS fingerprint against the cached snapshot; any change triggers full re-attestation, any TLS-cert change is a hard fail
+
+Results are also exposed on your P-Node's health endpoint at `GET /v1/models/attestation`, which reports per-model attestation state (`verified` / `pending` / `failed`), last-success timestamp, and workload verification result. This is useful both for your own monitoring and for any operator who wants to sanity-check the live state. Full developer reference: [proxy-router/docs/tee-backend-verification.md](../proxy-router/docs/tee-backend-verification.md).
+
+If Phase 2 fails for a `tee`-tagged model, your P-Node will not forward inference to that backend — the session open (or individual prompt) is refused locally. The consumer sees this as a normal provider-side failure.
 
 ---
 
@@ -262,7 +288,8 @@ If any check fails, the session is rejected and no prompts are sent. This all ha
 | Attestation quote empty | Port 29343 not exposed | SecretVM exposes this automatically — check your VM status |
 | RTMR3 mismatch | Wrong compose content or rootfs version | Ensure you're using the exact deployed compose from CI/CD artifacts (byte-for-byte) |
 | TLS binding fails | Using a proxy/CDN that terminates TLS | The consumer must connect directly to the SecretVM — no TLS-terminating intermediaries on port 29343 |
-| `tee` model not getting sessions | Consumers on older versions | Consumers need v6.0.0+ to be TEE-aware |
+| `tee` model not getting sessions | Consumers on older (pre-TEE) versions | Consumers need v6.0.0+ to perform Phase 1 (P-Node) attestation. v6+ consumers transparently gain Phase 2 guarantees by trusting a v7+ provider — no client-side upgrade is needed for Phase 2. |
+| Phase 2 failing silently on the consumer | Consumer isn't meant to run Phase 2 | Phase 2 (backend LLM attestation) is done **inside your P-Node**, not the consumer. Check your P-Node's `GET /v1/models/attestation` endpoint for per-model status. |
 
 ---
 

--- a/docs/03-provider-offer.md
+++ b/docs/03-provider-offer.md
@@ -47,7 +47,12 @@
         1. addStake: "modelMinStake": `100000000000000000`, (0.1 MOR) 
         1. Owner: Provider Wallet Address 
         1. name: Human Readable model like "Llama 2.0" or "Mistral 2.5" or "Collective Cognition 1.1" 
-        1. tags: array of tag strings for the model 
+        1. tags: array of tag strings for the model
+            - **TEE providers:** include the tag `"tee"` (case-insensitive) to opt this model into the full two-hop TEE trust chain. The tag turns on two independent verifications, one at each hop:
+                - **Phase 1 (consumer → your P-Node):** any v6.0.0+ consumer proxy-router will automatically verify your P-Node's TDX attestation (CPU quote, TLS cert pinning, RTMR3 of the `-tee` image) at session open and on every prompt before forwarding any inference.
+                - **Phase 2 (your P-Node → your backend LLM):** your v7.0.0+ P-Node will itself verify the backend LLM pointed to by the model's `apiUrl` — CPU TDX quote, TLS pinning, RTMR3 replay of the backend's `docker-compose.yaml`, CPU-GPU nonce binding, and NVIDIA NRAS GPU attestation — at startup and on every prompt. A v6+ consumer benefits from Phase 2 automatically by trusting your attested v7+ P-Node; the consumer itself does not talk to the backend.
+            - Models without the `tee` tag are treated as standard (non-TEE) providers — neither hop of the chain runs. See [02.3-proxy-router-tee.md](02.3-proxy-router-tee.md) and [02.4-proxy-router-secretvm-quickstart.md](02.4-proxy-router-secretvm-quickstart.md) for the full story.
+            - Other common tags include model-type hints: `llm`, `embedding`, `stt`, `tts`.
         1. Capture the `modelID` from the JSON response 
             **NOTE** The returned `modelID` is a combination of your requested modelID and your providerID and will be required to update your models-config.json file AND when offering bids
 

--- a/docs/models-config.json.md
+++ b/docs/models-config.json.md
@@ -9,6 +9,8 @@
 - `capacityPolicy` (optional) can be one of the following: "idle_timeout", "simple"
 - There maybe other variables that should be included in the model configuration. Please refer to the json-schema for descriptions and list of required and optional fields.
 
+> **TEE models:** there is **no `isTee` field in this file**. TEE verification is enabled per-model on the blockchain by adding the `"tee"` tag when the model is registered in the Diamond contract. Any v7+ proxy-router will automatically derive the backend attestation endpoints from the model's `apiUrl` host (port `29343`) and perform full Phase 1 + Phase 2 attestation whenever a `tee`-tagged model is used. See [03-provider-offer.md](03-provider-offer.md) for how to set the tag and [02.3-proxy-router-tee.md](02.3-proxy-router-tee.md) / [proxy-router/docs/tee-backend-verification.md](../proxy-router/docs/tee-backend-verification.md) for the full verification flow.
+
 ## Examples of models-config.json entries
 
 This file enables the morpheus-proxy-router to route requests to the correct model API. The model API can be hosted on the same server as the morpheus-proxy-router or on an external server. Please refer to the json-schema for descriptions and list of required and optional fields.

--- a/docs/proxy-router.all.env
+++ b/docs/proxy-router.all.env
@@ -103,3 +103,23 @@ SYS_TCP_MAX_SYN_BACKLOG=100000
 WEB_ADDRESS=0.0.0.0:8082
 # Public URL of the proxyrouter (falls back to http://Localhost:WEB_ADDRESS if not set)
 WEB_PUBLIC_URL=http://localhost:8082
+
+# TEE (Trusted Execution Environment) Configurations
+# These drive Phase 1 (P-node) and Phase 2 (backend LLM) attestation for any
+# model registered on-chain with the "tee" tag. See docs/02.3-proxy-router-tee.md
+# and proxy-router/docs/tee-backend-verification.md for full details.
+#
+# SecretAI Portal URL used to cryptographically verify raw TDX CPU quotes.
+# Required when any model in the market is "tee"-tagged; otherwise optional.
+TEE_PORTAL_URL=https://secretai.scrtlabs.com/api
+# GHCR image repo used by consumer-side P-node attestation to fetch the signed
+# golden attestation manifest (RTMR3 golden values, baked_env, etc.) via cosign.
+# Defaults to the mainnet TEE image repo; use the same repo for testnet (the
+# tag suffix distinguishes networks).
+TEE_IMAGE_REPO=ghcr.io/morpheusais/morpheus-lumerin-node-tee
+# URL for the SecretVM TDX artifact registry CSV used to look up MRTD + RTMR0-2
+# during backend workload verification. Defaults to the official SCRT Labs
+# registry and can be left blank to use the built-in default.
+ARTIFACT_REGISTRY_URL=https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/tdx.csv
+# How often the proxy-router re-downloads the artifact registry (default 1h).
+ARTIFACT_REGISTRY_REFRESH_INTERVAL=1h

--- a/proxy-router/docs/tee-backend-verification.md
+++ b/proxy-router/docs/tee-backend-verification.md
@@ -1,13 +1,28 @@
-# TEE Backend Verification
+# TEE Backend Verification (Phase 2)
+
+## Where this fits in the trust chain
+
+Morpheus TEE trust is a **two-hop chain**:
+
+```
+C-Node (v6.0.0+) ──── Phase 1 ────▶ P-Node -tee image (v7.0.0+) ──── Phase 2 ────▶ Backend LLM (SecretVM)
+                      (consumer                                      (this document)
+                       verifies                                       P-Node verifies
+                       P-Node)                                        its own backend
+```
+
+This document describes **Phase 2 only** — the verification performed **by the P-Node** (the provider's proxy-router running inside its own TEE) **against its backend LLM**. Phase 1 (consumer verifying the P-Node) is documented in [`docs/02.3-proxy-router-tee.md`](../../docs/02.3-proxy-router-tee.md).
+
+Phase 2 is entirely self-contained inside the P-Node: the consumer never talks to the backend LLM directly and never sees the backend's attestation quote. The consumer trusts Phase 2 transitively, because it has already attested (in Phase 1) that the P-Node is running the exact `-tee` binary that implements Phase 2 faithfully. This is why **a v6.0.0+ consumer paired with a v7.0.0+ provider gains all Phase 2 guarantees without any client-side change**.
 
 ## Overview
 
-The TEE (Trusted Execution Environment) Backend Verification system provides cryptographic proof that AI inference requests are processed inside authentic, unmodified SecretVM instances running on genuine Intel TDX and NVIDIA GPU hardware. It operates in two modes:
+The Phase 2 Backend Verification system provides cryptographic proof that AI inference requests forwarded by this P-Node are processed inside authentic, unmodified SecretVM instances running on genuine Intel TDX and NVIDIA GPU hardware. It operates in two modes:
 
 - **Full attestation** (`AttestBackend`) runs at startup and whenever the fast verify detects a backend change. It performs end-to-end cryptographic verification of the backend's CPU TEE quote, GPU attestation evidence, workload integrity, and TLS binding.
 - **Fast verification** (`FastVerifyBackend`) runs on every inference prompt. It always re-fetches the CPU quote and compares its hash and TLS fingerprint against the cached attestation snapshot. If the quote changes, it triggers full re-attestation. There is no TTL -- the fast check runs on every request unconditionally.
 
-Together, these ensure that every inference request reaches a verified, tamper-proof backend -- from the hardware root of trust down to the specific AI models loaded inside the TEE.
+Together, these ensure that every inference request forwarded by this P-Node reaches a verified, tamper-proof backend -- from the hardware root of trust down to the specific AI models loaded inside the TEE.
 
 ## Security Guarantees
 
@@ -195,31 +210,44 @@ This provides a cryptographic guarantee that the backend is running exactly the 
 
 ## Configuration Reference
 
-### Model Configuration (`models-config.json`)
+### Model Tagging (on-chain)
 
-Each model entry supports the following TEE-related field:
+TEE verification is enabled **per-model on the blockchain**, not in the local `models-config.json`. When a model is registered in the Diamond contract with the `tee` tag (case-insensitive) in its `tags` array, the proxy-router automatically:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `isTee` | `boolean` | When `true`, enables TEE verification for this model. The attestation URL is always derived from the `apiUrl` host with port `29343`. |
+- On the **provider** side: performs full `AttestBackend` against that model's `apiUrl` host at startup, and runs `FastVerifyBackend` on every inference prompt (see [Per-Prompt Fast Verify](#per-prompt-fast-verify)).
+- On the **consumer** side: runs `VerifyProviderQuick` against the provider's P-node at session open and on every prompt, refusing to forward inference if attestation fails.
 
-Example:
+Tag detection is implemented in `internal/blockchainapi/model_tags.go`:
 
-```json
-{
-  "modelName": "deepseek-r1:70b",
-  "apiUrl": "https://backend.example.com:8080/v1",
-  "isTee": true
+```go
+func IsTeeModel(tags []string) bool {
+    for _, raw := range tags {
+        if strings.ToLower(raw) == "tee" {
+            return true
+        }
+    }
+    return false
 }
 ```
 
-With `apiUrl` set to `https://backend.example.com:8080/v1`, the attestation endpoints are automatically resolved to `https://backend.example.com:29343/cpu`, `https://backend.example.com:29343/gpu`, and `https://backend.example.com:29343/docker-compose`.
+No `isTee` field is required (or accepted) in `models-config.json` — the `models-config-schema.json` does not declare one. The only model-config values that matter for TEE are `modelId` (which the proxy-router uses to look up the on-chain tags) and `apiUrl` (the backend LLM endpoint).
+
+### Backend Attestation Endpoint Derivation
+
+Attestation endpoints are derived from the model's `apiUrl` host with port `29343` (the standard SecretVM attestation port).
+
+Example: a model registered on-chain with the `tee` tag and `apiUrl` set to `https://backend.example.com:8080/v1` will be attested against:
+
+- `https://backend.example.com:29343/cpu` — TDX CPU quote
+- `https://backend.example.com:29343/gpu` — GPU attestation evidence
+- `https://backend.example.com:29343/docker-compose` — backend's compose file for RTMR3 replay
 
 ### Environment Variables
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `TEE_PORTAL_URL` | Yes (for TEE models) | -- | SecretAI Portal API URL for CPU quote verification |
+| `TEE_PORTAL_URL` | Yes (for `tee`-tagged models) | -- | SecretAI Portal API URL for CPU quote verification |
+| `TEE_IMAGE_REPO` | No | -- | GHCR image repo for cosign attestation manifest verification (e.g. `ghcr.io/morpheusais/morpheus-lumerin-node-tee`). Used by consumer-side P-node attestation to fetch the signed golden RTMR3 values for the provider image |
 | `ARTIFACT_REGISTRY_URL` | No | [default registry](https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/tdx.csv) | URL to the TDX artifact registry CSV file. The default points to the official SecretVM artifact registry maintained by SCRT Labs |
 | `ARTIFACT_REGISTRY_REFRESH_INTERVAL` | No | `1h` | How often to re-download the artifact registry |
 

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,13 @@
 ![Simple-Overview](docs/images/simple.png)
 The purpose of this software is to enable interaction with distributed, decentralized LLMs on the Morpheus network through a desktop chat experience.
 
+> **v7.0.0 — Full TEE capability.** The v7 release completes a two-hop Trusted Execution Environment (TEE) trust chain for any model registered on-chain with the `tee` tag:
+>
+> - **Phase 1** — *consumer → P-Node.* A consumer proxy-router (v6.0.0+) cryptographically verifies the provider's P-Node runs the exact official hardened `-tee` image inside a genuine Intel TDX SecretVM, with TLS pinning, at session open and on every prompt.
+> - **Phase 2 (new in v7)** — *P-Node → backend LLM.* The v7+ P-Node itself verifies the backend LLM it forwards inference to (CPU TDX quote, TLS pinning, workload RTMR3 replay of the backend's `docker-compose.yaml`, CPU-GPU nonce binding, and NVIDIA NRAS GPU attestation) at startup and on every prompt.
+>
+> Because Phase 2 runs inside the attested P-Node, **any v6+ consumer is forward-compatible with a v7+ provider** and gains the Phase 2 guarantees automatically — no client-side upgrade required. See [02.3-proxy-router-tee.md](docs/02.3-proxy-router-tee.md), [02.4-proxy-router-secretvm-quickstart.md](docs/02.4-proxy-router-secretvm-quickstart.md), and the developer reference at [proxy-router/docs/tee-backend-verification.md](proxy-router/docs/tee-backend-verification.md).
+
 0. PreRequisites: BASE Layer 2 Blockchain, MOR and ETH on BASE for staking and bidding
 1. Existing, Hosted AI model that is available for inference via the Morpheus network
 2. The proxy-router talks to and listens to the blockchain, routes prompts and inference between the providers’ models and the consumers that purchase and use the models
@@ -47,3 +54,9 @@ manages secure sessions between consumers and providers and routes prompts and r
 
 * [02-Provider-Setup](docs/02-provider-setup.md) - This is the simplest way to get started with the Morpheus Lumerin Node as a Provider.  This will allow you to connect your existing AI-Model to the Morpheus network and offer it for use by consumers.
     * [02.1-Proxy-Router-Docker](docs/02.1-proxy-router-docker.md) - Fast start using existing Docker image and proxy-router configuration
+    * [02.2-Proxy-Router-Akash](docs/02.2-proxy-router-akash.md) - Run the proxy-router on the Akash decentralized cloud
+    * [02.3-Proxy-Router-TEE](docs/02.3-proxy-router-tee.md) - Full TEE (Trusted Execution Environment) reference: build-time baked-in config, RTMR3 attestation, cosign image/manifest verification, and consumer-side verification steps
+    * [02.4-Proxy-Router-SecretVM-Quickstart](docs/02.4-proxy-router-secretvm-quickstart.md) - Shortest path to a v7 TEE provider: deploy the hardened `-tee` image on SecretVM and register a `tee`-tagged model
+    * [02.5-API-Auth](docs/02.5-api-auth.md) - API authentication (cookie/proxy.conf) required since v2.0.0
+
+* [03-Provider-Offer](docs/03-provider-offer.md) - Register your provider, model (optionally with the `tee` tag), and bid on-chain.

--- a/smart-contracts/deploy/data/config_base_mainnet.json
+++ b/smart-contracts/deploy/data/config_base_mainnet.json
@@ -1,6 +1,6 @@
 {
   "MOR": "0x7431ada8a591c955a994a21710752ef9b882b8e3",
-  "fundingAccount": "0x1FE04BC15Cf2c5A2d41a0b3a96725596676eBa1E",
+  "fundingAccount": "0x5160C0311A95E0A1072FA85Df23712A7BA1cD4b1",
   "providerMinStake": "100000000000000000",
   "modelMinStake": "100000000000000000",
   "marketplaceBidFee": "100000000000000000",


### PR DESCRIPTION
## Summary

This PR brings three things into `dev` to complete the **v7.0.0 (full TEE) release** prep:

1. **CI/CD fix (#701 equivalent)** — Fix for ECS deploy wait timing that was premature-failing the post-deploy healthcheck (`8b341f3`). `#701` on `dev` is the squashed version; this branch adds nothing new there.
2. **v7.0.0 version bump + funding-account update** (`71fff3d`) — Bumps `VMAJ_NEW` to `7` in `.github/workflows/build.yml` and updates the funding account in `smart-contracts/deploy/data/config_base_mainnet.json`. This is the major-version bump that marks "full TEE capability".
3. **Docs update for v7.0.0** (`fec3f92`) — Comprehensive documentation pass to accurately reflect the shipped Phase 1 + Phase 2 TEE trust chain.

## Doc changes (v7.0.0)

Consistently clarifies the **two-hop trust chain** across all public and internal docs:

```
C-Node (v6.0.0+)  ──Phase 1──▶  P-Node -tee image (v7.0.0+)  ──Phase 2──▶  Backend LLM
                  consumer                                     P-Node
                  verifies                                     verifies its
                  P-Node                                       own backend
```

**Key correctness fix:** earlier drafts described the consumer as performing Phase 2 backend verification. This is wrong — **Phase 2 runs entirely inside the P-Node**; the consumer never talks to the backend. This means **v6.0.0+ consumers are forward-compatible with v7.0.0+ providers** and get Phase 2 guarantees transparently, with no client-side upgrade needed. Every doc now emphasizes this.

### User-facing docs updated
- `readme.md` — v7.0.0 release callout with the two-hop flow and forward-compat note
- `docs/02.3-proxy-router-tee.md` — rewrote "What This Guarantees (and What It Doesn't)" with explicit Phase 1 / Phase 2 / remaining-gaps sections
- `docs/02.4-proxy-router-secretvm-quickstart.md` — rewrote "What Consumers See, and What Your P-Node Does" as two distinct hops + v7 troubleshooting rows
- `docs/03-provider-offer.md` — clarified the `tee` on-chain tag drives both hops
- `docs/models-config.json.md` — noted that `isTee` is no longer a local config field (tag-driven)
- `docs/proxy-router.all.env` — documented new TEE env vars: `TEE_PORTAL_URL`, `TEE_IMAGE_REPO`, `ARTIFACT_REGISTRY_URL`, `ARTIFACT_REGISTRY_REFRESH_INTERVAL`

### Developer reference updated
- `proxy-router/docs/tee-backend-verification.md` — added "Where this fits in the trust chain" section clarifying this doc is **Phase 2 only**, entirely inside the P-Node

### Internal `.ai-docs` updated (technical record of "how")
- `.ai-docs/TEE_Attestation_Architecture.md` — status bumped to v2.0, Phase 1/1c/2a marked DONE with real file paths and PR numbers, new §7.7 with the full Phase 2 technical write-up (attestation endpoints, full AttestBackend sequence, fast-verify semantics, reportData layout), open questions resolved
- `.ai-docs/TEE_CICD_Supply_Chain_Hardening.md` — added v7.0.0 banner, replaced placeholder diagram with two completed diagrams for Phase 1c and Phase 2, reorganized status tables

## Test plan

- [x] Clean `ort`-strategy merge from `origin/dev` into this branch (no conflicts, 11-file delta)
- [x] `GOOS=linux GOARCH=amd64 go build -ldflags='-w' -o /tmp/proxy-router-linux ./cmd/` succeeds (67 MB binary, exit 0)
- [x] No new `go vet` warnings introduced by the merge (all warnings are pre-existing on `dev`)
- [x] `grep` verification: no stale `isTee` references, no "consumer verifies backend" misstatements, no `v6.0.0+` references where `v7.0.0+` is meant
- [ ] CI/CD pipeline runs green (ECS deploy + post-deploy RTMR3 verification)
- [ ] Reviewer spot-check of the new `.ai-docs/TEE_Attestation_Architecture.md` §7.7 against the actual `proxy-router/internal/attestation/` code

## Release notes

This is the v7.0.0 release bump. Downstream merges:
1. This PR: `fix/cicd-ecs-deploy-wait-timing` → `dev`
2. Follow-up: `dev` → `test` (separate PR, opens immediately after this merges)
3. After test validation: `test` → `main` for the v7.0.0 tag

Made with [Cursor](https://cursor.com)