### PR TITLE
Release v7.0.0: Full TEE Capability — Phase 2 Backend LLM Attestation

### DIFF
--- a/.ai-docs/TEE_Attestation_Architecture.md
+++ b/.ai-docs/TEE_Attestation_Architecture.md
@@ -1,7 +1,16 @@
 # TEE Attestation Architecture — Verifiable Provider Compute
 
-**Status:** v1.0 — Full automated loop: build → sign → deploy → verify attestation  
-**Last updated:** 2026-03-11
+**Status:** v2.0 — Full two-hop trust chain shipped. Phase 1 (consumer → P-Node) in v6.0.0+; Phase 2 (P-Node → backend LLM) in v7.0.0+.
+**Last updated:** 2026-04-22
+
+> **Shipping summary (as of v7.0.0):**
+> - **Phase 1a (CI/CD supply-chain hardening)** — DONE (v6.0.0)
+> - **Phase 1b (RTMR3 computation + automated deployment + post-deploy attestation)** — DONE (v6.0.0)
+> - **Phase 1c (proxy-router code: consumer verifies P-Node)** — DONE (v6.0.0, refined through v6.2.x)
+> - **Phase 2a (P-Node verifies backend LLM: CPU quote, TLS pinning, RTMR3 replay, CPU-GPU binding, NRAS)** — DONE (v7.0.0, PR #699 and follow-ups #700, #703/#704, #705, #708/#709)
+> - **Phase 2b (verifiable per-message signing, local quote verification, co-located CPU+GPU TDX VM)** — still future work
+>
+> The `tee` on-chain model tag is the single switch that turns on **both** hops: consumer-side P-Node verification (Phase 1) and P-Node-side backend verification (Phase 2). A v6.0.0+ consumer paired with a v7.0.0+ provider gets the full chain transparently with no client-side upgrade.
 
 ---
 
@@ -16,25 +25,52 @@ A consumer node should be able to **cryptographically verify**, before sending a
 
 ---
 
-## 2. Scope — What We're Doing Now (Phase 1)
+## 2. Scope — What Shipped
 
-**In scope (CI/CD supply-chain hardening — our work):**
-- Cosign keyless image signing (both standard and TEE images)
-- Image digest capture and export
-- SBOM generation and attachment (syft)
-- Signed TEE attestation manifest (Option 5B — stored in GHCR as OCI artifact)
-- Support both Intel TDX and AMD SEV-SNP from day one
+### Phase 1 — DONE (v6.0.0)
 
-**In scope (proxy-router code — developer work, later):**
-- `IsTEEModel()` helper for on-chain tag detection
-- Consumer-side attestation verification before session creation (fetches quote from SecretVM host endpoint at `:29343`)
-- Consumer UI: TEE badge and verification status
+**CI/CD supply-chain hardening:**
+- Cosign keyless image signing (both standard and TEE images) — **DONE**
+- Image digest capture and export — **DONE**
+- SBOM generation and attachment (syft) — **DONE**
+- Signed TEE attestation manifest (Option 5B — stored in GHCR as OCI artifact) — **DONE**
+- Intel TDX RTMR3 computed in CI and published in the signed manifest — **DONE**
+- Auto-deploy to SecretVM test instance + post-deploy RTMR3 verification gate — **DONE**
+- AMD SEV-SNP measurement path — still TODO (blocked on upstream tooling)
 
-**Out of scope for Phase 1:**
-- On-chain oracle / DAO governance for measurements
-- Model backend (LLM) attestation (accepted gap — later phases co-locate proxy + LLM in same TEE)
+**Proxy-router code (consumer verifies P-Node):**
+- `IsTeeModel()` helper for on-chain tag detection — **DONE** (`blockchainapi/model_tags.go`)
+- Consumer-side attestation verification before session creation (fetches quote from SecretVM host endpoint at `:29343`, verifies via SecretAI portal, compares to manifest) — **DONE** (`attestation/verifier.go`, called from `blockchainapi/service.go` and `proxyapi/proxy_sender.go`)
+- Per-prompt `VerifyProviderQuick` fast-path re-check — **DONE** (hash + TLS fingerprint compare)
+- Consumer UI: TEE badge and verification status — **DONE**
+
+### Phase 2 — DONE (v7.0.0, PR #699 + #700)
+
+**P-Node verifies its own backend LLM** (the gap previously "accepted" for Phase 1 is now closed without co-locating):
+
+- `BackendVerifier.AttestBackend` at startup — **DONE**
+  - Fetch backend CPU quote from `:29343/cpu`; verify via SecretAI portal
+  - TLS binding: compare TLS cert SHA-256 with CPU quote `reportData[0:32]`
+  - Workload verification: parse TDX quote, look up MRTD + RTMR0-2 in the published SecretVM TDX artifact registry CSV, replay RTMR3 using SHA-384 extend chain over `SHA-256(docker-compose)` + rootfs data
+  - GPU attestation: fetch from `:29343/gpu`, verify CPU-GPU binding via `reportData[32:64] == GPU nonce`
+  - NVIDIA NRAS v4 API: submit GPU evidence for independent hardware validation (non-fatal if unreachable)
+- `BackendVerifier.FastVerifyBackend` on every prompt — **DONE**
+  - Always re-fetches CPU quote (~50 ms), compares hash + TLS fingerprint against cached snapshot
+  - Mismatch on hash → trigger full re-attestation
+  - Mismatch on TLS fingerprint → immediate hard fail (MITM signal)
+- Pinned-cert HTTP client for onward inference traffic (`PinnedHTTPClient`) — **DONE**
+  - Custom `VerifyPeerCertificate` refuses any TLS cert whose SHA-256 doesn't match the attested fingerprint
+- Artifact registry auto-refresh (`ArtifactRegistry`) — **DONE** (configurable via `ARTIFACT_REGISTRY_URL`, `ARTIFACT_REGISTRY_REFRESH_INTERVAL`)
+- Health endpoint `GET /v1/models/attestation` — **DONE**
+
+### Still out of scope (future)
+
+- On-chain oracle / DAO governance for golden-measurement updates (cosign keyless via GHA OIDC remains the signer)
+- Verifiable per-message signing using a TEE-bound key (§7.6) — slipped to Phase 2b
+- Local quote verification in Go (today we still call SCRT Labs `quote-parse`)
+- Co-located proxy-router + LLM in a single TDX VM (would collapse both hops into one RTMR3)
 - Rating system integration
-- CVE scanning gate (later)
+- CVE scanning gate
 
 ### Design Decisions (from review)
 
@@ -43,7 +79,7 @@ A consumer node should be able to **cryptographically verify**, before sending a
 | 1 | Oracle governance | **Automated by CI/CD** — cosign keyless signing via GitHub Actions OIDC. No multi-sig/DAO for now. |
 | 2 | SCRT Labs coupling | **Yes, couple** — use their quote-parse API and `reproduce-mr` tool. They control the VM layer; we need their artifacts. See §3. |
 | 3 | AMD SEV support | **Both platforms from day one** if feasible; if `reproduce-mr` only handles TDX, compute what we can and extend for SEV in a fast follow. |
-| 4 | Model backend trust | **Gap accepted for Phase 1.** Later phases co-locate proxy-router + LLM on the same TEE VM (CPU for proxy, GPU for inference), making RTMR3 cover both. |
+| 4 | Model backend trust | **Closed in Phase 2 (v7.0.0).** Instead of co-locating, the P-Node actively verifies the backend LLM over the network: CPU quote + TLS pinning + RTMR3 replay of the backend's `docker-compose.yaml` + CPU-GPU nonce binding + NVIDIA NRAS. See §7.7. Co-location (single TDX VM for proxy-router + LLM) remains a future simplification that would collapse both hops into one measurement chain. |
 | 5 | RTMR computation in CI/CD | **Attempt to integrate** `reproduce-mr` using SCRT Labs release artifacts from GitHub. If not available in CI, publish all inputs so it can be run independently. |
 | 6 | Attestation freshness | **Version-based, not clock-based.** Support current version and N-2 prior versions. When a new version publishes, the oldest attestation manifest becomes stale. This is a release-cadence policy. |
 | 7 | Consumer opt-out | **No opt-out.** If a consumer selects a TEE-tagged model, verification is mandatory. Failure = hard error, no prompt sent. |
@@ -491,15 +527,15 @@ The `secretvm-cli vm attestation <uuid>` command also returns the same data (use
 
 The attestation endpoint at `:29343` is served by the TEE host, not the proxy-router container. Even a compromised application cannot fake or suppress it — strong separation of concerns.
 
-### 7.3 `IsTEEModel()` helper and model tag convention
+### 7.3 `IsTeeModel()` helper and model tag convention — DONE
 
 **File:** `proxy-router/internal/blockchainapi/model_tags.go`
 
-**What:** Add a helper function to detect TEE models from their on-chain tags. The `ModelRegistry` contract already has `string[] tags` — providers registering TEE models add `"tee"` as a tag.
+**What shipped:** Helper function that detects the `tee` tag on an on-chain model's `tags` array. The `ModelRegistry` contract already has `string[] tags` — providers registering TEE models add `"tee"` as a tag. This single tag drives **both** hops of the trust chain: the consumer uses it to decide whether to verify the P-Node (Phase 1), and the P-Node uses it to decide whether to verify its own backend on every prompt (Phase 2).
 
-**Implementation:**
+**Implementation (current):**
 ```go
-func IsTEEModel(tags []string) bool {
+func IsTeeModel(tags []string) bool {
     for _, raw := range tags {
         if strings.ToLower(raw) == "tee" {
             return true
@@ -509,68 +545,166 @@ func IsTEEModel(tags []string) bool {
 }
 ```
 
-**Convention:** The canonical tag string is `"tee"` (lowercase). Document this for providers in the model registration guide.
+**Convention:** The canonical tag string is `"tee"` (matched case-insensitively). The v7 "tee tag for everything" refactor (PR #708, #709) removed the local `isTee` field from `models-config.json` entirely — the on-chain tag is now the sole source of truth.
 
-**Effort:** S
+**Effort:** S — **DONE**
 
-### 7.4 Consumer-side attestation verification in session flow
+### 7.4 Consumer-side attestation verification in session flow — DONE (v6.0.0, refined v6.2.x)
 
-**File:** `proxy-router/internal/blockchainapi/service.go` (`OpenSessionByModelId`, `tryOpenSession`)
+**Files:**
+- `proxy-router/internal/attestation/verifier.go` — core `Verifier`, `VerifyProvider` (full), `VerifyProviderQuick` (fast path)
+- `proxy-router/internal/blockchainapi/service.go` — calls `VerifyProvider` from `tryOpenSession` when `IsTeeSession` is true
+- `proxy-router/internal/proxyapi/proxy_sender.go` — calls `verifyTEEAttestation` (→ `VerifyProviderQuick`) before every `SendPrompt`, `SendTranscription`, `SendSpeech`, and session-init handshake
 
-**What:** Before creating a session with a TEE-tagged model, verify the provider's image and hardware attestation. This is the core of the trust loop.
+**What shipped:** When the consumer's C-Node picks a bid whose model carries the `tee` tag, it verifies the provider's P-Node attestation before opening the session and re-verifies on every prompt. Failure means fail-over to the next bid at session open, or a hard prompt-level error once a session is live.
 
-**Flow (inserted into the existing bid-ranking loop in `tryOpenSession`):**
+**Actual flow in `tryOpenSession` (v6+):**
 ```
-if IsTEEModel(model.Tags):
-    1. cosign.VerifyImageAttestations() → fetch signed manifest from GHCR
-       - Verify signature chain (OIDC issuer = GitHub Actions)
-       - Extract predicate: compose_sha256, baked_env, measurements
-    2. Confirm baked_env.PROXY_STORE_CHAT_CONTEXT == "false"
-    3. Confirm baked_env.ENVIRONMENT == "production"
-    4. GET provider attestation endpoint (https://{vm-domain}:29343/cpu.html)
-       → get raw TDX quote hex
-    5. Extract RTMR3 from TDX quote at byte offset 520 (48 bytes)
-       (same extraction logic used in CI/CD verification step)
-    6. Compare RTMR3 against expected value from signed manifest
-    7. Optionally: verify reportdata contains TLS certificate fingerprint (anti-MITM)
-    8. If all pass → proceed with InitiateSession
-    9. If any fail → log reason, skip this provider, try next bid
-   10. If all providers fail → hard error to user: "No verified TEE providers available"
+if IsTeeSession && attestationVerifier != nil:
+    1. Derive attestation VM domain from provider's Url
+    2. Verifier.VerifyProvider(vmDomain, providerAddr):
+       a. Fetch cosign-signed attestation manifest from GHCR for the `-tee` image
+          (cosign Go library, GitHub-Actions OIDC identity pattern,
+           type https://morpheusais.github.io/tee-attestation/v1)
+       b. Extract expected RTMR3 + baked_env from manifest predicate
+       c. Confirm baked_env.PROXY_STORE_CHAT_CONTEXT == "false",
+          ENVIRONMENT == "production", correct ETH_NODE_CHAIN_ID for network
+       d. GET https://{vm-domain}:29343/cpu → raw TDX quote hex
+       e. POST quote to TEE_PORTAL_URL (SecretAI quote-parse) — confirms genuine TDX
+       f. Extract RTMR3 from quote at byte offset 520 (48 bytes), compare to manifest
+       g. Extract reportData[0:32], compare to SHA-256 of the connection's
+          peer TLS certificate — anti-MITM
+       h. Cache snapshot (quote hash, TLS fingerprint, expiry-free)
+    3. If pass → InitiateSession / continue
+       If fail → skip this provider, try next bid; all fail → hard error
 ```
 
-**Note:** The attestation endpoint is provided by the SecretVM host (port 29343), not the proxy-router container. The consumer needs to derive the VM domain from the provider's public URL to reach it.
+**Per-prompt fast path (`VerifyProviderQuick`, called from `proxy_sender.go` before every forwarded prompt):**
+```
+1. Look up cached snapshot for providerAddr; no cache → re-run full VerifyProvider
+2. Re-fetch :29343/cpu, compute SHA-256 of the quote
+3. If quote hash == cached hash AND TLS fingerprint == cached fingerprint → pass
+4. If quote hash changed → trigger full re-attestation
+5. If TLS fingerprint changed → hard fail (MITM signal), refuse to forward
+```
 
-**Dependencies:**
-- `github.com/sigstore/cosign/v2/pkg/cosign` Go library for programmatic verification
-- Need to confirm compatibility with Go 1.23.x and impact on binary size (`FROM scratch` image)
-- Alternative: shell out to `cosign` binary (simpler but requires adding cosign to the image)
+**Dependencies (resolved):**
+- `github.com/sigstore/cosign/v2/pkg/cosign` — in-process Go verification, no shell-out, no binary added to image. Binary size impact acceptable for the `-tee` image (consumer proxy-router uses the same library).
+- Go 1.25.x (per CI/CD)
 
-**Effort:** L
+**Effort:** L — **DONE**
 
-### 7.5 Consumer UI: TEE badge and verification status
+### 7.5 Consumer UI: TEE badge and verification status — DONE
 
 **File:** `ui-desktop/src/renderer/src/components/` (model list, session views)
 
-**What:** Visual indicators for TEE models in the desktop UI.
+**What shipped:** Visual indicators for TEE models in the desktop UI.
 
 **Elements:**
 - TEE badge/icon on models tagged `"tee"` in the model browser
-- Verification status indicator during session creation ("Verifying TEE attestation...")
-- Success state: "Verified — running in TEE enclave"
-- Failure state: "Attestation verification failed — provider rejected"
+- Verification status indicator during session creation
+- Success and failure states
 
-**Effort:** M
+**Effort:** M — **DONE**
 
-### 7.6 Verifiable message signing (Phase 2, lower priority)
+### 7.6 Verifiable per-message signing — DEFERRED to Phase 2b
 
-**File:** New code in proxy-router
+**File:** New code in proxy-router (not yet added)
 
 **What:** Use SecretVM's internal signing service (`http://172.17.0.1:49153/sign`) to sign every response with a TEE-bound key. The public key is embedded in the attestation quote's `reportdata`, so consumers can verify that each response genuinely came from inside the TEE.
 
-**Why this matters:** Steps 7.1-7.5 verify attestation at session start. Per-message signing provides continuous proof throughout the session — not just "this provider was in a TEE when the session started" but "this specific response came from the TEE."
+**Why this matters:** Per-prompt fast-verify (§7.4) already re-checks the provider's CPU quote and TLS fingerprint on every request, so a compromise between session-open and the first prompt is detected before any inference ships. Per-message signing would tighten that further — prove that the response payload itself was produced inside the enclave, not just that the connection terminated there.
 
-**Effort:** L  
-**Priority:** Phase 2
+**Status:** Not shipped in v7.0.0. Deferred as "Phase 2b, lower priority" because the combination of TLS pinning (§7.7) + per-prompt fast-verify makes the practical attack window too narrow to justify the added per-response overhead at release time.
+
+**Effort:** L
+**Priority:** Phase 2b (post-v7)
+
+### 7.7 Phase 2 — P-Node verifies its own backend LLM — DONE (v7.0.0, PR #699)
+
+This is the Phase 2 capability that makes v7 the "full TEE" release. It closes the model-backend gap previously accepted in Phase 1 (Design Decision §2.4) without requiring CPU+GPU co-location in a single TDX VM.
+
+**Files (all under `proxy-router/internal/attestation/`):**
+- `backend_verifier.go` — `BackendVerifier.AttestBackend` (full) and `FastVerifyBackend` (per-prompt fast path)
+- `workload_verifier.go` — registry lookup + RTMR3 recalculation for the backend
+- `artifacts_registry.go` — downloads and caches the SecretVM TDX artifact registry CSV on a configurable interval (`ARTIFACT_REGISTRY_URL`, `ARTIFACT_REGISTRY_REFRESH_INTERVAL`)
+- `nras_verifier.go` — NVIDIA NRAS v4 API integration; validates the returned JWT Entity Attestation Token
+- `tdx_quote.go` — parses raw TDX quotes to extract MRTD + RTMR0-3 + reportData
+- `rtmr.go` — SHA-384 extend chain implementation used to replay expected RTMR3
+
+**Integration points:**
+- `proxy-router/cmd/main.go` — wires `BackendVerifier` into startup; calls `AttestBackend` once per `tee`-tagged model
+- `proxy-router/internal/proxyapi/proxy_receiver.go` — calls `FastVerifyBackend` in `SessionPrompt` before forwarding any inference for `tee`-tagged model sessions (hot path)
+- `proxy-router/internal/aiengine/ai_engine.go` — returns a `PinnedHTTPClient` for TEE models; the client's `VerifyPeerCertificate` callback refuses any onward TLS cert whose SHA-256 doesn't match the attested fingerprint
+- `proxy-router/internal/proxyapi/controller_http.go` — `GET /v1/models/attestation` returns per-model attestation state (verified / pending / failed + workload-match / last-success timestamp / error detail)
+
+**Backend attestation endpoints (derived from each TEE model's `apiUrl` host + standard port 29343):**
+- `:29343/cpu` — raw TDX CPU quote hex
+- `:29343/gpu` — JSON containing `nonce`, `arch`, `evidence_list`
+- `:29343/docker-compose` — exact `docker-compose.yaml` loaded into the backend VM (used for RTMR3 replay)
+
+**Full attestation sequence (`AttestBackend`):**
+```
+1. GET :29343/cpu            → raw TDX quote
+2. POST quote to TEE_PORTAL_URL (quote-parse) → portal verification
+3. Extract reportData[0:32]   → compare with SHA-256 of live TLS cert
+                                   → TLS binding proven
+4. if ArtifactRegistry loaded:
+     GET :29343/docker-compose
+     Parse TDX quote: MRTD + RTMR0-3 + reportData
+     Lookup (MRTD, RTMR0, RTMR1, RTMR2) in registry CSV → rootfs_data + secretvm_release
+     Replay RTMR3 = SHA-384-extend-chain( SHA-256(docker-compose) + rootfs_data )
+     if replayed RTMR3 != quote RTMR3 → fail (workload mismatch)
+5. GET :29343/gpu             → {nonce, arch, evidence_list}
+6. Extract reportData[32:64]  → compare with GPU nonce
+                                   → CPU-GPU binding proven
+7. if NRAS configured:
+     POST evidence to NVIDIA NRAS /v2/attest/gpu
+     Validate returned JWT EAT signature + claims
+     (non-fatal on network failure — NRAS outage does not block inference,
+      but CPU-GPU binding is still enforced)
+8. Cache snapshot: {quote_hash, tls_fingerprint, workload_status,
+                    last_verified_ts, compose_sha256}
+```
+
+**Per-prompt fast verify (`FastVerifyBackend`):**
+- No TTL. Runs unconditionally on every inference prompt for a `tee`-tagged model (inside `proxy_receiver.SessionPrompt`, on the hot path).
+- Always re-fetches `:29343/cpu` (~50 ms TLS handshake).
+- `SHA-256(new_quote) == cached_quote_hash` AND `live_tls_fp == cached_tls_fp` → pass.
+- Quote-hash change → run full `AttestBackend` again (backend restart / redeploy).
+- TLS-fingerprint change → immediate hard fail, prompt refused (MITM signal).
+- No cache → reject ("model not attested").
+- Cached status `failed` → reject ("attestation failed").
+
+**Measurement-register semantics (recap):**
+
+| Register | Content | How verified |
+|---|---|---|
+| MRTD | VM firmware measurement (set at launch, immutable) | Artifact registry lookup |
+| RTMR0 | VM configuration | Artifact registry lookup |
+| RTMR1 | Kernel | Artifact registry lookup |
+| RTMR2 | Initramfs | Artifact registry lookup |
+| RTMR3 | Rootfs + docker-compose.yaml | Client-side replay and compared to quote |
+
+**reportData layout (recap):**
+
+| Bytes | Content | Purpose |
+|---|---|---|
+| 0–31 | SHA-256(TLS cert) | Anti-MITM: pins the attested TEE to a specific TLS identity |
+| 32–63 | GPU nonce | CPU-GPU binding: GPU evidence can't be replayed from another box |
+
+**What Phase 2 proves end-to-end:**
+- The backend is genuine Intel TDX hardware running a known SecretVM firmware/kernel/initramfs build.
+- The exact set of loaded models (the `MODELS=...` line in `docker-compose.yaml`) is what the operator declared — swapping any model, port, or env var changes RTMR3 and fails verification.
+- The TLS endpoint serving inference terminates inside the attested enclave (no CDN/reverse-proxy MITM can sit between the P-Node and the backend).
+- The GPU evidence is genuine NVIDIA hardware (per NRAS), and cryptographically bound to the same CPU quote (per `reportData[32:64]`).
+- The backend identity hasn't changed since initial attestation, on a per-prompt basis.
+
+**Effort:** L — **DONE**
+**Priority:** Phase 2a — **shipped in v7.0.0**
+**PRs:** #699 (Phase 2 main), #700 (Phase 2 merge to test), #704 (error wrapping), #705 (request_id in logs), #708 / #709 (consolidate `tee` tag as sole TEE switch)
+
+See also: [`proxy-router/docs/tee-backend-verification.md`](../proxy-router/docs/tee-backend-verification.md) (developer reference with mermaid sequence + trust-chain diagrams).
 
 ---
 
@@ -580,11 +714,13 @@ if IsTEEModel(model.Tags):
 
 2. **~~SecretVM release pinning~~** — **RESOLVED.** Pinned in `.github/tee/secretvm.env`. Attestation manifest includes `secretvm_release` and `rootfs_sha256`. Providers must deploy on the matching release for RTMR3 to match.
 
-3. **Anti-MITM in practice:** The `reportdata` field contains the TLS certificate fingerprint. When the consumer connects to the provider over HTTPS, does it see the VM's TLS cert (proving it's inside the TEE), or does it see a CDN/load-balancer cert (breaking the chain)? If providers use Cloudflare/nginx in front, the anti-MITM guarantee breaks. Need to understand the typical network topology.
+3. **~~Anti-MITM in practice~~** — **RESOLVED in Phase 2.** The approach is now enforced on both hops:
+   - *Consumer → P-Node (Phase 1):* The consumer extracts the peer TLS cert during the `:29343/cpu` fetch and compares its SHA-256 to `reportData[0:32]` of the quote. Mismatch = session refused.
+   - *P-Node → Backend (Phase 2):* Same check at `AttestBackend`, **plus** the `PinnedHTTPClient` used for all onward inference refuses any TLS certificate whose SHA-256 doesn't match the attested fingerprint (in `VerifyPeerCertificate`). This means a TLS-terminating CDN/reverse-proxy in front of the backend *cannot* be used for `tee`-tagged models — the inference connection will refuse to establish. Operators are documented to expose SecretVM's port 443 (Traefik sidecar with SecretVM certs) directly for `tee`-tagged deployments.
 
-4. **Cosign verification in Go:** The consumer proxy-router is written in Go. Cosign has a Go library (`github.com/sigstore/cosign/v2/pkg/cosign`) for programmatic verification. Need to confirm it's compatible with the proxy-router's Go version (1.22.x) and doesn't bloat the binary excessively (relevant for `FROM scratch` image).
+4. **~~Cosign verification in Go~~** — **RESOLVED.** `github.com/sigstore/cosign/v2/pkg/cosign` is compiled into the proxy-router binary (Go 1.25.x). Binary-size impact accepted. Used both for consumer-side Phase 1 attestation manifest verification and for any in-process cosign verification needs.
 
-5. **ACPI templates for full RTMR0-2:** The `reproduce-mr` tool requires `template_qemu_cpu{N}.hex` files for ACPI table generation. These aren't published in the reproduce-mr repo. Need to either obtain from SCRT Labs or generate from a QEMU build. Not blocking — RTMR3 is the critical register for our software layer verification.
+5. **ACPI templates for full RTMR0-2:** The `reproduce-mr` tool requires `template_qemu_cpu{N}.hex` files for ACPI table generation — not needed for Phase 1 CI/CD (we only verify RTMR3 against the published manifest) *nor* for Phase 2 (we verify MRTD + RTMR0-2 by lookup in the published SecretVM TDX artifact registry CSV, not by recomputation). Remaining only if we ever want to recompute RTMR0-2 ourselves.
 
 ---
 
@@ -626,24 +762,45 @@ if IsTEEModel(model.Tags):
 | 1.20 | Temporarily disable service/UI builds on cicd/* branches | S | **DONE** | `Build-Service-Executables` set to `if: false`; cascades to all UI jobs. Re-enable before merge to main |
 | 1.21 | Testnet/mainnet TEE image split | S | **DONE** | `Dockerfile.tee` parameterized via ARG; pipeline sources `test.env` or `main.env` per branch — PR #669 |
 
-### Phase 1c — Proxy-Router Code (Developer Work)
+### Phase 1c — Proxy-Router Code (Consumer verifies P-Node) — DONE (v6.0.0)
 
 | # | Task | Effort | Status | Reference |
 |---|---|---|---|---|
 | ~~1.15~~ | ~~Extend `/healthcheck` with TEE metadata~~ | ~~S~~ | **DROPPED** | Not needed; TEE capability discovered via on-chain tag |
-| ~~1.16~~ | ~~Add `/attestation/quote` proxy endpoint~~ | ~~M~~ | **DROPPED** | Not needed; SecretVM host already exposes `:29343/cpu.html` |
-| 1.17 | `IsTEEModel()` helper in `model_tags.go` | S | TODO | §7.3 |
-| 1.18 | Consumer-side attestation verification in session flow | L | TODO | §7.4 — fetch quote from `:29343`, verify RTMR3 against signed manifest |
-| 1.19 | Consumer UI: TEE badge and verification status | M | TODO | §7.5 — frontend work, after 1.18 |
+| ~~1.16~~ | ~~Add `/attestation/quote` proxy endpoint~~ | ~~M~~ | **DROPPED** | Not needed; SecretVM host already exposes `:29343/cpu` |
+| 1.17 | `IsTeeModel()` helper in `model_tags.go` | S | **DONE** | §7.3 — consolidated in PR #708/#709 as sole TEE switch |
+| 1.18 | Consumer-side attestation verification in session flow | L | **DONE** | §7.4 — `attestation/verifier.go`, called from `blockchainapi/service.go` + `proxyapi/proxy_sender.go` |
+| 1.18a | Per-prompt `VerifyProviderQuick` fast path | M | **DONE** | PR #686 + #689 (quote-mismatch re-verify instead of hard fail) |
+| 1.18b | Storage-layer activity tracking for TEE sessions | S | **DONE** | PR #692/#693 (per-entry Badger keys, improved GC) |
+| 1.18c | Error-wrapping + request_id propagation for TEE failures | S | **DONE** | PR #704, #705 |
+| 1.19 | Consumer UI: TEE badge and verification status | M | **DONE** | §7.5 — renderer components + session-view states |
 
-### Phase 2 — Deeper Guarantees (future)
+### Phase 2a — P-Node verifies Backend LLM — DONE (v7.0.0)
 
-| # | Task | Effort | Status |
-|---|---|---|---|
-| 2.1 | Co-locate proxy-router + LLM in same TEE VM | L | TODO |
-| 2.2 | Verifiable per-message signing (TEE-bound key) | L | TODO |
-| 2.3 | On-chain measurement registry (if needed beyond cosign) | L | TODO |
-| 2.4 | Local quote verification (remove SCRT Labs API dependency) | L | TODO |
+| # | Task | Effort | Status | Reference |
+|---|---|---|---|---|
+| 2a.1 | `BackendVerifier` — full `AttestBackend` at startup | L | **DONE** | `attestation/backend_verifier.go`; PR #699 |
+| 2a.2 | `FastVerifyBackend` per-prompt hot-path check | M | **DONE** | Hooked from `proxy_receiver.SessionPrompt`; PR #699 |
+| 2a.3 | `WorkloadVerifier` — MRTD + RTMR0-2 registry lookup, RTMR3 replay | M | **DONE** | `attestation/workload_verifier.go`, `rtmr.go`, `tdx_quote.go` |
+| 2a.4 | `ArtifactRegistry` — download + cache SecretVM TDX artifact CSV | S | **DONE** | `attestation/artifacts_registry.go`; configurable interval |
+| 2a.5 | `NrasVerifier` — NVIDIA NRAS v4 evidence submission + JWT EAT validation | M | **DONE** | `attestation/nras_verifier.go` |
+| 2a.6 | `PinnedHTTPClient` — refuse onward TLS certs whose fingerprint doesn't match attested value | S | **DONE** | `aiengine/` — custom `VerifyPeerCertificate` |
+| 2a.7 | Health endpoint `GET /v1/models/attestation` | S | **DONE** | `proxyapi/controller_http.go` |
+| 2a.8 | New env config: `TEE_PORTAL_URL`, `TEE_IMAGE_REPO`, `ARTIFACT_REGISTRY_URL`, `ARTIFACT_REGISTRY_REFRESH_INTERVAL` | S | **DONE** | `config/config.go` (§7.7) |
+| 2a.9 | Consolidate `tee` on-chain tag as sole TEE switch (remove `isTee` field from models config schema) | S | **DONE** | PR #708 / #709 |
+| 2a.10 | Test coverage: `backend_verifier_test.go`, `golden_test.go`, `workload_verifier_test.go`, `workload_rytn_test.go`, `nras_verifier_test.go` | M | **DONE** | PR #699 |
+
+### Phase 2b — Deeper Guarantees (future, post-v7)
+
+| # | Task | Effort | Status | Notes |
+|---|---|---|---|---|
+| 2b.1 | Co-locate proxy-router + LLM in same TEE VM (single RTMR3 covers both hops) | L | TODO | Collapses Phase 1 + Phase 2 into one measurement chain |
+| 2b.2 | Verifiable per-message signing (TEE-bound key via SecretVM internal signer) | L | TODO | §7.6; deferred because Phase 2a fast-verify narrows the attack window significantly |
+| 2b.3 | AMD SEV-SNP measurement path in CI/CD | M | TODO | Blocked on upstream tooling; TDX-only today |
+| 2b.4 | Local quote verification in-process (remove SCRT Labs `quote-parse` dependency) | L | TODO | Requires PCK cert chain handling + Intel quote-verification library in Go |
+| 2b.5 | On-chain measurement registry (if ever needed beyond cosign signatures) | L | TODO | Cosign keyless via GHA OIDC is sufficient today |
+| 2b.6 | NRAS alternatives for non-NVIDIA GPU vendors | M | TODO | NVIDIA-only today |
+| 2b.7 | CVE scanning gate in CI/CD (Trivy/Grype) | S | TODO | §6.6 |
 
 ---
 
@@ -654,12 +811,22 @@ if IsTEEModel(model.Tags):
 | **Delivered artifacts** | |
 | Supply-chain hardening doc (in LMN) | `Morpheus-Lumerin-Node/.ai-docs/TEE_CICD_Supply_Chain_Hardening.md` |
 | Provider/consumer TEE guide (in LMN) | `Morpheus-Lumerin-Node/docs/02.3-proxy-router-tee.md` |
+| SecretVM provider quick-start (in LMN) | `Morpheus-Lumerin-Node/docs/02.4-proxy-router-secretvm-quickstart.md` |
+| **Phase 2 developer reference (in LMN)** | `Morpheus-Lumerin-Node/proxy-router/docs/tee-backend-verification.md` |
 | PR #644 — TEE image + BASE migration | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/644 |
 | PR #646 — Supply-chain hardening | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/646 |
 | PR #648 — Compose canonical format | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/648 |
 | PR #650 — User-facing TEE docs | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/650 |
 | PR #652 — SecretVM CLI instructions (from SCRT Labs) | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/652 |
 | PR #669 — Testnet/mainnet TEE image split | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/669 |
+| PR #686 — per-prompt TEE attestation with TLS binding and quote caching | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/686 |
+| PR #689 — re-verify provider on quote hash mismatch instead of failing | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/689 |
+| PR #692 — per-entry Badger activity tracking, improved GC reclaim | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/692 |
+| **PR #699 — Phase 2 TEE backend verification (main)** | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/699 |
+| PR #700 — Phase 2 merge to test | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/700 |
+| PR #703 / #704 — correct error wrapping on P-Node TEE attestation fail | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/704 |
+| PR #705 — request_id propagation in TEE logs | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/705 |
+| PR #708 / #709 — `tee` on-chain tag as sole TEE switch (removed `isTee` from models-config schema) | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/709 |
 | First verified pipeline run (build + sign) | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22920492249 |
 | First end-to-end run (build → sign → deploy → verify attestation) | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22969993910 |
 | **SCRT Labs / TEE platform** | |
@@ -678,8 +845,17 @@ if IsTEEModel(model.Tags):
 | **Proxy-router code references** | |
 | Healthcheck handler | `proxy-router/internal/system/controller.go:72-101` |
 | Healthcheck response struct | `proxy-router/internal/system/structs.go:19-24` |
-| Model tags detection | `proxy-router/internal/blockchainapi/model_tags.go` |
-| Session creation flow | `proxy-router/internal/blockchainapi/service.go` (`OpenSessionByModelId`, `tryOpenSession`) |
-| InitiateSession handshake | `proxy-router/internal/proxyapi/proxy_sender.go`, `proxy_receiver.go` |
+| Model tags detection (`IsTeeModel`) | `proxy-router/internal/blockchainapi/model_tags.go` |
+| Session creation flow + TEE branch | `proxy-router/internal/blockchainapi/service.go` (`OpenSessionByModelId`, `tryOpenSession`, sets `IsTee` on session) |
+| InitiateSession handshake + `VerifyProviderQuick` callsites | `proxy-router/internal/proxyapi/proxy_sender.go`, `proxy_receiver.go` |
+| **Phase 1 consumer verifier** | `proxy-router/internal/attestation/verifier.go` (`Verifier`, `VerifyProvider`, `VerifyProviderQuick`) |
+| **Phase 2 backend verifier** | `proxy-router/internal/attestation/backend_verifier.go` (`BackendVerifier.AttestBackend`, `FastVerifyBackend`) |
+| **Phase 2 workload verifier + RTMR3 replay** | `proxy-router/internal/attestation/workload_verifier.go`, `rtmr.go`, `tdx_quote.go` |
+| **Phase 2 artifact registry** | `proxy-router/internal/attestation/artifacts_registry.go` |
+| **Phase 2 NVIDIA NRAS client** | `proxy-router/internal/attestation/nras_verifier.go` |
+| **Phase 2 pinned TLS client** | `proxy-router/internal/aiengine/ai_engine.go` (returns `PinnedHTTPClient` for TEE models) |
+| **Phase 2 health endpoint** | `proxy-router/internal/proxyapi/controller_http.go` (`GET /v1/models/attestation`) |
+| TEE config struct | `proxy-router/internal/config/config.go` — `TEE` section (lines ~87-92) |
+| Session repository (tracks `IsTee`) | `proxy-router/internal/repositories/session/session_model.go`, `session_repo.go` |
 | ModelRegistry contract | `smart-contracts/contracts/diamond/facets/ModelRegistry.sol` |
 | Model struct (with tags) | `smart-contracts/contracts/interfaces/storage/IModelStorage.sol` |

--- a/.ai-docs/TEE_CICD_Supply_Chain_Hardening.md
+++ b/.ai-docs/TEE_CICD_Supply_Chain_Hardening.md
@@ -1,8 +1,10 @@
 # CI/CD Supply-Chain Hardening for Morpheus Docker Images
 
-**Last updated:** 2026-03-11  
-**First successful run (Phase 1a — signing):** [#22920492249](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22920492249)  
+**Last updated:** 2026-04-22
+**First successful run (Phase 1a — signing):** [#22920492249](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22920492249)
 **First end-to-end run (Phase 1b — deploy + verify):** [#22969993910](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22969993910)
+
+> **v7.0.0 release status.** The CI/CD hardening described here is the foundation that every downstream trust check depends on. Both **Phase 1c** (consumer-side proxy-router verification of the P-Node) and **Phase 2** (P-Node verifies its own backend LLM) have shipped on top of it — see [`TEE_Attestation_Architecture.md`](TEE_Attestation_Architecture.md) §7.4 and §7.7 for the code-level flow. The CI/CD pipeline itself remains unchanged from Phase 1b in this release; v7 is the *consumer* of the artifacts this pipeline produces.
 
 ---
 
@@ -197,37 +199,58 @@ This shows all attached artifacts — signature, attestation, and SBOM — in a 
 
 ---
 
-## What This Enables — The Full Loop
+## What This Enables — The Full Loop (as of v7.0.0)
 
-This CI/CD hardening is the **foundation layer** for the full TEE attestation loop. As of Phase 1b, the pipeline is fully automated end-to-end:
+This CI/CD hardening is the **foundation layer** for the full TEE attestation loop. As of v7.0.0, the loop is complete end-to-end — both consumer-side Phase 1 and P-Node-side Phase 2 are shipped:
 
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
-│                         CI/CD Pipeline (done)                         │
+│                    CI/CD Pipeline (Phase 1a + 1b — DONE)             │
 │                                                                      │
 │  Source Code ──► Build ──► Sign ──► Compute RTMR3 ──► Publish GHCR   │
 │                    │         │           │               │            │
-│                    │     cosign sig    RTMR3 in       ├── image      │
-│                    │     (Sigstore)    manifest        ├── SBOM      │
-│                    │                                   └── manifest  │
-│                    ▼                                                  │
-│                  Deploy to SecretVM ──► Verify live RTMR3 matches     │
-│                  (secretvm-cli)         (polls attestation quote)     │
+│                    │     cosign sig    RTMR3 in        ├── image     │
+│                    │     (Sigstore)    manifest         ├── SBOM     │
+│                    │                                    └── manifest │
+│                    ▼                                                 │
+│                  Deploy to SecretVM ──► Verify live RTMR3 matches    │
+│                  (secretvm-cli)         (polls attestation quote)    │
 └──────────────────────────────────────────────────────────────────────┘
                                               │
                                               ▼
-                              ┌──────────────────────────────┐
-                              │  Consumer Verification       │
-                              │  (proxy-router code, next)   │
-                              │                              │
-                              │  1. Detect "tee" model tag   │
-                              │  2. Fetch manifest from GHCR │
-                              │  3. Fetch quote from :29343  │
-                              │  4. Compare RTMR3            │
-                              │  5. If match → session       │
-                              │     If fail → reject         │
-                              └──────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│     Phase 1c — Consumer verifies P-Node (DONE in v6.0.0)             │
+│                                                                      │
+│  C-Node (v6.0.0+) session open + every prompt:                       │
+│    1. IsTeeModel(on-chain tags) == true                              │
+│    2. cosign fetch signed manifest from GHCR                         │
+│    3. GET provider :29343/cpu → raw TDX quote                        │
+│    4. POST to TEE_PORTAL_URL → quote is genuine                      │
+│    5. Compare RTMR3 against manifest golden value                    │
+│    6. reportData[0:32] == SHA-256(peer TLS cert) → anti-MITM         │
+│    7. Cache snapshot; fast-verify on every prompt                    │
+│  (attestation/verifier.go; PR #686, #689, #699)                      │
+└──────────────────────────────────────────────────────────────────────┘
+                                              │
+                                              ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│     Phase 2  — P-Node verifies its Backend LLM (DONE in v7.0.0)      │
+│                                                                      │
+│  P-Node (-tee image, v7.0.0+) startup + every prompt:                │
+│    1. GET backend :29343/cpu → backend TDX quote (portal-verified)   │
+│    2. TLS pinning via reportData[0:32]                               │
+│    3. Artifact-registry lookup for MRTD + RTMR0-2                    │
+│    4. Replay RTMR3 from backend docker-compose.yaml (SHA-384 chain)  │
+│    5. GET backend :29343/gpu → CPU-GPU binding via reportData[32:64] │
+│    6. NVIDIA NRAS v4 attestation of GPU evidence                     │
+│    7. Fast-verify on every prompt; PinnedHTTPClient for inference    │
+│    8. State exposed at GET /v1/models/attestation                    │
+│  (attestation/backend_verifier.go, workload_verifier.go,             │
+│   nras_verifier.go, artifacts_registry.go; PR #699, #700, #708-#709) │
+└──────────────────────────────────────────────────────────────────────┘
 ```
+
+**Why v6+ consumers are forward-compatible with v7+ providers:** Phase 2 runs **entirely inside the P-Node** — the consumer never talks to the backend LLM and never sees the backend's attestation quote. The consumer trusts Phase 2 transitively because it has already attested (via Phase 1) that the P-Node is running the exact `-tee` binary that enforces Phase 2. No client-side upgrade is required to get Phase 2 guarantees.
 
 **How each artifact feeds the trust chain:**
 
@@ -255,28 +278,46 @@ This CI/CD hardening is the **foundation layer** for the full TEE attestation lo
 
 ## Current Status and Next Steps
 
-### Completed (Phase 1a + 1b)
+### Completed (Phase 1a + 1b — CI/CD)
 
 | Step | Description | Status |
 |---|---|---|
-| **Cosign signing + SBOM** | Keyless signing, digest capture, SPDX SBOM for TEE image | **Done** |
-| **TEE attestation manifest** | Signed JSON with digests, hashes, baked env, build provenance | **Done** |
-| **RTMR3 computation** | Computed in CI/CD from deployed compose + SecretVM rootfs; embedded in signed manifest | **Done** |
-| **Auto-deploy to SecretVM** | `Deploy-SecretVM-Test` job deploys digest-pinned compose to test VM via `secretvm-cli` | **Done** |
-| **Post-deploy verification** | Polls live VM attestation, extracts RTMR3 from raw TDX quote, compares against CI-computed value | **Done** |
+| **Cosign signing + SBOM** | Keyless signing, digest capture, SPDX SBOM for TEE image | **Done** (v6.0.0) |
+| **TEE attestation manifest** | Signed JSON with digests, hashes, baked env, build provenance | **Done** (v6.0.0) |
+| **RTMR3 computation** | Computed in CI/CD from deployed compose + SecretVM rootfs; embedded in signed manifest | **Done** (v6.0.0) |
+| **Auto-deploy to SecretVM** | `Deploy-SecretVM-Test` job deploys digest-pinned compose to test VM via `secretvm-cli` | **Done** (v6.0.0) |
+| **Post-deploy verification** | Polls live VM attestation, extracts RTMR3 from raw TDX quote, compares against CI-computed value | **Done** (v6.0.0) |
+| **ECS deploy timing hardening** | Retry + stabilization-timeout improvements so post-deploy healthchecks don't race ECS | **Done** (PR #694/#695, #701) |
 
-### Remaining (Developer Work — Proxy-Router Code)
-
-| Step | Description | Status |
-|---|---|---|
-| **`IsTEEModel()` helper** | Detect `"tee"` tag on blockchain-registered models | TODO |
-| **Consumer-side verification** | Fetch attestation from `:29343`, verify RTMR3 against signed manifest before opening session | TODO |
-| **Consumer UI TEE badge** | Visual indicator for TEE-verified models | TODO |
-
-### Lower Priority (CI/CD)
+### Completed (Phase 1c — Consumer verifies P-Node, v6.0.0 → v6.2.x)
 
 | Step | Description | Status |
 |---|---|---|
-| **Full RTMR0-2** | Integrate `reproduce-mr` for firmware/kernel layers (blocked on ACPI templates) | TODO |
-| **AMD SEV measurement** | Integrate `sev-snp-measure` for AMD platform | TODO |
-| **CVE scanning** | Trivy/Grype scan as advisory step, then gating | TODO |
+| **`IsTeeModel()` helper** | Detect `"tee"` tag on blockchain-registered models; drives both hops of the trust chain | **Done** — PR #708, #709 (consolidated as sole TEE switch) |
+| **Consumer-side verification** | Fetch attestation from `:29343`, verify quote via SecretAI portal, compare RTMR3 against signed manifest, pin TLS cert — all before opening session | **Done** (`attestation/verifier.go`) |
+| **Per-prompt fast-verify** | Re-fetch quote, compare hash + TLS fingerprint on every forwarded prompt | **Done** — PR #686, #689 |
+| **Consumer UI TEE badge** | Visual indicator for TEE-verified models + session status | **Done** |
+
+### Completed (Phase 2a — P-Node verifies its Backend LLM, v7.0.0)
+
+| Step | Description | Status |
+|---|---|---|
+| **`BackendVerifier.AttestBackend`** | Startup full attestation: portal-verified CPU quote, TLS binding, workload RTMR3 replay, CPU-GPU nonce binding, NRAS | **Done** — PR #699 |
+| **`FastVerifyBackend`** | Per-prompt hot-path re-check with hash + TLS fingerprint; no TTL | **Done** — PR #699 |
+| **`ArtifactRegistry`** | Auto-refreshed SecretVM TDX artifact CSV for MRTD + RTMR0-2 lookup | **Done** — PR #699 |
+| **`NrasVerifier`** | NVIDIA NRAS v4 API integration for GPU attestation | **Done** — PR #699 |
+| **`PinnedHTTPClient`** | Onward inference rejects any TLS cert whose SHA-256 differs from attested fingerprint | **Done** — PR #699 |
+| **`GET /v1/models/attestation`** | Per-model attestation state endpoint for monitoring and forensics | **Done** — PR #699 |
+| **New env vars** | `TEE_PORTAL_URL`, `TEE_IMAGE_REPO`, `ARTIFACT_REGISTRY_URL`, `ARTIFACT_REGISTRY_REFRESH_INTERVAL` | **Done** — PR #699 |
+
+### Remaining (Lower Priority / Future)
+
+| Area | Step | Status |
+|---|---|---|
+| CI/CD | Full RTMR0-2 *recomputation* in CI (today we verify RTMR0-2 by artifact-registry lookup, which is sufficient) | TODO — blocked on ACPI templates |
+| CI/CD | AMD SEV-SNP measurement via `sev-snp-measure` | TODO — TDX-only today |
+| CI/CD | CVE scanning (Trivy/Grype) — advisory then gating | TODO |
+| Proxy-router | Verifiable per-message signing using SecretVM TEE-bound key | Deferred to Phase 2b |
+| Proxy-router | Local in-process quote verification (remove `quote-parse` dependency on SCRT Labs) | Deferred to Phase 2b |
+| Proxy-router | Co-located proxy-router + LLM in a single TDX VM (collapses both hops into one RTMR3) | Deferred to Phase 2b |
+| Proxy-router | NRAS alternatives for non-NVIDIA GPU vendors | Deferred to Phase 2b |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,11 @@ on:
         description: "Deploy to hosted environments"
         required: true
         type: boolean
+      cnode_rehydration_wait_secs:
+        description: "Seconds to hold traffic off the new C-Node after it's up, to let BadgerDB session rehydration complete (default 90)"
+        required: false
+        type: string
+        default: "90"
 
   push:
     branches:
@@ -1164,6 +1169,132 @@ jobs:
             echo "⚠️ Continuing with warning - ECS deployment completed but version verification inconclusive"
           fi
 
+  Drain-Morpheus-C-Node:
+    # Quiet the C-Node BEFORE restarting any provider (P-Node) or the C-Node itself.
+    # 
+    # Why: the proxy-router on the C-Node keeps a BadgerDB of active sessions. On v6.x
+    # the BadgerDB is ephemeral on Fargate (no EFS) and the router has rehydration
+    # logic that rebuilds state on boot from on-chain data. While a P-Node restarts,
+    # any warm session streaming through the C-Node will see a clean upstream failure
+    # (NLB returns 503 / connection closed) instead of a half-dead mid-stream hang
+    # that would require manual BadgerDB cleanup afterwards.
+    #
+    # This job deregisters the running C-Node task ENI from every target group on the
+    # C-Node NLB. The target groups have connection_termination=true (see
+    # Morpheus-Infra/environments/02-morpheus_c_node/.terragrunt/02_mor_router_svc.tf),
+    # so existing TCP sessions are closed promptly. The ECS service and its task
+    # continue to run; we are only manipulating LB membership.
+    name: Drain Morpheus C-Node from NLB
+    if: |
+      github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      (
+        (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true' && github.event.inputs.create_deployment == 'true')
+      )
+    needs:
+      - Generate-Tag
+      - GHCR-Build-and-Push
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name }}
+    outputs:
+      tg_arns: ${{ steps.drain.outputs.tg_arns }}
+      drained_ips: ${{ steps.drain.outputs.drained_ips }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.MORPHEUS_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.MORPHEUS_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Deregister C-Node targets from all NLB target groups
+        id: drain
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.ref_name }}" == "test" ]; then
+            ENV="dev"
+          elif [ "${{ github.ref_name }}" == "main" ]; then
+            ENV="prd"
+          else
+            echo "❌ Unsupported branch for drain: ${{ github.ref_name }}"
+            exit 1
+          fi
+
+          CLUSTER_NAME="ecs-${ENV}-morpheus-engine"
+          SERVICE_NAME="svc-${ENV}-router"
+
+          echo "🎯 Discovering target groups for ${CLUSTER_NAME}/${SERVICE_NAME}..."
+          TG_ARNS=$(aws ecs describe-services \
+            --cluster "$CLUSTER_NAME" \
+            --services "$SERVICE_NAME" \
+            --query 'services[0].loadBalancers[].targetGroupArn' \
+            --output text)
+
+          if [ -z "$TG_ARNS" ] || [ "$TG_ARNS" == "None" ]; then
+            echo "❌ No target groups resolved for service $SERVICE_NAME"
+            exit 1
+          fi
+
+          echo "📋 Target groups: $TG_ARNS"
+
+          DRAINED_IPS=""
+          for TG_ARN in $TG_ARNS; do
+            echo ""
+            echo "🔄 Inspecting $TG_ARN..."
+            TARGETS_JSON=$(aws elbv2 describe-target-health \
+              --target-group-arn "$TG_ARN" \
+              --query 'TargetHealthDescriptions[].Target' \
+              --output json)
+            TARGET_COUNT=$(echo "$TARGETS_JSON" | jq 'length')
+
+            if [ "$TARGET_COUNT" -eq 0 ]; then
+              echo "  (no registered targets — nothing to drain)"
+              continue
+            fi
+
+            # Build --targets Id=...,Port=... arg list
+            TARGETS_CLI=$(echo "$TARGETS_JSON" | jq -r '.[] | "Id=\(.Id),Port=\(.Port)"')
+            echo "  Current targets ($TARGET_COUNT):"
+            echo "$TARGETS_CLI" | sed 's/^/    /'
+
+            # Collect IPs across all TGs for later reference (deduped)
+            IPS=$(echo "$TARGETS_JSON" | jq -r '.[].Id')
+            DRAINED_IPS="$DRAINED_IPS $IPS"
+
+            echo "  Calling DeregisterTargets..."
+            # shellcheck disable=SC2086
+            aws elbv2 deregister-targets \
+              --target-group-arn "$TG_ARN" \
+              --targets $TARGETS_CLI
+          done
+
+          # connection_termination=true on router TGs closes live TCP sessions in under
+          # a second; svc TG has deregistration_delay=0 and API TG has 30. 45s leaves
+          # plenty of margin for LB state to propagate across AZs before we let the
+          # P-Node deployment start disrupting upstream providers.
+          DRAIN_WAIT=45
+          echo ""
+          echo "⏳ Waiting ${DRAIN_WAIT}s for deregistration to propagate..."
+          sleep $DRAIN_WAIT
+
+          # Flatten outputs (newline → space, then comma for workflow output)
+          TG_ARNS_CSV=$(echo "$TG_ARNS" | tr -s '[:space:]' ',' | sed 's/^,//;s/,$//')
+          IPS_CSV=$(echo "$DRAINED_IPS" | tr -s '[:space:]' ',' | sed 's/^,//;s/,$//' | awk -F, '{for (i=1;i<=NF;i++) if (!seen[$i]++) printf (i>1?",":"")"%s",$i; print ""}')
+
+          echo "tg_arns=$TG_ARNS_CSV" >> "$GITHUB_OUTPUT"
+          echo "drained_ips=$IPS_CSV" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### 🚰 C-Node drain complete"
+            echo ""
+            echo "**Environment:** \`$ENV\`"
+            echo "**Target groups drained:** \`$TG_ARNS_CSV\`"
+            echo "**Target IPs removed:** \`$IPS_CSV\`"
+            echo ""
+            echo "Upstream providers may now be safely restarted; the NLB will return clean upstream errors until the new C-Node is re-registered."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   Deploy-to-Morpheus-C-Node:
     name: Deploy to Morpheus Consumer via GitHub
     if: |
@@ -1174,7 +1305,11 @@ jobs:
       )
     needs:
       - Generate-Tag
-      - GHCR-Build-and-Push  
+      - GHCR-Build-and-Push
+      - Drain-Morpheus-C-Node
+      # P-Node is main-only; on test this job is skipped and the `needs` is still
+      # satisfied (skipped jobs are treated as successful for dependency resolution).
+      - Deploy-to-Morpheus-P-Node
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name }}
     steps:
@@ -1294,12 +1429,20 @@ jobs:
           
           echo "✅ New task definition registered: $NEW_TASK_ARN"
           
-          # Update the ECS service
+          # Update the ECS service.
+          #
+          # --health-check-grace-period-seconds 600: ECS ignores LB target health for
+          # 10 minutes after the task starts. We need this because the next steps
+          # deliberately deregister the new task from the NLB target groups during
+          # the rehydration window. Without a generous grace period ECS would see
+          # the target as "unhealthy" (since it's not registered anywhere) and the
+          # deployment circuit breaker could roll back mid-deployment.
           echo "🔄 Updating ECS service..."
           UPDATE_RESULT=$(aws ecs update-service \
             --cluster "$CLUSTER_NAME" \
             --service "$SERVICE_NAME" \
             --task-definition "$NEW_TASK_ARN" \
+            --health-check-grace-period-seconds 600 \
             --force-new-deployment \
             --query 'service.{serviceName:serviceName,taskDefinition:taskDefinition,desiredCount:desiredCount,runningCount:runningCount,pendingCount:pendingCount}' \
             --output json)
@@ -1318,40 +1461,183 @@ jobs:
           echo "⚙️  Service: $SERVICE_NAME"
           echo "📦 Image: $BUILDIMAGE:$BUILDTAG"
           echo "📋 Task Definition: $NEW_TASK_ARN"
-          
-          # Wait for deployment to stabilize
-          # C-Node ECS lifecycle (from Terraform 02_mor_router_svc.tf):
-          #   - deployment_minimum_healthy_percent=0, deployment_maximum_percent=100
-          #     → ECS stops old task FIRST, then starts new one (single-writer BadgerDB)
-          #   - stopTimeout=120s (SIGTERM→SIGKILL)
-          #   - deregistration_delay=0 (svc TG) / 30s (API TG)
-          #   - ALB health_check: healthy_threshold=3, interval=30s → ~90s to register healthy
-          # Worst case: ~120s + ~30s + ~90s ≈ 4 min; enforce 180s floor before health-check polling.
-          DEPLOY_WAIT_FLOOR_SECS=180
-          echo "⏳ Waiting for ECS service to stabilize (default waiter: up to 10 min at 40×15s)..."
-          WAIT_START=$(date +%s)
-          set +e
-          aws ecs wait services-stable \
-            --cluster "$CLUSTER_NAME" \
-            --services "$SERVICE_NAME" \
-            --cli-read-timeout 900 \
-            --cli-connect-timeout 60
-          STABILIZATION_STATUS=$?
-          WAIT_ELAPSED=$(( $(date +%s) - WAIT_START ))
-          set -e
-          
-          if [ $STABILIZATION_STATUS -eq 0 ]; then
-            echo "✅ ECS service stabilized after ${WAIT_ELAPSED}s"
+
+          ##################################################################
+          # Controlled-traffic deployment sequence (v7+).
+          #
+          # Goal: after ECS brings up the new C-Node task, hold traffic off it
+          # for CNODE_REHYDRATION_WAIT_SECS so the proxy-router's BadgerDB
+          # session rehydration loop can catch up from on-chain state. Only
+          # then re-register to the NLB target groups.
+          #
+          # Flow:
+          #   1. Discover TG ARNs from the ECS service.
+          #   2. Poll until a task running the NEW task definition is RUNNING
+          #      and has a private ENI IP.
+          #   3. Deregister that IP from every TG — targets that are still in
+          #      "initial" state at this point never serve traffic; targets
+          #      that already became "healthy" go through connection_termination
+          #      (see Morpheus-Infra 02_mor_router_svc.tf).
+          #   4. Sleep CNODE_REHYDRATION_WAIT_SECS (the manual hold window).
+          #   5. Re-register and `elbv2 wait target-in-service` on each TG.
+          #   6. Fall through to the public /healthcheck version-match loop.
+          #
+          # The grace period on update-service prevents the ECS circuit
+          # breaker from rolling back while the task is deregistered.
+          ##################################################################
+
+          # Resolve the rehydration hold (workflow_dispatch override → env → default 90s).
+          CNODE_REHYDRATION_WAIT_SECS="${{ github.event.inputs.cnode_rehydration_wait_secs || '90' }}"
+          # Guard against non-numeric input
+          if ! [[ "$CNODE_REHYDRATION_WAIT_SECS" =~ ^[0-9]+$ ]]; then
+            echo "⚠️ cnode_rehydration_wait_secs not numeric ('$CNODE_REHYDRATION_WAIT_SECS'), defaulting to 90"
+            CNODE_REHYDRATION_WAIT_SECS=90
+          fi
+          echo "⏱️  Rehydration hold window: ${CNODE_REHYDRATION_WAIT_SECS}s"
+
+          # Resolve TGs (re-use drain-job output if provided, else rediscover).
+          DRAIN_TG_ARNS="${{ needs.Drain-Morpheus-C-Node.outputs.tg_arns }}"
+          if [ -n "$DRAIN_TG_ARNS" ]; then
+            TG_ARN_LIST=$(echo "$DRAIN_TG_ARNS" | tr ',' ' ')
+            echo "📋 Re-using TG ARNs from drain job: $TG_ARN_LIST"
           else
-            echo "⚠️ ECS wait returned status $STABILIZATION_STATUS after ${WAIT_ELAPSED}s, continuing with health check..."
+            echo "📋 Discovering TGs from ECS service (drain job output was empty)..."
+            TG_ARN_LIST=$(aws ecs describe-services \
+              --cluster "$CLUSTER_NAME" \
+              --services "$SERVICE_NAME" \
+              --query 'services[0].loadBalancers[].targetGroupArn' \
+              --output text)
           fi
-          
-          REMAINING=$(( DEPLOY_WAIT_FLOOR_SECS - WAIT_ELAPSED ))
-          if [ $REMAINING -gt 0 ]; then
-            echo "⏳ Ensuring minimum ${DEPLOY_WAIT_FLOOR_SECS}s deploy wait (sleeping ${REMAINING}s more)..."
-            sleep $REMAINING
+
+          if [ -z "$TG_ARN_LIST" ]; then
+            echo "❌ No TG ARNs resolved; cannot safely control traffic. Aborting."
+            exit 1
           fi
-          
+
+          # Poll (up to 15 min) until the new task is RUNNING and has a private IP.
+          # ECS lifecycle:
+          #   - stopTimeout=120s to let old task drain (already deregistered by drain job)
+          #   - new task goes PROVISIONING → PENDING → RUNNING
+          echo "⏳ Waiting for new C-Node task ($NEW_TASK_ARN) to be RUNNING..."
+          NEW_TASK_IP=""
+          NEW_TASK_DEF_ARN_TRIMMED="${NEW_TASK_ARN##*/}"  # family:revision
+          for attempt in $(seq 1 90); do
+            RUNNING_TASKS=$(aws ecs list-tasks \
+              --cluster "$CLUSTER_NAME" \
+              --service-name "$SERVICE_NAME" \
+              --desired-status RUNNING \
+              --query 'taskArns' \
+              --output json)
+
+            # Find a task whose taskDefinitionArn matches the one we just deployed.
+            if [ "$(echo "$RUNNING_TASKS" | jq 'length')" != "0" ]; then
+              TASK_DETAILS=$(aws ecs describe-tasks \
+                --cluster "$CLUSTER_NAME" \
+                --tasks $(echo "$RUNNING_TASKS" | jq -r '.[]') \
+                --query 'tasks[?lastStatus==`RUNNING`]' \
+                --output json)
+
+              NEW_TASK_IP=$(echo "$TASK_DETAILS" | jq -r --arg TD "$NEW_TASK_ARN" '
+                .[] | select(.taskDefinitionArn == $TD) |
+                .attachments[0].details[] | select(.name == "privateIPv4Address") | .value
+              ' | head -n1)
+
+              if [ -n "$NEW_TASK_IP" ] && [ "$NEW_TASK_IP" != "null" ]; then
+                echo "✅ New C-Node task running on ENI IP ${NEW_TASK_IP} (after ${attempt} polls)"
+                break
+              fi
+            fi
+
+            sleep 10
+          done
+
+          if [ -z "$NEW_TASK_IP" ] || [ "$NEW_TASK_IP" == "null" ]; then
+            echo "❌ Timed out waiting for new C-Node task to reach RUNNING with an ENI IP"
+            exit 1
+          fi
+
+          # Step: block traffic to the new task while rehydration runs.
+          echo ""
+          echo "🚧 Deregistering new C-Node task IP from all TGs to hold traffic..."
+          for TG_ARN in $TG_ARN_LIST; do
+            TG_PORT=$(aws elbv2 describe-target-groups \
+              --target-group-arns "$TG_ARN" \
+              --query 'TargetGroups[0].Port' \
+              --output text)
+            echo "  $TG_ARN (port $TG_PORT)"
+            # Idempotent: if ECS hasn't registered it yet, this is a no-op; if it has,
+            # the target enters `draining` (NLB connection_termination=true closes live flows).
+            aws elbv2 deregister-targets \
+              --target-group-arn "$TG_ARN" \
+              --targets "Id=${NEW_TASK_IP},Port=${TG_PORT}" || true
+          done
+
+          # Step: rehydration hold. This is the "manual delay from when new task is up
+          # before traffic is allowed back in".
+          echo ""
+          echo "⏳ Holding traffic off new C-Node for ${CNODE_REHYDRATION_WAIT_SECS}s (BadgerDB rehydration window)..."
+          sleep "$CNODE_REHYDRATION_WAIT_SECS"
+
+          # Step: re-register. Wrapped in a trap-like always-run block: if any of the
+          # subsequent checks fail, we want to make sure we don't leave the TGs empty
+          # and the service stuck.
+          REREGISTER_SUCCESS=false
+          echo ""
+          echo "🔁 Re-registering new C-Node task IP to all TGs..."
+          for TG_ARN in $TG_ARN_LIST; do
+            TG_PORT=$(aws elbv2 describe-target-groups \
+              --target-group-arns "$TG_ARN" \
+              --query 'TargetGroups[0].Port' \
+              --output text)
+            echo "  $TG_ARN (port $TG_PORT)"
+            aws elbv2 register-targets \
+              --target-group-arn "$TG_ARN" \
+              --targets "Id=${NEW_TASK_IP},Port=${TG_PORT}"
+          done
+          REREGISTER_SUCCESS=true
+
+          # Step: wait for each TG to report the new target healthy.
+          # healthy_threshold=3, interval=30s → ~90s typical; allow 4 min margin.
+          echo ""
+          echo "⏳ Waiting for TGs to report new target in service (timeout ~4 min per TG)..."
+          WAIT_FAILED_TGS=""
+          for TG_ARN in $TG_ARN_LIST; do
+            TG_PORT=$(aws elbv2 describe-target-groups \
+              --target-group-arns "$TG_ARN" \
+              --query 'TargetGroups[0].Port' \
+              --output text)
+            echo "  ⏳ $TG_ARN (port $TG_PORT)..."
+            set +e
+            aws elbv2 wait target-in-service \
+              --target-group-arn "$TG_ARN" \
+              --targets "Id=${NEW_TASK_IP},Port=${TG_PORT}"
+            WAIT_STATUS=$?
+            set -e
+            if [ $WAIT_STATUS -ne 0 ]; then
+              echo "    ⚠️ wait target-in-service returned status $WAIT_STATUS"
+              WAIT_FAILED_TGS="$WAIT_FAILED_TGS $TG_ARN"
+            else
+              echo "    ✅ in service"
+            fi
+          done
+
+          if [ -n "$WAIT_FAILED_TGS" ]; then
+            echo "⚠️ One or more TGs did not reach in-service within the waiter timeout:$WAIT_FAILED_TGS"
+            echo "    Continuing to public /healthcheck verification — NLB may still come healthy shortly."
+          fi
+
+          {
+            echo "### 🚦 C-Node controlled redeploy"
+            echo ""
+            echo "- **New task ENI IP:** \`${NEW_TASK_IP}\`"
+            echo "- **Target groups:** \`$(echo $TG_ARN_LIST | tr ' ' ',')\`"
+            echo "- **Rehydration hold:** \`${CNODE_REHYDRATION_WAIT_SECS}s\`"
+            echo "- **Re-registered:** \`${REREGISTER_SUCCESS}\`"
+            if [ -n "$WAIT_FAILED_TGS" ]; then
+              echo "- ⚠️ **TGs that did not confirm in-service before waiter timeout:** \`${WAIT_FAILED_TGS}\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
           # Determine the public endpoint for health check
           if [ "$ENV" == "dev" ]; then
             HEALTH_ENDPOINT="http://router.dev.mor.org:8082/healthcheck"
@@ -1441,7 +1727,9 @@ jobs:
 
   Deploy-to-Morpheus-P-Node:
     name: Deploy to Morpheus Provider via GitHub
-    # Only deploy provider node on main branch (production) - no dev provider node exists
+    # Only deploy provider node on main branch (production) - no dev provider node exists.
+    # Gated behind Drain-Morpheus-C-Node so the C-Node NLB is already quiet before the
+    # P-Node restarts and takes its hosted models briefly offline.
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
       (
@@ -1450,7 +1738,8 @@ jobs:
       )
     needs:
       - Generate-Tag
-      - GHCR-Build-and-Push  
+      - GHCR-Build-and-Push
+      - Drain-Morpheus-C-Node
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1048,15 +1048,17 @@ jobs:
           echo "📦 Image: $BUILDIMAGE:$BUILDTAG"
           echo "📋 Task Definition: $NEW_TASK_ARN"
           
-          # Wait for deployment to stabilize with extended timeout
-          echo "⏳ Waiting for service to stabilize (up to 15 minutes)..."
+          # Wait for deployment to stabilize (set +e: bash -e would exit before capturing $? on waiter timeout 255)
+          echo "⏳ Waiting for service to stabilize (up to ~12.5 min at 50×15s)..."
+          set +e
           aws ecs wait services-stable \
             --cluster "$CLUSTER_NAME" \
             --services "$SERVICE_NAME" \
+            --max-attempts 50 \
             --cli-read-timeout 900 \
             --cli-connect-timeout 60
-          
           STABILIZATION_STATUS=$?
+          set -e
           
           if [ $STABILIZATION_STATUS -eq 0 ]; then
             echo "✅ ECS service stabilized successfully"
@@ -1303,15 +1305,17 @@ jobs:
           echo "📦 Image: $BUILDIMAGE:$BUILDTAG"
           echo "📋 Task Definition: $NEW_TASK_ARN"
           
-          # Wait for deployment to stabilize with extended timeout
-          echo "⏳ Waiting for service to stabilize (up to 15 minutes)..."
+          # Wait for deployment to stabilize (set +e: bash -e would exit before capturing $? on waiter timeout 255)
+          echo "⏳ Waiting for service to stabilize (up to ~12.5 min at 50×15s)..."
+          set +e
           aws ecs wait services-stable \
             --cluster "$CLUSTER_NAME" \
             --services "$SERVICE_NAME" \
+            --max-attempts 50 \
             --cli-read-timeout 900 \
             --cli-connect-timeout 60
-          
           STABILIZATION_STATUS=$?
+          set -e
           
           if [ $STABILIZATION_STATUS -eq 0 ]; then
             echo "✅ ECS service stabilized successfully"
@@ -1430,14 +1434,6 @@ jobs:
           aws-access-key-id: ${{ secrets.MORPHEUS_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.MORPHEUS_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
-
-      - name: Pause Active Models refresh
-        run: |
-          ENV="prd"
-          RULE_NAME="${ENV}-morpheus-active-models-updater"
-          echo "⏸️ Disabling Active Models EventBridge rule: $RULE_NAME"
-          aws events disable-rule --name "$RULE_NAME" --region us-east-2
-          echo "✅ Active Models refresh paused — prevents stale data during provider rolling deploy"
 
       - name: Deploy to Morpheus Provider ECS
         run: |
@@ -1559,15 +1555,17 @@ jobs:
           echo "📦 Image: $BUILDIMAGE:$BUILDTAG"
           echo "📋 Task Definition: $NEW_TASK_ARN"
           
-          # Wait for deployment to stabilize with extended timeout
-          echo "⏳ Waiting for service to stabilize (up to 15 minutes)..."
+          # Wait for deployment to stabilize (P-Node: ALB drain + health checks can exceed default 40×15s; set +e preserves $? under bash -e)
+          echo "⏳ Waiting for service to stabilize (up to ~12.5 min at 50×15s)..."
+          set +e
           aws ecs wait services-stable \
             --cluster "$CLUSTER_NAME" \
             --services "$SERVICE_NAME" \
+            --max-attempts 50 \
             --cli-read-timeout 900 \
             --cli-connect-timeout 60
-          
           STABILIZATION_STATUS=$?
+          set -e
           
           if [ $STABILIZATION_STATUS -eq 0 ]; then
             echo "✅ ECS service stabilized successfully"
@@ -1653,36 +1651,6 @@ jobs:
             # Don't fail the deployment for version mismatch, as it might be a timing issue
             # The ECS service update was successful, version verification is informational
             echo "⚠️ Continuing with warning - ECS deployment completed but version verification inconclusive"
-          fi
-
-      - name: Resume Active Models refresh
-        if: always()
-        run: |
-          ENV="prd"
-          RULE_NAME="${ENV}-morpheus-active-models-updater"
-          FUNCTION_NAME="${ENV}-morpheus-active-models-updater"
-          
-          echo "▶️ Re-enabling Active Models EventBridge rule: $RULE_NAME"
-          aws events enable-rule --name "$RULE_NAME" --region us-east-2
-          echo "✅ Active Models refresh re-enabled"
-          
-          echo "🔄 Invoking Active Models Lambda to refresh immediately..."
-          INVOKE_RESULT=$(aws lambda invoke \
-            --function-name "$FUNCTION_NAME" \
-            --region us-east-2 \
-            --log-type Tail \
-            --payload '{}' \
-            /tmp/lambda-response.json 2>&1)
-          
-          INVOKE_STATUS=$?
-          if [ $INVOKE_STATUS -eq 0 ]; then
-            echo "✅ Active Models Lambda invoked successfully"
-            echo "📋 Response:"
-            cat /tmp/lambda-response.json | jq . 2>/dev/null || cat /tmp/lambda-response.json
-          else
-            echo "⚠️ Active Models Lambda invocation failed (status: $INVOKE_STATUS)"
-            echo "$INVOKE_RESULT"
-            echo "ℹ️ The EventBridge schedule will pick it up on the next cycle"
           fi
 
   UI-macOS-latest-arm64:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1048,22 +1048,33 @@ jobs:
           echo "📦 Image: $BUILDIMAGE:$BUILDTAG"
           echo "📋 Task Definition: $NEW_TASK_ARN"
           
-          # Wait for deployment to stabilize (set +e: bash -e would exit before capturing $? on waiter timeout 255)
-          echo "⏳ Waiting for service to stabilize (up to ~12.5 min at 50×15s)..."
+          # Wait for deployment to stabilize
+          # ECS lifecycle: stopTimeout=120s (SIGTERM→SIGKILL) + deregistration_delay ≤30s
+          #   + new task image pull/start + ALB health checks (healthy_threshold×interval ≈90s)
+          # Worst-case ~4 min; enforce a 180s floor so health-check retries aren't wasted on the old task.
+          DEPLOY_WAIT_FLOOR_SECS=180
+          echo "⏳ Waiting for ECS service to stabilize (default waiter: up to 10 min at 40×15s)..."
+          WAIT_START=$(date +%s)
           set +e
           aws ecs wait services-stable \
             --cluster "$CLUSTER_NAME" \
             --services "$SERVICE_NAME" \
-            --max-attempts 50 \
             --cli-read-timeout 900 \
             --cli-connect-timeout 60
           STABILIZATION_STATUS=$?
+          WAIT_ELAPSED=$(( $(date +%s) - WAIT_START ))
           set -e
           
           if [ $STABILIZATION_STATUS -eq 0 ]; then
-            echo "✅ ECS service stabilized successfully"
+            echo "✅ ECS service stabilized after ${WAIT_ELAPSED}s"
           else
-            echo "⚠️ ECS stabilization wait timed out, but continuing with health check..."
+            echo "⚠️ ECS wait returned status $STABILIZATION_STATUS after ${WAIT_ELAPSED}s, continuing with health check..."
+          fi
+          
+          REMAINING=$(( DEPLOY_WAIT_FLOOR_SECS - WAIT_ELAPSED ))
+          if [ $REMAINING -gt 0 ]; then
+            echo "⏳ Ensuring minimum ${DEPLOY_WAIT_FLOOR_SECS}s deploy wait (sleeping ${REMAINING}s more)..."
+            sleep $REMAINING
           fi
           
           # Determine the public endpoint for health check
@@ -1080,6 +1091,8 @@ jobs:
           HEALTH_RETRY_COUNT=0
           VERSION_VERIFIED=false
           
+          # Disable errexit for the health-check loop so curl timeouts (exit 28) don't kill the script
+          set +e
           while [ $HEALTH_RETRY_COUNT -lt $MAX_HEALTH_RETRIES ]; do
             echo "🔄 Health check attempt $((HEALTH_RETRY_COUNT + 1))/$MAX_HEALTH_RETRIES..."
             
@@ -1125,6 +1138,7 @@ jobs:
               sleep 15
             fi
           done
+          set -e
           
           # Final deployment status
           if [ "$VERSION_VERIFIED" = true ]; then
@@ -1305,22 +1319,37 @@ jobs:
           echo "📦 Image: $BUILDIMAGE:$BUILDTAG"
           echo "📋 Task Definition: $NEW_TASK_ARN"
           
-          # Wait for deployment to stabilize (set +e: bash -e would exit before capturing $? on waiter timeout 255)
-          echo "⏳ Waiting for service to stabilize (up to ~12.5 min at 50×15s)..."
+          # Wait for deployment to stabilize
+          # C-Node ECS lifecycle (from Terraform 02_mor_router_svc.tf):
+          #   - deployment_minimum_healthy_percent=0, deployment_maximum_percent=100
+          #     → ECS stops old task FIRST, then starts new one (single-writer BadgerDB)
+          #   - stopTimeout=120s (SIGTERM→SIGKILL)
+          #   - deregistration_delay=0 (svc TG) / 30s (API TG)
+          #   - ALB health_check: healthy_threshold=3, interval=30s → ~90s to register healthy
+          # Worst case: ~120s + ~30s + ~90s ≈ 4 min; enforce 180s floor before health-check polling.
+          DEPLOY_WAIT_FLOOR_SECS=180
+          echo "⏳ Waiting for ECS service to stabilize (default waiter: up to 10 min at 40×15s)..."
+          WAIT_START=$(date +%s)
           set +e
           aws ecs wait services-stable \
             --cluster "$CLUSTER_NAME" \
             --services "$SERVICE_NAME" \
-            --max-attempts 50 \
             --cli-read-timeout 900 \
             --cli-connect-timeout 60
           STABILIZATION_STATUS=$?
+          WAIT_ELAPSED=$(( $(date +%s) - WAIT_START ))
           set -e
           
           if [ $STABILIZATION_STATUS -eq 0 ]; then
-            echo "✅ ECS service stabilized successfully"
+            echo "✅ ECS service stabilized after ${WAIT_ELAPSED}s"
           else
-            echo "⚠️ ECS stabilization wait timed out, but continuing with health check..."
+            echo "⚠️ ECS wait returned status $STABILIZATION_STATUS after ${WAIT_ELAPSED}s, continuing with health check..."
+          fi
+          
+          REMAINING=$(( DEPLOY_WAIT_FLOOR_SECS - WAIT_ELAPSED ))
+          if [ $REMAINING -gt 0 ]; then
+            echo "⏳ Ensuring minimum ${DEPLOY_WAIT_FLOOR_SECS}s deploy wait (sleeping ${REMAINING}s more)..."
+            sleep $REMAINING
           fi
           
           # Determine the public endpoint for health check
@@ -1337,6 +1366,8 @@ jobs:
           HEALTH_RETRY_COUNT=0
           VERSION_VERIFIED=false
           
+          # Disable errexit for the health-check loop so curl timeouts (exit 28) don't kill the script
+          set +e
           while [ $HEALTH_RETRY_COUNT -lt $MAX_HEALTH_RETRIES ]; do
             echo "🔄 Health check attempt $((HEALTH_RETRY_COUNT + 1))/$MAX_HEALTH_RETRIES..."
             
@@ -1382,6 +1413,7 @@ jobs:
               sleep 15
             fi
           done
+          set -e
           
           # Final deployment status
           if [ "$VERSION_VERIFIED" = true ]; then
@@ -1555,22 +1587,32 @@ jobs:
           echo "📦 Image: $BUILDIMAGE:$BUILDTAG"
           echo "📋 Task Definition: $NEW_TASK_ARN"
           
-          # Wait for deployment to stabilize (P-Node: ALB drain + health checks can exceed default 40×15s; set +e preserves $? under bash -e)
-          echo "⏳ Waiting for service to stabilize (up to ~12.5 min at 50×15s)..."
+          # Wait for deployment to stabilize
+          # P-Node ECS lifecycle: stopTimeout + ALB drain + health checks can take several minutes.
+          # Enforce a 180s floor so health-check retries aren't wasted on the old task.
+          DEPLOY_WAIT_FLOOR_SECS=180
+          echo "⏳ Waiting for ECS service to stabilize (default waiter: up to 10 min at 40×15s)..."
+          WAIT_START=$(date +%s)
           set +e
           aws ecs wait services-stable \
             --cluster "$CLUSTER_NAME" \
             --services "$SERVICE_NAME" \
-            --max-attempts 50 \
             --cli-read-timeout 900 \
             --cli-connect-timeout 60
           STABILIZATION_STATUS=$?
+          WAIT_ELAPSED=$(( $(date +%s) - WAIT_START ))
           set -e
           
           if [ $STABILIZATION_STATUS -eq 0 ]; then
-            echo "✅ ECS service stabilized successfully"
+            echo "✅ ECS service stabilized after ${WAIT_ELAPSED}s"
           else
-            echo "⚠️ ECS stabilization wait timed out, but continuing with health check..."
+            echo "⚠️ ECS wait returned status $STABILIZATION_STATUS after ${WAIT_ELAPSED}s, continuing with health check..."
+          fi
+          
+          REMAINING=$(( DEPLOY_WAIT_FLOOR_SECS - WAIT_ELAPSED ))
+          if [ $REMAINING -gt 0 ]; then
+            echo "⏳ Ensuring minimum ${DEPLOY_WAIT_FLOOR_SECS}s deploy wait (sleeping ${REMAINING}s more)..."
+            sleep $REMAINING
           fi
           
           # Provider node health endpoint
@@ -1583,6 +1625,8 @@ jobs:
           HEALTH_RETRY_COUNT=0
           VERSION_VERIFIED=false
           
+          # Disable errexit for the health-check loop so curl timeouts (exit 28) don't kill the script
+          set +e
           while [ $HEALTH_RETRY_COUNT -lt $MAX_HEALTH_RETRIES ]; do
             echo "🔄 Health check attempt $((HEALTH_RETRY_COUNT + 1))/$MAX_HEALTH_RETRIES..."
             
@@ -1628,6 +1672,7 @@ jobs:
               sleep 15
             fi
           done
+          set -e
           
           # Final deployment status
           if [ "$VERSION_VERIFIED" = true ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1297,18 +1297,32 @@ jobs:
 
   Deploy-to-Morpheus-C-Node:
     name: Deploy to Morpheus Consumer via GitHub
+    # NOTE on `needs` + skipped dependencies:
+    # GitHub Actions' default job condition is implicit `success()`, which returns
+    # false when ANY needed job was skipped. P-Node is main-only (see its own `if`),
+    # so on a `test` deploy `Deploy-to-Morpheus-P-Node` is always skipped. Without
+    # an explicit `if` that tolerates that skip, the C-Node deploy gets skipped
+    # too — which is exactly what bit us on the first v7 test run: the drain job
+    # ran and deregistered the C-Node, then the actual deploy silently skipped,
+    # leaving dev without a replacement task.
+    #
+    # This `if` explicitly allows the skipped P-Node outcome, while still gating
+    # on drain + GHCR success and requiring we're on a deploy-eligible branch.
+    # `!cancelled()` keeps the guard working if a user cancels mid-run.
     if: |
+      !cancelled() &&
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      needs.GHCR-Build-and-Push.result == 'success' &&
+      needs.Drain-Morpheus-C-Node.result == 'success' &&
+      (needs.Deploy-to-Morpheus-P-Node.result == 'success' || needs.Deploy-to-Morpheus-P-Node.result == 'skipped') &&
       (
-        (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test'))||
+        (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true' && github.event.inputs.create_deployment == 'true')
       )
     needs:
       - Generate-Tag
       - GHCR-Build-and-Push
       - Drain-Morpheus-C-Node
-      # P-Node is main-only; on test this job is skipped and the `needs` is still
-      # satisfied (skipped jobs are treated as successful for dependency resolution).
       - Deploy-to-Morpheus-P-Node
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
         shell: bash
         run: |
           IMAGE_NAME="ghcr.io/morpheusais/morpheus-lumerin-node"
-          VMAJ_NEW=6
+          VMAJ_NEW=7
           VMIN_NEW=0
           VPAT_NEW=0
           set +o pipefail

--- a/docs/02.3-proxy-router-tee.md
+++ b/docs/02.3-proxy-router-tee.md
@@ -367,20 +367,50 @@ The output should match `measurements.intel_tdx.rtmr3` from the attestation mani
 
 ## What This Guarantees (and What It Doesn't)
 
-**Guarantees:**
-* The proxy-router binary is the exact binary built by the official CI/CD from a known commit
-* Chat context storage is disabled and cannot be re-enabled
-* Logging is in production mode and cannot be increased to capture prompts
-* The blockchain configuration (contracts, chain ID, blockscout URL) is immutable — frozen at build time for the target network (mainnet or testnet)
-* The image has not been tampered with between build and deployment
+TEE trust is a **two-hop chain**, with each hop attested separately. The on-chain `tee` tag on a model triggers both hops:
 
-**CI/CD automated verification:**
+```
+C-Node (v6.0.0+) ─────Phase 1─────▶ P-Node -tee image (v7.0.0+) ─────Phase 2─────▶ Backend LLM (SecretVM)
+```
+
+* **Phase 1** is what the **consumer's proxy-router** runs against the provider's P-Node. It has shipped since v6.0.0.
+* **Phase 2** is what the **provider's P-Node** (v7.0.0+) runs against its own backend LLM. The consumer never sees Phase 2 directly — it sees Phase 2 *indirectly*, because the v7+ `-tee` image it just attested in Phase 1 is the code that enforces Phase 2.
+* A v6.0.0+ consumer paired with a v7.0.0+ provider gets the full chain transparently — **no consumer-side upgrade is needed** to benefit from Phase 2.
+
+### Phase 1 — Consumer attests the P-Node (v6.0.0+)
+
+When a v6.0.0+ C-Node opens a session (and on every subsequent prompt) for a `tee`-tagged model, the consumer's proxy-router proves the following about the provider's P-Node:
+
+* The proxy-router binary is the exact binary built by the official CI/CD from a known commit (verified via cosign signature on the `-tee` image).
+* Chat context storage is disabled and cannot be re-enabled (baked in at image build; enforced by RTMR3).
+* Logging is in production mode and cannot be increased to capture prompts (baked in; enforced by RTMR3).
+* The blockchain configuration (contracts, chain ID, blockscout URL) is immutable — frozen at build time for the target network (mainnet or testnet).
+* The image has not been tampered with between build and deployment (RTMR3 replay of the published deployed compose against the live TDX quote).
+* The TLS certificate terminating the connection is pinned into the quote's `reportData[0:32]`, so no TLS-terminating proxy or CDN can sit between the consumer and the P-Node.
+* The check runs at session open and is re-checked on every prompt via a ~50 ms fast path (quote hash + TLS fingerprint compare); full re-verification kicks in on drift.
+
+### Phase 2 — P-Node attests its own backend LLM (v7.0.0+)
+
+Phase 2 runs **entirely inside the provider's P-Node**. The consumer does not participate. For each `tee`-tagged model, your v7+ P-Node proves the following about the backend LLM it forwards inference to:
+
+* The backend's CPU TDX quote is independently verified at startup (full `AttestBackend`) and re-checked on **every inference prompt** via the fast path (`FastVerifyBackend` — see [tee-backend-verification.md](../proxy-router/docs/tee-backend-verification.md)). Any quote or TLS drift triggers full re-attestation or a hard fail.
+* The backend's TLS certificate fingerprint is pinned into the CPU quote's `reportData[0:32]`, and the P-Node's onward HTTP client rejects any certificate that doesn't match — no MITM can slip between the P-Node and the backend.
+* The backend's GPU attestation nonce is bound to the CPU quote via `reportData[32:64]`, and GPU evidence is independently verified by **NVIDIA NRAS** (Remote Attestation Service) for genuine hardware.
+* The backend's `docker-compose.yaml` is recovered from `:29343/docker-compose` and **RTMR3 is replayed** against the live TDX quote, proving the exact set of models loaded (e.g., `MODELS='deepseek-r1:70b ...'`) — swapping, adding, or removing any model changes the hash and fails verification.
+* MRTD + RTMR0-2 are looked up in the published SecretVM TDX artifact registry to confirm firmware, VM config, kernel, and initramfs all match a known SecretVM build.
+* Per-model attestation state is exposed on the P-Node's `GET /v1/models/attestation` endpoint for monitoring and forensics.
+
+If Phase 2 fails, the P-Node refuses the session open or the individual prompt locally. The consumer observes this as a standard provider-side failure and can fail over to another provider.
+
+### CI/CD automated verification
+
 * On every push to `test` (or `cicd/*` branches), the pipeline automatically deploys the new TEE image to a test SecretVM instance and verifies the live RTMR3 attestation matches the CI-computed value. This catches measurement mismatches before they reach providers.
 
-**Current limitations (to be addressed in future phases):**
-* The model backend (LLM) that the proxy-router connects to is not yet attested separately. In future versions, the proxy-router and LLM will run in the same TEE VM.
-* Manual verification is required today for end-users. Future C-Node releases will automate this for models tagged `tee` on the blockchain — the consumer node will verify the provider's attestation before opening a session.
-* RTMR0-2 (firmware, kernel, initramfs layers) and AMD SEV-SNP measurements are not yet computed in CI/CD. RTMR3 (the software layer — our image + compose) is computed and published in the attestation manifest.
+### Remaining gaps (future work)
+
+* AMD SEV-SNP measurements are not yet computed in CI/CD. Only Intel TDX RTMR3 is published in the P-Node attestation manifest today.
+* Phase 2 backend verification assumes the LLM runs inside a separate SecretVM with the SecretAI attestation endpoints exposed on port `29343`. A future variant will co-locate proxy-router and LLM in a single TDX VM so one RTMR3 covers both hops.
+* Backend GPU attestation currently targets NVIDIA NRAS v4 API. Other GPU vendors / alternative attestation services are not yet plumbed in.
 
 ---
 

--- a/docs/02.4-proxy-router-secretvm-quickstart.md
+++ b/docs/02.4-proxy-router-secretvm-quickstart.md
@@ -175,7 +175,7 @@ You should see:
 ```json
 {
   "status": "healthy",
-  "version": "v6.0.0",
+  "version": "v7.0.0",
   "uptime": "1m30s"
 }
 ```
@@ -241,16 +241,42 @@ cosign verify-attestation \
 
 ---
 
-## What Consumers See
+## What Consumers See, and What Your P-Node Does
 
-When a consumer's C-Node (v6.0.0+) opens a session with your TEE-tagged model, it automatically:
+TEE verification is a **two-hop trust chain**. The consumer only talks to your P-Node; your P-Node is what reaches out to the backend LLM. Each hop is attested independently, and the on-chain `tee` tag is what turns both hops on.
 
-1. **Fetches your attestation quote** from `:29343/cpu`
-2. **Verifies the quote** via the SecretAI Portal — confirms genuine TEE hardware
-3. **Checks TLS binding** — compares the SHA-256 fingerprint of your TLS certificate against the `reportdata` in the quote, proving the quote belongs to your server (not replayed from elsewhere)
-4. **Compares RTMR3** against the CI/CD-signed golden values — confirms you're running the exact official image
+```
+C-Node (v6.0.0+)    ─verifies──▶    P-Node (your -tee image, v7.0.0+)    ─verifies──▶    Backend LLM (SecretVM)
+                    Phase 1                                               Phase 2
+```
 
-If any check fails, the session is rejected and no prompts are sent. This all happens transparently — the consumer doesn't need to do anything manually.
+### Hop 1 — Consumer (v6.0.0+) verifies your P-Node (Phase 1)
+
+When a consumer's C-Node opens a session with your `tee`-tagged model, the consumer's proxy-router automatically performs these checks against **your P-Node** at session open and on every prompt:
+
+1. **Fetches your P-Node's attestation quote** from `:29343/cpu`
+2. **Verifies the quote** via the SecretAI Portal — confirms genuine Intel TDX hardware
+3. **Checks TLS binding** — compares the SHA-256 fingerprint of your P-Node's TLS certificate against `reportData[0:32]` in the quote, proving the quote belongs to your server (not replayed from elsewhere)
+4. **Compares RTMR3** against the CI/CD-signed golden values published in the `-tee` image's cosign attestation manifest — confirms you're running the exact official `-tee` image
+5. **Fast-path re-check on every prompt** — a ~50 ms hash + TLS-fingerprint compare against the cached snapshot; any drift triggers full re-verification
+
+If any check fails, the consumer refuses to open the session or forward the prompt. This is fully handled inside the consumer's proxy-router (v6.0.0+) — the end user doesn't do anything manually.
+
+> **Forward compatibility:** a v6.0.0+ C-Node only needs to understand Phase 1 — Phase 2 is entirely your P-Node's job. This means **any v6+ consumer works with any v7+ provider**, gaining the Phase 2 guarantees automatically through the trust chain without a client-side upgrade.
+
+### Hop 2 — Your P-Node (v7.0.0+) verifies its own backend LLM (Phase 2)
+
+At startup and on every inference prompt, **your P-Node** (not the consumer) performs these checks against the backend LLM referenced by each `tee`-tagged model's `apiUrl`:
+
+1. **Fetches the backend's CPU quote** from `<apiUrl-host>:29343/cpu` and verifies it via the SecretAI Portal
+2. **TLS pinning** — compares the backend's TLS cert fingerprint against `reportData[0:32]` of its quote, and refuses any onward inference connection whose certificate doesn't match (no MITM can slip between the P-Node and the backend)
+3. **Workload RTMR3 replay** — pulls the backend's `docker-compose.yaml` via `:29343/docker-compose`, recomputes the SHA-384 extend chain using the rootfs data from the SecretVM TDX artifact registry, and compares against the RTMR3 reported in the backend's TDX quote — proving the exact set of models loaded (e.g., `MODELS='deepseek-r1:70b ...'`)
+4. **GPU attestation + CPU-GPU binding** — fetches GPU evidence from `:29343/gpu`, verifies `reportData[32:64]` of the CPU quote equals the GPU nonce (so the GPU evidence can't be replayed from another box), and submits the GPU evidence to **NVIDIA NRAS** for independent hardware validation
+5. **Per-prompt fast verify** — before every forwarded prompt, re-fetches `:29343/cpu` and compares the quote hash + TLS fingerprint against the cached snapshot; any change triggers full re-attestation, any TLS-cert change is a hard fail
+
+Results are also exposed on your P-Node's health endpoint at `GET /v1/models/attestation`, which reports per-model attestation state (`verified` / `pending` / `failed`), last-success timestamp, and workload verification result. This is useful both for your own monitoring and for any operator who wants to sanity-check the live state. Full developer reference: [proxy-router/docs/tee-backend-verification.md](../proxy-router/docs/tee-backend-verification.md).
+
+If Phase 2 fails for a `tee`-tagged model, your P-Node will not forward inference to that backend — the session open (or individual prompt) is refused locally. The consumer sees this as a normal provider-side failure.
 
 ---
 
@@ -262,7 +288,8 @@ If any check fails, the session is rejected and no prompts are sent. This all ha
 | Attestation quote empty | Port 29343 not exposed | SecretVM exposes this automatically — check your VM status |
 | RTMR3 mismatch | Wrong compose content or rootfs version | Ensure you're using the exact deployed compose from CI/CD artifacts (byte-for-byte) |
 | TLS binding fails | Using a proxy/CDN that terminates TLS | The consumer must connect directly to the SecretVM — no TLS-terminating intermediaries on port 29343 |
-| `tee` model not getting sessions | Consumers on older versions | Consumers need v6.0.0+ to be TEE-aware |
+| `tee` model not getting sessions | Consumers on older (pre-TEE) versions | Consumers need v6.0.0+ to perform Phase 1 (P-Node) attestation. v6+ consumers transparently gain Phase 2 guarantees by trusting a v7+ provider — no client-side upgrade is needed for Phase 2. |
+| Phase 2 failing silently on the consumer | Consumer isn't meant to run Phase 2 | Phase 2 (backend LLM attestation) is done **inside your P-Node**, not the consumer. Check your P-Node's `GET /v1/models/attestation` endpoint for per-model status. |
 
 ---
 

--- a/docs/03-provider-offer.md
+++ b/docs/03-provider-offer.md
@@ -47,7 +47,12 @@
         1. addStake: "modelMinStake": `100000000000000000`, (0.1 MOR) 
         1. Owner: Provider Wallet Address 
         1. name: Human Readable model like "Llama 2.0" or "Mistral 2.5" or "Collective Cognition 1.1" 
-        1. tags: array of tag strings for the model 
+        1. tags: array of tag strings for the model
+            - **TEE providers:** include the tag `"tee"` (case-insensitive) to opt this model into the full two-hop TEE trust chain. The tag turns on two independent verifications, one at each hop:
+                - **Phase 1 (consumer → your P-Node):** any v6.0.0+ consumer proxy-router will automatically verify your P-Node's TDX attestation (CPU quote, TLS cert pinning, RTMR3 of the `-tee` image) at session open and on every prompt before forwarding any inference.
+                - **Phase 2 (your P-Node → your backend LLM):** your v7.0.0+ P-Node will itself verify the backend LLM pointed to by the model's `apiUrl` — CPU TDX quote, TLS pinning, RTMR3 replay of the backend's `docker-compose.yaml`, CPU-GPU nonce binding, and NVIDIA NRAS GPU attestation — at startup and on every prompt. A v6+ consumer benefits from Phase 2 automatically by trusting your attested v7+ P-Node; the consumer itself does not talk to the backend.
+            - Models without the `tee` tag are treated as standard (non-TEE) providers — neither hop of the chain runs. See [02.3-proxy-router-tee.md](02.3-proxy-router-tee.md) and [02.4-proxy-router-secretvm-quickstart.md](02.4-proxy-router-secretvm-quickstart.md) for the full story.
+            - Other common tags include model-type hints: `llm`, `embedding`, `stt`, `tts`.
         1. Capture the `modelID` from the JSON response 
             **NOTE** The returned `modelID` is a combination of your requested modelID and your providerID and will be required to update your models-config.json file AND when offering bids
 

--- a/docs/models-config.json.md
+++ b/docs/models-config.json.md
@@ -9,6 +9,8 @@
 - `capacityPolicy` (optional) can be one of the following: "idle_timeout", "simple"
 - There maybe other variables that should be included in the model configuration. Please refer to the json-schema for descriptions and list of required and optional fields.
 
+> **TEE models:** there is **no `isTee` field in this file**. TEE verification is enabled per-model on the blockchain by adding the `"tee"` tag when the model is registered in the Diamond contract. Any v7+ proxy-router will automatically derive the backend attestation endpoints from the model's `apiUrl` host (port `29343`) and perform full Phase 1 + Phase 2 attestation whenever a `tee`-tagged model is used. See [03-provider-offer.md](03-provider-offer.md) for how to set the tag and [02.3-proxy-router-tee.md](02.3-proxy-router-tee.md) / [proxy-router/docs/tee-backend-verification.md](../proxy-router/docs/tee-backend-verification.md) for the full verification flow.
+
 ## Examples of models-config.json entries
 
 This file enables the morpheus-proxy-router to route requests to the correct model API. The model API can be hosted on the same server as the morpheus-proxy-router or on an external server. Please refer to the json-schema for descriptions and list of required and optional fields.

--- a/docs/proxy-router.all.env
+++ b/docs/proxy-router.all.env
@@ -103,3 +103,23 @@ SYS_TCP_MAX_SYN_BACKLOG=100000
 WEB_ADDRESS=0.0.0.0:8082
 # Public URL of the proxyrouter (falls back to http://Localhost:WEB_ADDRESS if not set)
 WEB_PUBLIC_URL=http://localhost:8082
+
+# TEE (Trusted Execution Environment) Configurations
+# These drive Phase 1 (P-node) and Phase 2 (backend LLM) attestation for any
+# model registered on-chain with the "tee" tag. See docs/02.3-proxy-router-tee.md
+# and proxy-router/docs/tee-backend-verification.md for full details.
+#
+# SecretAI Portal URL used to cryptographically verify raw TDX CPU quotes.
+# Required when any model in the market is "tee"-tagged; otherwise optional.
+TEE_PORTAL_URL=https://secretai.scrtlabs.com/api
+# GHCR image repo used by consumer-side P-node attestation to fetch the signed
+# golden attestation manifest (RTMR3 golden values, baked_env, etc.) via cosign.
+# Defaults to the mainnet TEE image repo; use the same repo for testnet (the
+# tag suffix distinguishes networks).
+TEE_IMAGE_REPO=ghcr.io/morpheusais/morpheus-lumerin-node-tee
+# URL for the SecretVM TDX artifact registry CSV used to look up MRTD + RTMR0-2
+# during backend workload verification. Defaults to the official SCRT Labs
+# registry and can be left blank to use the built-in default.
+ARTIFACT_REGISTRY_URL=https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/tdx.csv
+# How often the proxy-router re-downloads the artifact registry (default 1h).
+ARTIFACT_REGISTRY_REFRESH_INTERVAL=1h

--- a/proxy-router/cmd/main.go
+++ b/proxy-router/cmd/main.go
@@ -317,7 +317,7 @@ func start() error {
 
 	aiEngine := aiengine.NewAiEngine(proxyRouterApi, chatStorage, modelConfigLoader, agentConfigLoader, cfg.Proxy.LLMTimeout, appLog)
 
-	// Phase 2 TEE: create artifact registry and backend verifier
+	// TEE: create artifact registry and backend verifier
 	artifactRegistry := attestation.NewArtifactRegistry(
 		cfg.TEE.ArtifactRegistryURL,
 		cfg.TEE.ArtifactRegistryRefreshInterval,
@@ -331,7 +331,7 @@ func start() error {
 		artifactRegistry,
 		appLog.Named("BACKEND_TEE"),
 	)
-	// Startup pre-flight: attest models that have "tee-gpu" tag on-chain
+	// Startup pre-flight: attest models that have "tee" tag on-chain
 	modelIDs, modelConfigs := modelConfigLoader.GetAll()
 	for i, mc := range modelConfigs {
 		tags, err := blockchainApi.GetModelTags(context.Background(), modelIDs[i])
@@ -339,7 +339,7 @@ func start() error {
 			appLog.Debugf("cannot fetch model %s tags from blockchain: %s", modelIDs[i].Hex(), err)
 			continue
 		}
-		if !blockchainapi.IsTeeGPUModel(tags) {
+		if !blockchainapi.IsTeeModel(tags) {
 			continue
 		}
 		attestURL, err := attestation.DeriveAttestationURL(mc.ApiURL)

--- a/proxy-router/cmd/main.go
+++ b/proxy-router/cmd/main.go
@@ -316,6 +316,38 @@ func start() error {
 
 	aiEngine := aiengine.NewAiEngine(proxyRouterApi, chatStorage, modelConfigLoader, agentConfigLoader, cfg.Proxy.LLMTimeout, appLog)
 
+	// Phase 2 TEE: create artifact registry and backend verifier
+	artifactRegistry := attestation.NewArtifactRegistry(
+		cfg.TEE.ArtifactRegistryURL,
+		cfg.TEE.ArtifactRegistryRefreshInterval,
+		appLog.Named("ARTIFACT_REGISTRY"),
+	)
+	artifactRegistry.Start(context.Background())
+
+	backendVerifier := attestation.NewBackendVerifier(
+		cfg.TEE.PortalURL,
+		&attestation.NoopGoldenSource{},
+		artifactRegistry,
+		appLog.Named("BACKEND_TEE"),
+	)
+	aiEngine.SetBackendVerifier(backendVerifier)
+
+	// Startup pre-flight: attest all isTee models
+	modelIDs, modelConfigs := modelConfigLoader.GetAll()
+	for i, mc := range modelConfigs {
+		if !mc.IsTee {
+			continue
+		}
+		attestURL, err := attestation.DeriveAttestationURL(mc.ApiURL)
+		if err != nil {
+			appLog.Warnf("cannot derive attestation URL for model %s: %s", modelIDs[i].Hex(), err)
+			continue
+		}
+		if err := backendVerifier.AttestBackend(context.Background(), modelIDs[i].Hex(), attestURL); err != nil {
+			appLog.Warnf("startup backend attestation failed for model %s (%s): %s", modelIDs[i].Hex(), mc.ModelName, err)
+		}
+	}
+
 	eventListener := blockchainapi.NewEventsListener(sessionRepo, sessionRouter, wallet, logWatcher, appLog)
 
 	sessionExpiryHandler := blockchainapi.NewSessionExpiryHandler(blockchainApi, sessionStorage, wallet, appLog)
@@ -329,6 +361,7 @@ func start() error {
 		ipfsManager = proxyapi.NewIpfsManager(cfg.IPFS.Address, appLog)
 	}
 	proxyController := proxyapi.NewProxyController(proxyRouterApi, aiEngine, chatStorage, *cfg.Proxy.StoreChatContext.Bool, *cfg.Proxy.ForwardChatContext.Bool, *authCfg, ipfsManager, log)
+	proxyController.SetBackendAttestationStatus(backendVerifier)
 	walletController := walletapi.NewWalletController(wallet, *authCfg)
 	systemController := system.NewSystemController(&cfg, wallet, rpcClientStore, sysConfig, appStartTime, chainID, appLog, ethConnectionValidator, *authCfg, storage)
 	authController := authapi.NewAuthController(authCfg, cfg.Environment, appLog)
@@ -347,7 +380,7 @@ func start() error {
 
 	appLog.Infof("API docs available at %s/swagger/index.html", cfg.Web.PublicUrl)
 
-	proxy := proxyctl.NewProxyCtl(eventListener, wallet, chainID, appLog, tcpLog, cfg.Proxy.Address, sessionStorage, modelConfigLoader, valid, aiEngine, blockchainApi, sessionRepo, sessionExpiryHandler)
+	proxy := proxyctl.NewProxyCtl(eventListener, wallet, chainID, appLog, tcpLog, cfg.Proxy.Address, sessionStorage, modelConfigLoader, valid, aiEngine, blockchainApi, sessionRepo, sessionExpiryHandler, backendVerifier)
 	err = proxy.Run(ctx)
 
 	cancelServer()

--- a/proxy-router/cmd/main.go
+++ b/proxy-router/cmd/main.go
@@ -330,8 +330,6 @@ func start() error {
 		artifactRegistry,
 		appLog.Named("BACKEND_TEE"),
 	)
-	aiEngine.SetBackendVerifier(backendVerifier)
-
 	// Startup pre-flight: attest all isTee models
 	modelIDs, modelConfigs := modelConfigLoader.GetAll()
 	for i, mc := range modelConfigs {

--- a/proxy-router/cmd/main.go
+++ b/proxy-router/cmd/main.go
@@ -293,6 +293,7 @@ func start() error {
 	}
 
 	blockchainApi := blockchainapi.NewBlockchainService(ethClient, multicallBackend, *cfg.Marketplace.DiamondContractAddress, *cfg.Marketplace.MorTokenAddress, explorer, wallet, proxyRouterApi, sessionRepo, scorer, authCfg, appLog, rpcLog, cfg.Blockchain.EthLegacyTx, teeVerifier)
+	sessionRepo.SetModelTagsProvider(blockchainApi)
 	proxyRouterApi.SetSessionService(blockchainApi)
 	proxyRouterApi.SetAttestationVerifier(teeVerifier)
 	if teeVerifier != nil {
@@ -330,10 +331,15 @@ func start() error {
 		artifactRegistry,
 		appLog.Named("BACKEND_TEE"),
 	)
-	// Startup pre-flight: attest all isTee models
+	// Startup pre-flight: attest models that have "tee-gpu" tag on-chain
 	modelIDs, modelConfigs := modelConfigLoader.GetAll()
 	for i, mc := range modelConfigs {
-		if !mc.IsTee {
+		tags, err := blockchainApi.GetModelTags(context.Background(), modelIDs[i])
+		if err != nil {
+			appLog.Debugf("cannot fetch model %s tags from blockchain: %s", modelIDs[i].Hex(), err)
+			continue
+		}
+		if !blockchainapi.IsTeeGPUModel(tags) {
 			continue
 		}
 		attestURL, err := attestation.DeriveAttestationURL(mc.ApiURL)

--- a/proxy-router/docs/docs.go
+++ b/proxy-router/docs/docs.go
@@ -2986,6 +2986,33 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/models/attestation": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "Get backend TEE attestation status for all configured models",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/attestation.BackendAttestationSnapshot"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/wallet": {
             "get": {
                 "security": [
@@ -3191,6 +3218,70 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "attestation.BackendAttestationSnapshot": {
+            "type": "object",
+            "properties": {
+                "artifactsVersion": {
+                    "type": "string"
+                },
+                "attestationUrl": {
+                    "type": "string"
+                },
+                "dockerComposeHash": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "modelId": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/attestation.BackendAttestationStatus"
+                },
+                "teeType": {
+                    "$ref": "#/definitions/attestation.TEEType"
+                },
+                "verifiedAt": {
+                    "type": "string"
+                },
+                "vmTemplateName": {
+                    "type": "string"
+                },
+                "workloadStatus": {
+                    "type": "string"
+                }
+            }
+        },
+        "attestation.BackendAttestationStatus": {
+            "type": "string",
+            "enum": [
+                "passed",
+                "failed",
+                "unknown",
+                "expired"
+            ],
+            "x-enum-varnames": [
+                "StatusPassed",
+                "StatusFailed",
+                "StatusUnknown",
+                "StatusExpired"
+            ]
+        },
+        "attestation.TEEType": {
+            "type": "string",
+            "enum": [
+                "TDX",
+                "SEV"
+            ],
+            "x-enum-varnames": [
+                "TEETypeTDX",
+                "TEETypeSEV"
+            ]
         },
         "authapi.AddUserReq": {
             "type": "object",
@@ -3991,6 +4082,9 @@ const docTemplate = `{
             "properties": {
                 "ping": {
                     "type": "integer"
+                },
+                "version": {
+                    "type": "string"
                 }
             }
         },
@@ -4667,6 +4761,12 @@ const docTemplate = `{
         "system.HealthCheckResponse": {
             "type": "object",
             "properties": {
+                "components": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "status": {
                     "type": "string"
                 },

--- a/proxy-router/docs/swagger.json
+++ b/proxy-router/docs/swagger.json
@@ -2978,6 +2978,33 @@
                 }
             }
         },
+        "/v1/models/attestation": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "Get backend TEE attestation status for all configured models",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/attestation.BackendAttestationSnapshot"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/wallet": {
             "get": {
                 "security": [
@@ -3183,6 +3210,70 @@
                     "type": "string"
                 }
             }
+        },
+        "attestation.BackendAttestationSnapshot": {
+            "type": "object",
+            "properties": {
+                "artifactsVersion": {
+                    "type": "string"
+                },
+                "attestationUrl": {
+                    "type": "string"
+                },
+                "dockerComposeHash": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "modelId": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/attestation.BackendAttestationStatus"
+                },
+                "teeType": {
+                    "$ref": "#/definitions/attestation.TEEType"
+                },
+                "verifiedAt": {
+                    "type": "string"
+                },
+                "vmTemplateName": {
+                    "type": "string"
+                },
+                "workloadStatus": {
+                    "type": "string"
+                }
+            }
+        },
+        "attestation.BackendAttestationStatus": {
+            "type": "string",
+            "enum": [
+                "passed",
+                "failed",
+                "unknown",
+                "expired"
+            ],
+            "x-enum-varnames": [
+                "StatusPassed",
+                "StatusFailed",
+                "StatusUnknown",
+                "StatusExpired"
+            ]
+        },
+        "attestation.TEEType": {
+            "type": "string",
+            "enum": [
+                "TDX",
+                "SEV"
+            ],
+            "x-enum-varnames": [
+                "TEETypeTDX",
+                "TEETypeSEV"
+            ]
         },
         "authapi.AddUserReq": {
             "type": "object",
@@ -3983,6 +4074,9 @@
             "properties": {
                 "ping": {
                     "type": "integer"
+                },
+                "version": {
+                    "type": "string"
                 }
             }
         },
@@ -4659,6 +4753,12 @@
         "system.HealthCheckResponse": {
             "type": "object",
             "properties": {
+                "components": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "status": {
                     "type": "string"
                 },

--- a/proxy-router/docs/swagger.yaml
+++ b/proxy-router/docs/swagger.yaml
@@ -55,6 +55,51 @@ definitions:
       type:
         type: string
     type: object
+  attestation.BackendAttestationSnapshot:
+    properties:
+      artifactsVersion:
+        type: string
+      attestationUrl:
+        type: string
+      dockerComposeHash:
+        type: string
+      error:
+        type: string
+      expiresAt:
+        type: string
+      modelId:
+        type: string
+      status:
+        $ref: '#/definitions/attestation.BackendAttestationStatus'
+      teeType:
+        $ref: '#/definitions/attestation.TEEType'
+      verifiedAt:
+        type: string
+      vmTemplateName:
+        type: string
+      workloadStatus:
+        type: string
+    type: object
+  attestation.BackendAttestationStatus:
+    enum:
+    - passed
+    - failed
+    - unknown
+    - expired
+    type: string
+    x-enum-varnames:
+    - StatusPassed
+    - StatusFailed
+    - StatusUnknown
+    - StatusExpired
+  attestation.TEEType:
+    enum:
+    - TDX
+    - SEV
+    type: string
+    x-enum-varnames:
+    - TEETypeTDX
+    - TEETypeSEV
   authapi.AddUserReq:
     properties:
       password:
@@ -589,6 +634,8 @@ definitions:
     properties:
       ping:
         type: integer
+      version:
+        type: string
     type: object
   proxyapi.PinnedFileRes:
     properties:
@@ -1040,6 +1087,10 @@ definitions:
     type: object
   system.HealthCheckResponse:
     properties:
+      components:
+        additionalProperties:
+          type: string
+        type: object
       status:
         type: string
       uptime:
@@ -2945,6 +2996,22 @@ paths:
       security:
       - BasicAuth: []
       summary: Get local models
+      tags:
+      - system
+  /v1/models/attestation:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/attestation.BackendAttestationSnapshot'
+            type: array
+      security:
+      - BasicAuth: []
+      summary: Get backend TEE attestation status for all configured models
       tags:
       - system
   /wallet:

--- a/proxy-router/docs/tee-backend-verification.md
+++ b/proxy-router/docs/tee-backend-verification.md
@@ -1,0 +1,258 @@
+# TEE Backend Verification
+
+## Overview
+
+The TEE (Trusted Execution Environment) Backend Verification system provides cryptographic proof that AI inference requests are processed inside authentic, unmodified SecretVM instances running on genuine Intel TDX and NVIDIA GPU hardware. It operates in two modes:
+
+- **Full attestation** (`AttestBackend`) runs at startup and whenever the fast verify detects a backend change. It performs end-to-end cryptographic verification of the backend's CPU TEE quote, GPU attestation evidence, workload integrity, and TLS binding.
+- **Fast verification** (`FastVerifyBackend`) runs on every inference prompt. It always re-fetches the CPU quote and compares its hash and TLS fingerprint against the cached attestation snapshot. If the quote changes, it triggers full re-attestation. There is no TTL -- the fast check runs on every request unconditionally.
+
+Together, these ensure that every inference request reaches a verified, tamper-proof backend -- from the hardware root of trust down to the specific AI models loaded inside the TEE.
+
+## Security Guarantees
+
+The verification system proves the following properties:
+
+- **Hardware authenticity** -- The backend runs inside a genuine Intel TDX confidential VM with a hardware-signed attestation quote that chains back to Intel's root of trust.
+- **Firmware and OS integrity** -- The measured boot chain (MRTD, RTMR0-2) matches entries in the SecretVM artifact registry, confirming the VM runs an authentic, unmodified SecretVM image.
+- **Workload integrity** -- RTMR3 is recalculated from the backend's `docker-compose.yaml` and root filesystem data, proving the exact workload configuration running inside the TEE has not been altered.
+- **Model identity** -- The `docker-compose.yaml` declares which AI models are loaded. Because RTMR3 covers this file byte-for-byte, swapping, adding, or removing any model changes the hash and fails verification.
+- **TLS channel binding** -- The TLS certificate fingerprint is embedded in the CPU quote's `reportData`, binding the attested environment to a specific TLS identity. This prevents man-in-the-middle attacks: inference data can only reach the attested endpoint.
+- **CPU-GPU binding** -- The GPU attestation nonce is embedded in the second half of the CPU `reportData`, cryptographically linking the GPU evidence to the same CPU TEE quote and preventing GPU attestation replay.
+- **GPU hardware authenticity** -- GPU attestation evidence is independently verified by NVIDIA's Remote Attestation Service (NRAS), confirming the GPU hardware is genuine and uncompromised.
+- **Continuous verification** -- Every inference prompt triggers a fast re-check of the backend's identity. TLS fingerprint or quote changes between attestations are detected immediately.
+
+## Verification Checks
+
+| # | Check | What It Proves | Failure Meaning |
+|---|-------|---------------|-----------------|
+| 1 | CPU quote fetch and portal verification | The backend runs in an Intel TDX TEE; the quote is cryptographically valid | Backend is not running in a TEE, or the quote is forged |
+| 2 | TLS binding (reportData first 32 bytes = TLS cert fingerprint) | The TLS channel terminates inside the attested TEE | Possible MITM -- traffic may be intercepted before reaching the TEE |
+| 3 | Workload verification -- MRTD + RTMR0-2 registry lookup | The VM firmware, config, kernel, and initramfs match a known SecretVM build | The VM image has been modified or is not an authentic SecretVM |
+| 4 | Workload verification -- RTMR3 recalculation | The exact `docker-compose.yaml` and rootfs running inside the TEE match expectations | The workload has been tampered with (different models, altered config) |
+| 5 | GPU attestation fetch | The backend exposes GPU attestation evidence | No GPU attestation available; GPU integrity unknown |
+| 6 | CPU-GPU binding (reportData second 32 bytes = GPU nonce) | The GPU evidence was generated in the same session as the CPU quote | GPU attestation may be replayed from a different machine |
+| 7 | NVIDIA NRAS verification | NVIDIA independently confirms the GPU hardware and certificate chain | GPU hardware is not genuine, or evidence has been tampered with |
+| 8 | Per-prompt fast verify (always re-fetches /cpu, compares quote hash + TLS fingerprint) | The backend identity has not changed since initial attestation | The backend may have been restarted, replaced, or compromised |
+
+## Full Attestation Flow
+
+The `AttestBackend` method orchestrates the complete verification sequence at startup and whenever the fast verify detects a change in the backend's CPU quote.
+
+```mermaid
+sequenceDiagram
+    participant P as Proxy-Router (PNode)
+    participant B as Backend SecretVM
+    participant S as SecretAI Portal
+    participant R as Artifact Registry
+    participant N as NVIDIA NRAS
+
+    Note over P: AttestBackend begins
+
+    P->>B: GET :29343/cpu
+    B-->>P: CPU attestation quote (TDX)
+
+    P->>S: POST /quote-parse (CPU quote)
+    S-->>P: Verification result (valid/invalid)
+
+    Note over P: Extract TLS cert fingerprint<br/>Compare with reportData[0:32]
+
+    alt Artifact Registry loaded
+        P->>B: GET :29343/docker-compose
+        B-->>P: docker-compose.yaml
+
+        Note over P: Parse TDX quote:<br/>extract MRTD, RTMR0-3
+
+        P->>R: Lookup MRTD + RTMR0-2
+        R-->>P: Matching registry entries + rootfs_data
+
+        Note over P: Calculate expected RTMR3:<br/>SHA-384 extend chain of<br/>SHA-256(docker-compose) + rootfs_data
+
+        Note over P: Compare calculated RTMR3<br/>vs quote RTMR3
+    end
+
+    P->>B: GET :29343/gpu
+    B-->>P: GPU attestation JSON (nonce, arch, evidence_list)
+
+    Note over P: Verify reportData[32:64] == GPU nonce<br/>(CPU-GPU binding)
+
+    alt NRAS configured
+        P->>N: POST /v2/attest/gpu (evidence)
+        N-->>P: JWT Entity Attestation Token
+    end
+
+    Note over P: Cache attestation snapshot<br/>(quote hash, TLS fingerprint)
+```
+
+### Step-by-Step
+
+1. **Fetch CPU quote** -- The proxy-router requests the raw TDX attestation quote from the backend's attestation port (`:29343/cpu`).
+2. **Verify CPU quote** -- The quote is sent to the SecretAI Portal's `quote-parse` API, which performs cryptographic verification against Intel's root of trust.
+3. **TLS binding** -- The proxy-router extracts the TLS certificate fingerprint from the connection and compares it to the first 32 bytes of the quote's `reportData` field. A match proves the TLS endpoint is inside the attested TEE.
+4. **Workload verification** (if artifact registry is loaded):
+   - Fetch `docker-compose.yaml` from the backend.
+   - Parse the TDX quote to extract measurement registers (MRTD, RTMR0-3).
+   - Look up MRTD + RTMR0-2 in the artifact registry to confirm this is a recognized SecretVM build.
+   - Recalculate the expected RTMR3 from `SHA-256(docker-compose.yaml)` combined with `rootfs_data` using a SHA-384 extend chain.
+   - Compare the calculated RTMR3 against the quote's RTMR3 to prove workload integrity.
+5. **Fetch GPU attestation** -- Retrieve GPU attestation data (JSON containing nonce, architecture, and evidence list) from `:29343/gpu`.
+6. **CPU-GPU binding** -- Verify that the second 32 bytes of the CPU `reportData` match the GPU nonce, proving both attestations originate from the same machine and session.
+7. **NRAS verification** (if configured) -- Submit GPU evidence to NVIDIA's Remote Attestation Service for independent hardware validation. NRAS returns a signed JWT (Entity Attestation Token) confirming GPU authenticity.
+8. **Cache snapshot** -- Store the attestation result (quote hash, TLS fingerprint, workload status) for use by the fast verification path. The cache has no TTL -- it remains valid as long as the backend's CPU quote and TLS certificate haven't changed.
+
+## Trust Chain
+
+The TDX trust chain starts at the hardware and extends through each layer of the boot process up to the running workload.
+
+```mermaid
+flowchart TD
+    HW[TEE Hardware<br/>Intel TDX CPU] --> MRTD[MRTD<br/>VM firmware measurement]
+    MRTD --> RTMR0[RTMR0<br/>VM configuration]
+    RTMR0 --> RTMR1[RTMR1<br/>Kernel]
+    RTMR1 --> RTMR2[RTMR2<br/>Initramfs]
+    RTMR2 --> RTMR3[RTMR3<br/>Rootfs + docker-compose.yaml]
+    RTMR3 --> DC[docker-compose.yaml<br/>defines MODELS env var]
+    DC --> MI[Model Identity Proven<br/>e.g. deepseek-r1:70b, llama3.3:70b]
+
+    HW --> RD[reportData<br/>64 bytes in CPU quote]
+    RD --> RD1[Bytes 0-31<br/>TLS certificate fingerprint]
+    RD --> RD2[Bytes 32-63<br/>GPU attestation nonce]
+    RD1 --> TLS[TLS Channel Binding<br/>Inference traffic pinned to TEE]
+    RD2 --> GPU[CPU-GPU Binding<br/>GPU evidence tied to CPU quote]
+
+    style HW fill:#2d5016,color:#fff
+    style RTMR3 fill:#1a3a5c,color:#fff
+    style MI fill:#1a3a5c,color:#fff
+    style TLS fill:#5c1a1a,color:#fff
+    style GPU fill:#5c1a1a,color:#fff
+```
+
+### Measurement Registers
+
+| Register | Contents | Verified By |
+|----------|----------|-------------|
+| MRTD | VM firmware hash (set at launch, immutable) | Artifact registry lookup |
+| RTMR0 | VM configuration | Artifact registry lookup |
+| RTMR1 | Kernel measurement | Artifact registry lookup |
+| RTMR2 | Initramfs measurement | Artifact registry lookup |
+| RTMR3 | Root filesystem + docker-compose.yaml | Recalculated and compared |
+
+### reportData Layout
+
+| Byte Range | Contents | Purpose |
+|------------|----------|---------|
+| 0 -- 31 | SHA-256 of TLS certificate | Binds attested TEE to a specific TLS identity |
+| 32 -- 63 | GPU attestation nonce | Links GPU evidence to this CPU attestation |
+
+## Per-Prompt Fast Verify
+
+Every inference prompt for a TEE-marked model triggers `FastVerifyBackend` before the request is forwarded. This keeps verification latency low (approximately 50ms) while maintaining continuous assurance.
+
+```mermaid
+flowchart TD
+    START[Inference prompt received] --> CACHE{Attestation cache<br/>exists?}
+    CACHE -- No --> REJECT[Error: model not attested]
+    CACHE -- Yes --> STATUS{Status is passed?}
+    STATUS -- No --> REJECT2[Error: attestation failed]
+    STATUS -- Yes --> FETCH[Re-fetch CPU quote<br/>from :29343/cpu]
+    FETCH --> HASH[Compute SHA-256<br/>of fetched quote]
+    HASH --> CMP_HASH{Quote hash matches<br/>cached hash?}
+    CMP_HASH -- No --> FULL[Run full AttestBackend<br/>Backend has changed]
+    CMP_HASH -- Yes --> CMP_TLS{TLS cert fingerprint<br/>matches cached<br/>fingerprint?}
+    CMP_TLS -- No --> ERR[Immediate error<br/>Possible MITM detected]
+    CMP_TLS -- Yes --> PASS[Verification passed<br/>Forward inference request]
+    FULL --> PASS
+```
+
+### Fast Verify Logic
+
+There is no TTL or cache expiry. The fast verify runs the same check on every prompt unconditionally:
+
+1. **Cache check** -- If no cached attestation exists (model was never attested), reject the request.
+2. **Status check** -- If the cached status is `failed`, reject the request.
+3. **Re-fetch CPU quote** -- Always request the current CPU quote from `:29343/cpu` (~50ms TLS handshake).
+4. **Hash comparison** -- Compute `SHA-256` of the fetched quote and compare against the cached hash. A mismatch indicates the backend has changed (restart, redeployment) and triggers full re-attestation.
+5. **TLS fingerprint comparison** -- Verify the current connection's TLS certificate fingerprint matches the cached value. A mismatch is treated as a critical error (possible MITM attack) and the request is rejected immediately.
+6. **Pass** -- If both checks succeed, the inference request proceeds to the backend.
+
+As long as the backend hasn't changed (same quote, same TLS cert), the fast path always passes without needing to re-run the expensive full attestation. Full re-attestation only triggers when something actually changes.
+
+## Model Identity Guarantee
+
+The `docker-compose.yaml` inside a SecretVM backend declares the AI models to be loaded via the `MODELS` environment variable:
+
+```yaml
+MODELS='deepseek-r1:70b gemma3:4b llama3.2-vision llama3.3:70b qwen3:8b'
+```
+
+RTMR3 is computed as a SHA-384 extend chain covering the root filesystem data and `SHA-256(docker-compose.yaml)`. This means:
+
+- Changing any byte of `docker-compose.yaml` -- swapping `qwen3:8b` for a different model, altering a port binding, modifying an environment variable -- produces a different RTMR3 value.
+- The TDX hardware enforces that measurement registers reflect the actual loaded software. Values cannot be faked or overridden from within the VM.
+- The proxy-router independently recalculates the expected RTMR3 and compares it against the hardware-reported value. Any discrepancy fails verification.
+
+This provides a cryptographic guarantee that the backend is running exactly the declared set of models, with no substitutions or additions.
+
+## Configuration Reference
+
+### Model Configuration (`models-config.json`)
+
+Each model entry supports the following TEE-related field:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `isTee` | `boolean` | When `true`, enables TEE verification for this model. The attestation URL is always derived from the `apiUrl` host with port `29343`. |
+
+Example:
+
+```json
+{
+  "modelName": "deepseek-r1:70b",
+  "apiUrl": "https://backend.example.com:8080/v1",
+  "isTee": true
+}
+```
+
+With `apiUrl` set to `https://backend.example.com:8080/v1`, the attestation endpoints are automatically resolved to `https://backend.example.com:29343/cpu`, `https://backend.example.com:29343/gpu`, and `https://backend.example.com:29343/docker-compose`.
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `TEE_PORTAL_URL` | Yes (for TEE models) | -- | SecretAI Portal API URL for CPU quote verification |
+| `ARTIFACT_REGISTRY_URL` | No | [default registry](https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/tdx.csv) | URL to the TDX artifact registry CSV file. The default points to the official SecretVM artifact registry maintained by SCRT Labs |
+| `ARTIFACT_REGISTRY_REFRESH_INTERVAL` | No | `1h` | How often to re-download the artifact registry |
+
+## Health Endpoint
+
+```
+GET /v1/models/attestation
+```
+
+Returns the current attestation status for each TEE-enabled model. The response includes:
+
+- Attestation state (verified, pending, failed)
+- Timestamp of last successful attestation
+- Workload verification result (`authentic_match`, `authentic_mismatch`, `not_authentic`)
+- Error details if verification failed
+
+Use this endpoint for monitoring and operational visibility into the TEE verification state.
+
+## Architecture
+
+All TEE verification code resides in `internal/attestation/`:
+
+| File | Component | Responsibility |
+|------|-----------|---------------|
+| `backend_verifier.go` | `BackendVerifier` | Orchestrates `AttestBackend` (full verification) and `FastVerifyBackend` (per-prompt check) |
+| `workload_verifier.go` | `WorkloadVerifier` | Verifies workload integrity: registry lookup, RTMR3 recalculation, docker-compose validation |
+| `artifacts_registry.go` | `ArtifactRegistry` | Downloads and caches the TDX artifact registry CSV; refreshes on a configurable interval |
+| `nras_verifier.go` | `NrasVerifier` | Sends GPU evidence to NVIDIA NRAS and validates the returned JWT Entity Attestation Tokens |
+| `tdx_quote.go` | TDX quote parsing | Parses raw TDX quotes to extract MRTD, RTMR0-3, and reportData |
+| `rtmr.go` | RTMR calculation | Implements the SHA-384 extend chain used to calculate expected RTMR3 values |
+| `verifier.go` | General verification | Core attestation verification logic and types |
+
+### Integration Points
+
+- **`ProxyReceiver.SessionPrompt`** -- Calls `FastVerifyBackend` before forwarding each inference request for TEE-marked models. This is the per-prompt hot path.
+- **`AiEngine.GetAdapter`** -- Returns a `PinnedHTTPClient` for TEE models. The pinned client uses a custom `VerifyPeerCertificate` callback that rejects any TLS certificate whose fingerprint does not match the attested value. This ensures inference data cannot be routed to an unattested endpoint.

--- a/proxy-router/docs/tee-backend-verification.md
+++ b/proxy-router/docs/tee-backend-verification.md
@@ -1,13 +1,28 @@
-# TEE Backend Verification
+# TEE Backend Verification (Phase 2)
+
+## Where this fits in the trust chain
+
+Morpheus TEE trust is a **two-hop chain**:
+
+```
+C-Node (v6.0.0+) ──── Phase 1 ────▶ P-Node -tee image (v7.0.0+) ──── Phase 2 ────▶ Backend LLM (SecretVM)
+                      (consumer                                      (this document)
+                       verifies                                       P-Node verifies
+                       P-Node)                                        its own backend
+```
+
+This document describes **Phase 2 only** — the verification performed **by the P-Node** (the provider's proxy-router running inside its own TEE) **against its backend LLM**. Phase 1 (consumer verifying the P-Node) is documented in [`docs/02.3-proxy-router-tee.md`](../../docs/02.3-proxy-router-tee.md).
+
+Phase 2 is entirely self-contained inside the P-Node: the consumer never talks to the backend LLM directly and never sees the backend's attestation quote. The consumer trusts Phase 2 transitively, because it has already attested (in Phase 1) that the P-Node is running the exact `-tee` binary that implements Phase 2 faithfully. This is why **a v6.0.0+ consumer paired with a v7.0.0+ provider gains all Phase 2 guarantees without any client-side change**.
 
 ## Overview
 
-The TEE (Trusted Execution Environment) Backend Verification system provides cryptographic proof that AI inference requests are processed inside authentic, unmodified SecretVM instances running on genuine Intel TDX and NVIDIA GPU hardware. It operates in two modes:
+The Phase 2 Backend Verification system provides cryptographic proof that AI inference requests forwarded by this P-Node are processed inside authentic, unmodified SecretVM instances running on genuine Intel TDX and NVIDIA GPU hardware. It operates in two modes:
 
 - **Full attestation** (`AttestBackend`) runs at startup and whenever the fast verify detects a backend change. It performs end-to-end cryptographic verification of the backend's CPU TEE quote, GPU attestation evidence, workload integrity, and TLS binding.
 - **Fast verification** (`FastVerifyBackend`) runs on every inference prompt. It always re-fetches the CPU quote and compares its hash and TLS fingerprint against the cached attestation snapshot. If the quote changes, it triggers full re-attestation. There is no TTL -- the fast check runs on every request unconditionally.
 
-Together, these ensure that every inference request reaches a verified, tamper-proof backend -- from the hardware root of trust down to the specific AI models loaded inside the TEE.
+Together, these ensure that every inference request forwarded by this P-Node reaches a verified, tamper-proof backend -- from the hardware root of trust down to the specific AI models loaded inside the TEE.
 
 ## Security Guarantees
 
@@ -195,31 +210,44 @@ This provides a cryptographic guarantee that the backend is running exactly the 
 
 ## Configuration Reference
 
-### Model Configuration (`models-config.json`)
+### Model Tagging (on-chain)
 
-Each model entry supports the following TEE-related field:
+TEE verification is enabled **per-model on the blockchain**, not in the local `models-config.json`. When a model is registered in the Diamond contract with the `tee` tag (case-insensitive) in its `tags` array, the proxy-router automatically:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `isTee` | `boolean` | When `true`, enables TEE verification for this model. The attestation URL is always derived from the `apiUrl` host with port `29343`. |
+- On the **provider** side: performs full `AttestBackend` against that model's `apiUrl` host at startup, and runs `FastVerifyBackend` on every inference prompt (see [Per-Prompt Fast Verify](#per-prompt-fast-verify)).
+- On the **consumer** side: runs `VerifyProviderQuick` against the provider's P-node at session open and on every prompt, refusing to forward inference if attestation fails.
 
-Example:
+Tag detection is implemented in `internal/blockchainapi/model_tags.go`:
 
-```json
-{
-  "modelName": "deepseek-r1:70b",
-  "apiUrl": "https://backend.example.com:8080/v1",
-  "isTee": true
+```go
+func IsTeeModel(tags []string) bool {
+    for _, raw := range tags {
+        if strings.ToLower(raw) == "tee" {
+            return true
+        }
+    }
+    return false
 }
 ```
 
-With `apiUrl` set to `https://backend.example.com:8080/v1`, the attestation endpoints are automatically resolved to `https://backend.example.com:29343/cpu`, `https://backend.example.com:29343/gpu`, and `https://backend.example.com:29343/docker-compose`.
+No `isTee` field is required (or accepted) in `models-config.json` — the `models-config-schema.json` does not declare one. The only model-config values that matter for TEE are `modelId` (which the proxy-router uses to look up the on-chain tags) and `apiUrl` (the backend LLM endpoint).
+
+### Backend Attestation Endpoint Derivation
+
+Attestation endpoints are derived from the model's `apiUrl` host with port `29343` (the standard SecretVM attestation port).
+
+Example: a model registered on-chain with the `tee` tag and `apiUrl` set to `https://backend.example.com:8080/v1` will be attested against:
+
+- `https://backend.example.com:29343/cpu` — TDX CPU quote
+- `https://backend.example.com:29343/gpu` — GPU attestation evidence
+- `https://backend.example.com:29343/docker-compose` — backend's compose file for RTMR3 replay
 
 ### Environment Variables
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `TEE_PORTAL_URL` | Yes (for TEE models) | -- | SecretAI Portal API URL for CPU quote verification |
+| `TEE_PORTAL_URL` | Yes (for `tee`-tagged models) | -- | SecretAI Portal API URL for CPU quote verification |
+| `TEE_IMAGE_REPO` | No | -- | GHCR image repo for cosign attestation manifest verification (e.g. `ghcr.io/morpheusais/morpheus-lumerin-node-tee`). Used by consumer-side P-node attestation to fetch the signed golden RTMR3 values for the provider image |
 | `ARTIFACT_REGISTRY_URL` | No | [default registry](https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/tdx.csv) | URL to the TDX artifact registry CSV file. The default points to the official SecretVM artifact registry maintained by SCRT Labs |
 | `ARTIFACT_REGISTRY_REFRESH_INTERVAL` | No | `1h` | How often to re-download the artifact registry |
 

--- a/proxy-router/internal/aiengine/ai_engine.go
+++ b/proxy-router/internal/aiengine/ai_engine.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"time"
 
 	gcs "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/chatstorage/genericchatstorage"
@@ -16,17 +15,11 @@ import (
 	mcp "github.com/mark3labs/mcp-go/mcp"
 )
 
-// BackendVerifier provides TLS-pinned HTTP clients for TEE-attested backends.
-type BackendVerifier interface {
-	PinnedHTTPClient(modelID string) (*http.Client, error)
-}
-
 type AiEngine struct {
 	modelsConfigLoader *config.ModelConfigLoader
 	agentsConfigLoader *config.AgentConfigLoader
 	service            ProxyService
 	storage            gcs.ChatStorageInterface
-	backendVerifier    BackendVerifier
 	llmTimeout         time.Duration
 	log                lib.ILogger
 }
@@ -58,11 +51,6 @@ func NewAiEngine(service ProxyService, storage gcs.ChatStorageInterface, modelsC
 	}
 }
 
-// SetBackendVerifier sets the backend TEE verifier for TLS-pinned connections.
-func (a *AiEngine) SetBackendVerifier(bv BackendVerifier) {
-	a.backendVerifier = bv
-}
-
 func (a *AiEngine) GetAdapter(ctx context.Context, chatID, modelID, sessionID common.Hash, storeChatContext, forwardChatContext bool) (AIEngineStream, error) {
 	var engine AIEngineStream
 	if sessionID == (common.Hash{}) {
@@ -72,17 +60,8 @@ func (a *AiEngine) GetAdapter(ctx context.Context, chatID, modelID, sessionID co
 			return nil, fmt.Errorf("model not found: %s", modelID.Hex())
 		}
 
-		var httpClient *http.Client
-		if modelConfig.IsTee && a.backendVerifier != nil {
-			var err error
-			httpClient, err = a.backendVerifier.PinnedHTTPClient(modelID.Hex())
-			if err != nil {
-				a.log.Warnf("failed to get pinned HTTP client for TEE model %s, using default: %s", modelID.Hex(), err)
-			}
-		}
-
 		var ok bool
-		engine, ok = ApiAdapterFactory(modelConfig.ApiType, modelConfig.ModelName, modelConfig.ApiURL, modelConfig.ApiKey, modelConfig.Parameters, a.llmTimeout, a.log, httpClient)
+		engine, ok = ApiAdapterFactory(modelConfig.ApiType, modelConfig.ModelName, modelConfig.ApiURL, modelConfig.ApiKey, modelConfig.Parameters, a.llmTimeout, a.log, nil)
 		if !ok {
 			return nil, fmt.Errorf("api adapter not found: %s", modelConfig.ApiType)
 		}

--- a/proxy-router/internal/aiengine/ai_engine.go
+++ b/proxy-router/internal/aiengine/ai_engine.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	gcs "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/chatstorage/genericchatstorage"
@@ -15,11 +16,17 @@ import (
 	mcp "github.com/mark3labs/mcp-go/mcp"
 )
 
+// BackendVerifier provides TLS-pinned HTTP clients for TEE-attested backends.
+type BackendVerifier interface {
+	PinnedHTTPClient(modelID string) (*http.Client, error)
+}
+
 type AiEngine struct {
 	modelsConfigLoader *config.ModelConfigLoader
 	agentsConfigLoader *config.AgentConfigLoader
 	service            ProxyService
 	storage            gcs.ChatStorageInterface
+	backendVerifier    BackendVerifier
 	llmTimeout         time.Duration
 	log                lib.ILogger
 }
@@ -51,6 +58,11 @@ func NewAiEngine(service ProxyService, storage gcs.ChatStorageInterface, modelsC
 	}
 }
 
+// SetBackendVerifier sets the backend TEE verifier for TLS-pinned connections.
+func (a *AiEngine) SetBackendVerifier(bv BackendVerifier) {
+	a.backendVerifier = bv
+}
+
 func (a *AiEngine) GetAdapter(ctx context.Context, chatID, modelID, sessionID common.Hash, storeChatContext, forwardChatContext bool) (AIEngineStream, error) {
 	var engine AIEngineStream
 	if sessionID == (common.Hash{}) {
@@ -59,8 +71,18 @@ func (a *AiEngine) GetAdapter(ctx context.Context, chatID, modelID, sessionID co
 		if modelConfig == nil {
 			return nil, fmt.Errorf("model not found: %s", modelID.Hex())
 		}
+
+		var httpClient *http.Client
+		if modelConfig.IsTee && a.backendVerifier != nil {
+			var err error
+			httpClient, err = a.backendVerifier.PinnedHTTPClient(modelID.Hex())
+			if err != nil {
+				a.log.Warnf("failed to get pinned HTTP client for TEE model %s, using default: %s", modelID.Hex(), err)
+			}
+		}
+
 		var ok bool
-		engine, ok = ApiAdapterFactory(modelConfig.ApiType, modelConfig.ModelName, modelConfig.ApiURL, modelConfig.ApiKey, modelConfig.Parameters, a.llmTimeout, a.log)
+		engine, ok = ApiAdapterFactory(modelConfig.ApiType, modelConfig.ModelName, modelConfig.ApiURL, modelConfig.ApiKey, modelConfig.Parameters, a.llmTimeout, a.log, httpClient)
 		if !ok {
 			return nil, fmt.Errorf("api adapter not found: %s", modelConfig.ApiType)
 		}

--- a/proxy-router/internal/aiengine/claudeai.go
+++ b/proxy-router/internal/aiengine/claudeai.go
@@ -75,15 +75,18 @@ type ClaudeAI struct {
 	log        lib.ILogger
 }
 
-func NewClaudeAIEngine(modelName, baseURL, apiKey string, llmTimeout time.Duration, log lib.ILogger) *ClaudeAI {
+func NewClaudeAIEngine(modelName, baseURL, apiKey string, llmTimeout time.Duration, log lib.ILogger, httpClient *http.Client) *ClaudeAI {
 	if baseURL != "" {
 		baseURL = strings.TrimSuffix(baseURL, "/")
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{}
 	}
 	return &ClaudeAI{
 		baseURL:    baseURL,
 		modelName:  modelName,
 		apiKey:     apiKey,
-		client:     &http.Client{},
+		client:     httpClient,
 		llmTimeout: llmTimeout,
 		log:        log,
 	}

--- a/proxy-router/internal/aiengine/factory.go
+++ b/proxy-router/internal/aiengine/factory.go
@@ -1,15 +1,19 @@
 package aiengine
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
 )
 
-func ApiAdapterFactory(apiType string, modelName string, url string, apikey string, parameters ModelParameters, llmTimeout time.Duration, log lib.ILogger) (AIEngineStream, bool) {
+// ApiAdapterFactory creates the appropriate AI engine adapter for the given API type.
+// httpClient is optional; when non-nil it overrides the default http.Client used by
+// adapters that support it (currently openai and claudeai). Pass nil for default behavior.
+func ApiAdapterFactory(apiType string, modelName string, url string, apikey string, parameters ModelParameters, llmTimeout time.Duration, log lib.ILogger, httpClient *http.Client) (AIEngineStream, bool) {
 	switch apiType {
 	case API_TYPE_OPENAI:
-		return NewOpenAIEngine(modelName, url, apikey, llmTimeout, log), true
+		return NewOpenAIEngine(modelName, url, apikey, llmTimeout, log, httpClient), true
 	case API_TYPE_PRODIA_SD:
 		return NewProdiaSDEngine(modelName, url, apikey, log), true
 	case API_TYPE_PRODIA_SDXL:
@@ -19,7 +23,7 @@ func ApiAdapterFactory(apiType string, modelName string, url string, apikey stri
 	case API_TYPE_HYPERBOLIC_SD:
 		return NewHyperbolicSDEngine(modelName, url, apikey, parameters, log), true
 	case API_TYPE_CLAUDEAI:
-		return NewClaudeAIEngine(modelName, url, apikey, llmTimeout, log), true
+		return NewClaudeAIEngine(modelName, url, apikey, llmTimeout, log, httpClient), true
 	}
 	return nil, false
 }

--- a/proxy-router/internal/aiengine/openai.go
+++ b/proxy-router/internal/aiengine/openai.go
@@ -31,15 +31,18 @@ type OpenAI struct {
 	log        lib.ILogger
 }
 
-func NewOpenAIEngine(modelName, baseURL, apiKey string, llmTimeout time.Duration, log lib.ILogger) *OpenAI {
+func NewOpenAIEngine(modelName, baseURL, apiKey string, llmTimeout time.Duration, log lib.ILogger, httpClient *http.Client) *OpenAI {
 	if baseURL != "" {
 		baseURL = strings.TrimSuffix(baseURL, "/")
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{}
 	}
 	return &OpenAI{
 		baseURL:    baseURL,
 		modelName:  modelName,
 		apiKey:     apiKey,
-		client:     &http.Client{},
+		client:     httpClient,
 		llmTimeout: llmTimeout,
 		log:        log,
 	}

--- a/proxy-router/internal/attestation/artifacts_registry.go
+++ b/proxy-router/internal/attestation/artifacts_registry.go
@@ -1,0 +1,244 @@
+package attestation
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+)
+
+const (
+	DefaultRegistryURL             = "https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/tdx.csv"
+	DefaultRegistryRefreshInterval = 1 * time.Hour
+)
+
+type TdxArtifactEntry struct {
+	TemplateName string
+	VMType       string
+	ArtifactsVer string
+	MRTD         string
+	RTMR0        string
+	RTMR1        string
+	RTMR2        string
+	RootfsData   string
+	HostID       string
+}
+
+type ArtifactRegistry struct {
+	registryURL     string
+	refreshInterval time.Duration
+	client          *http.Client
+	log             lib.ILogger
+
+	mu          sync.RWMutex
+	entries     []TdxArtifactEntry
+	lastFetched time.Time
+}
+
+func NewArtifactRegistry(registryURL string, refreshInterval time.Duration, log lib.ILogger) *ArtifactRegistry {
+	if registryURL == "" {
+		registryURL = DefaultRegistryURL
+	}
+	if refreshInterval == 0 {
+		refreshInterval = DefaultRegistryRefreshInterval
+	}
+	return &ArtifactRegistry{
+		registryURL:     registryURL,
+		refreshInterval: refreshInterval,
+		client:          &http.Client{Timeout: 30 * time.Second},
+		log:             log,
+	}
+}
+
+func (r *ArtifactRegistry) Start(ctx context.Context) {
+	if err := r.fetch(ctx); err != nil {
+		r.log.Warnf("initial artifact registry fetch failed: %v", err)
+	}
+
+	go func() {
+		ticker := time.NewTicker(r.refreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := r.fetch(ctx); err != nil {
+					r.log.Warnf("artifact registry refresh failed, keeping stale cache: %v", err)
+				}
+			}
+		}
+	}()
+}
+
+func (r *ArtifactRegistry) fetch(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.registryURL, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("fetch registry: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("registry returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
+
+	entries := parseTdxRegistryCSV(string(body))
+
+	r.mu.Lock()
+	r.entries = entries
+	r.lastFetched = time.Now()
+	r.mu.Unlock()
+
+	r.log.Infof("artifact registry loaded %d entries", len(entries))
+	return nil
+}
+
+func parseTdxRegistryCSV(content string) []TdxArtifactEntry {
+	lines := strings.Split(strings.TrimSpace(content), "\n")
+	if len(lines) < 2 {
+		return nil
+	}
+
+	var entries []TdxArtifactEntry
+	for _, line := range lines[1:] {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Split(line, ",")
+		if len(fields) < 9 {
+			continue
+		}
+		entries = append(entries, TdxArtifactEntry{
+			TemplateName: strings.TrimSpace(fields[0]),
+			VMType:       strings.TrimSpace(fields[1]),
+			ArtifactsVer: strings.TrimSpace(fields[2]),
+			MRTD:         normalizeHex(fields[3]),
+			RTMR0:        normalizeHex(fields[4]),
+			RTMR1:        normalizeHex(fields[5]),
+			RTMR2:        normalizeHex(fields[6]),
+			RootfsData:   normalizeHex(fields[7]),
+			HostID:       normalizeHex(fields[8]),
+		})
+	}
+	return entries
+}
+
+func normalizeHex(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ToLower(s)
+	s = strings.TrimPrefix(s, "0x")
+	return s
+}
+
+func (r *ArtifactRegistry) FindMatchingArtifacts(mrtd, rtmr0, rtmr1, rtmr2 string) []TdxArtifactEntry {
+	mrtd = normalizeHex(mrtd)
+	rtmr0 = normalizeHex(rtmr0)
+	rtmr1 = normalizeHex(rtmr1)
+	rtmr2 = normalizeHex(rtmr2)
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var matched []TdxArtifactEntry
+	for _, e := range r.entries {
+		if e.MRTD == mrtd && e.RTMR0 == rtmr0 && e.RTMR1 == rtmr1 && e.RTMR2 == rtmr2 {
+			matched = append(matched, e)
+		}
+	}
+	return matched
+}
+
+func (r *ArtifactRegistry) PickNewestVersion(entries []TdxArtifactEntry) *TdxArtifactEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	best := 0
+	for i := 1; i < len(entries); i++ {
+		if compareSemver(entries[i].ArtifactsVer, entries[best].ArtifactsVer) > 0 {
+			best = i
+		}
+	}
+	result := entries[best]
+	return &result
+}
+
+// compareSemver returns >0 if a > b, <0 if a < b, 0 if equal.
+// Release versions (no pre-release) sort after pre-release.
+func compareSemver(a, b string) int {
+	aMajor, aMinor, aPatch, aPre := parseSemver(a)
+	bMajor, bMinor, bPatch, bPre := parseSemver(b)
+
+	if aMajor != bMajor {
+		return aMajor - bMajor
+	}
+	if aMinor != bMinor {
+		return aMinor - bMinor
+	}
+	if aPatch != bPatch {
+		return aPatch - bPatch
+	}
+
+	// "" (release) > any non-empty pre-release string
+	if aPre == "" && bPre == "" {
+		return 0
+	}
+	if aPre == "" {
+		return 1
+	}
+	if bPre == "" {
+		return -1
+	}
+	if aPre < bPre {
+		return -1
+	}
+	if aPre > bPre {
+		return 1
+	}
+	return 0
+}
+
+func parseSemver(v string) (major, minor, patch int, pre string) {
+	v = strings.TrimPrefix(v, "v")
+
+	preParts := strings.SplitN(v, "-", 2)
+	core := preParts[0]
+	if len(preParts) > 1 {
+		pre = preParts[1]
+	}
+
+	parts := strings.Split(core, ".")
+	if len(parts) >= 1 {
+		major, _ = strconv.Atoi(parts[0])
+	}
+	if len(parts) >= 2 {
+		minor, _ = strconv.Atoi(parts[1])
+	}
+	if len(parts) >= 3 {
+		patch, _ = strconv.Atoi(parts[2])
+	}
+	return
+}
+
+func (r *ArtifactRegistry) IsLoaded() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return !r.lastFetched.IsZero()
+}

--- a/proxy-router/internal/attestation/backend_verifier.go
+++ b/proxy-router/internal/attestation/backend_verifier.go
@@ -1,0 +1,449 @@
+package attestation
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+)
+
+// BackendGoldenSource provides golden register values for LLM backend TEE verification.
+// The source of these values is TBD -- could be GHCR OCI attestation, a Secret AI API,
+// or per-model configuration. Until defined, use NoopGoldenSource.
+type BackendGoldenSource interface {
+	FetchGoldenValues(ctx context.Context, modelID string, attestationURL string) (*GoldenValues, error)
+}
+
+// NoopGoldenSource always returns nil, skipping golden register comparison.
+// Used as a placeholder until the real golden values source is defined.
+type NoopGoldenSource struct{}
+
+func (n *NoopGoldenSource) FetchGoldenValues(_ context.Context, _ string, _ string) (*GoldenValues, error) {
+	return nil, nil
+}
+
+type BackendAttestationStatus string
+
+const (
+	StatusPassed  BackendAttestationStatus = "passed"
+	StatusFailed  BackendAttestationStatus = "failed"
+	StatusUnknown BackendAttestationStatus = "unknown"
+)
+
+// BackendAttestationSnapshot holds the cached attestation state for a single model backend.
+type BackendAttestationSnapshot struct {
+	ModelID           string                   `json:"modelId"`
+	AttestationURL    string                   `json:"attestationUrl"`
+	CPUQuoteHash      string                   `json:"-"`
+	GPUQuoteHash      string                   `json:"-"`
+	TLSFingerprint    string                   `json:"-"`
+	CPUReportData     string                   `json:"-"`
+	GPUReportData     string                   `json:"-"`
+	TEEType           TEEType                  `json:"teeType,omitempty"`
+	VerifiedAt        time.Time                `json:"verifiedAt"`
+	Status            BackendAttestationStatus `json:"status"`
+	Error             string                   `json:"error,omitempty"`
+	WorkloadStatus    string                   `json:"workloadStatus,omitempty"`
+	VMTemplateName    string                   `json:"vmTemplateName,omitempty"`
+	ArtifactsVersion  string                   `json:"artifactsVersion,omitempty"`
+	DockerComposeHash string                   `json:"dockerComposeHash,omitempty"`
+}
+
+// BackendVerifier manages TEE attestation verification of LLM backend endpoints.
+// It performs CPU+GPU attestation, caches results per model, and provides
+// fast-verify for the per-prompt hot path.
+type BackendVerifier struct {
+	portalClient      *http.Client
+	attestationClient *http.Client
+	portalURL         string
+	goldenSource      BackendGoldenSource
+	nrasVerifier      *NRASVerifier
+	artifactRegistry  *ArtifactRegistry
+	log               lib.ILogger
+
+	mu    sync.RWMutex
+	cache map[string]*BackendAttestationSnapshot
+}
+
+func NewBackendVerifier(portalURL string, goldenSource BackendGoldenSource, registry *ArtifactRegistry, log lib.ILogger) *BackendVerifier {
+	if portalURL == "" {
+		portalURL = DefaultPortalURL
+	}
+	if goldenSource == nil {
+		goldenSource = &NoopGoldenSource{}
+	}
+
+	return &BackendVerifier{
+		portalClient:      NewPortalHTTPClient(),
+		attestationClient: NewAttestationHTTPClient(),
+		portalURL:         portalURL,
+		goldenSource:      goldenSource,
+		nrasVerifier:      NewNRASVerifier(log),
+		artifactRegistry:  registry,
+		log:               log,
+		cache:             make(map[string]*BackendAttestationSnapshot),
+	}
+}
+
+// AttestBackend performs full CPU+GPU attestation of a backend LLM TEE endpoint.
+// On success the result is cached for fast-verify. On failure the snapshot is
+// stored with StatusFailed so the health endpoint can report it.
+func (bv *BackendVerifier) AttestBackend(ctx context.Context, modelID string, attestationURL string) error {
+	bv.log.Infof("backend attestation: starting full verification for model %s at %s", modelID, attestationURL)
+
+	// 1. Fetch CPU quote
+	cpuURL := attestationURL + "/cpu"
+	cpuQuote, tlsFingerprint, err := LoadAttestationQuote(ctx, bv.attestationClient, cpuURL)
+	if err != nil {
+		bv.storeFailure(modelID, attestationURL, fmt.Sprintf("CPU quote fetch failed: %s", err))
+		return fmt.Errorf("failed to load CPU attestation quote from %s: %w", cpuURL, err)
+	}
+	bv.log.Infof("backend attestation: fetched CPU quote from %s, TLS fingerprint: %s", cpuURL, tlsFingerprint)
+
+	if tlsFingerprint == "" {
+		bv.storeFailure(modelID, attestationURL, "no TLS certificate from CPU endpoint")
+		return fmt.Errorf("no TLS peer certificate received from %s", cpuURL)
+	}
+
+	// 2. Verify CPU quote via portal
+	cpuResult, err := VerifyQuote(ctx, bv.portalClient, bv.portalURL, cpuQuote)
+	if err != nil {
+		bv.storeFailure(modelID, attestationURL, fmt.Sprintf("CPU quote portal verification failed: %s", err))
+		return fmt.Errorf("CPU attestation quote verification failed: %w", err)
+	}
+	if !cpuResult.Valid {
+		bv.storeFailure(modelID, attestationURL, fmt.Sprintf("CPU attestation invalid: %s", cpuResult.Error))
+		return fmt.Errorf("CPU attestation invalid (%s): %s", cpuResult.Type, cpuResult.Error)
+	}
+	bv.log.Infof("backend attestation: CPU quote valid (type: %s) for model %s", cpuResult.Type, modelID)
+
+	// 3. Verify TLS binding (first half of reportData = TLS cert fingerprint)
+	if err := VerifyTLSBinding(tlsFingerprint, cpuResult.ReportData); err != nil {
+		bv.storeFailure(modelID, attestationURL, fmt.Sprintf("TLS binding failed: %s", err))
+		return fmt.Errorf("CPU TLS binding verification failed: %w", err)
+	}
+	bv.log.Infof("backend attestation: TLS binding verified for model %s", modelID)
+
+	// 3a. Workload verification (docker-compose vs attestation quote)
+	var workloadResult *WorkloadResult
+	if bv.artifactRegistry != nil && bv.artifactRegistry.IsLoaded() {
+		dockerCompose, composeErr := bv.fetchDockerCompose(ctx, attestationURL)
+		if composeErr != nil {
+			bv.log.Warnf("backend attestation: could not fetch docker-compose for model %s: %s (workload verification skipped)", modelID, composeErr)
+		} else {
+			result := VerifyWorkload(bv.artifactRegistry, cpuQuote, dockerCompose, bv.log)
+			workloadResult = &result
+			switch result.Status {
+			case WorkloadAuthentic:
+				bv.log.Infof("backend attestation: workload verified for model %s (template=%s, version=%s, env=%s)", modelID, result.TemplateName, result.ArtifactsVer, result.Env)
+			case WorkloadAuthenticMismatch:
+				bv.storeFailure(modelID, attestationURL, "docker-compose does not match attestation (authentic VM but wrong workload)")
+				return fmt.Errorf("workload verification failed for model %s: docker-compose does not match attestation", modelID)
+			case WorkloadNotAuthentic:
+				bv.storeFailure(modelID, attestationURL, "VM is not an authentic SecretVM (MRTD/RTMR values not in registry)")
+				return fmt.Errorf("workload verification failed for model %s: not an authentic SecretVM", modelID)
+			}
+		}
+	} else {
+		bv.log.Infof("backend attestation: artifact registry not available, skipping workload verification for model %s", modelID)
+	}
+
+	// 4. Fetch GPU attestation data (JSON with nonce, arch, evidence_list)
+	gpuURL := attestationURL + "/gpu"
+	gpuRawJSON, _, err := LoadAttestationQuote(ctx, bv.attestationClient, gpuURL)
+	if err != nil {
+		bv.storeFailure(modelID, attestationURL, fmt.Sprintf("GPU quote fetch failed: %s", err))
+		return fmt.Errorf("failed to load GPU attestation data from %s: %w", gpuURL, err)
+	}
+	bv.log.Infof("backend attestation: fetched GPU attestation data from %s", gpuURL)
+
+	// 5. Parse GPU attestation JSON and extract nonce
+	gpuData, err := ParseGPUAttestationData(gpuRawJSON)
+	if err != nil {
+		bv.storeFailure(modelID, attestationURL, fmt.Sprintf("GPU attestation data parse failed: %s", err))
+		return fmt.Errorf("failed to parse GPU attestation data: %w", err)
+	}
+	bv.log.Infof("backend attestation: GPU arch=%s, nonce=%s, evidences=%d", gpuData.Arch, gpuData.Nonce, len(gpuData.EvidenceList))
+
+	// 6. Verify CPU-GPU binding: second half of CPU reportData should be the GPU nonce
+	if err := VerifyCPUGPUBinding(cpuResult.ReportData, gpuData.Nonce); err != nil {
+		bv.storeFailure(modelID, attestationURL, fmt.Sprintf("CPU-GPU binding failed: %s", err))
+		return fmt.Errorf("CPU-GPU binding verification failed: %w", err)
+	}
+	bv.log.Infof("backend attestation: CPU-GPU binding verified for model %s", modelID)
+
+	// 7. Verify GPU evidence via NVIDIA Remote Attestation Service (NRAS)
+	// NRAS may be unreachable from some networks (403/timeout). GPU trust is already
+	// established via CPU-GPU nonce binding (step 6), so NRAS failure is non-fatal.
+	nrasResult, err := bv.nrasVerifier.VerifyGPU(ctx, gpuData)
+	if err != nil {
+		bv.log.Warnf("backend attestation: NRAS GPU verification failed for model %s (non-fatal): %s", modelID, err)
+	} else {
+		bv.log.Infof("backend attestation: NRAS verified GPU for model %s (%d GPU tokens received)", modelID, len(nrasResult.GPUTokens))
+	}
+
+	// 8. Golden values comparison (placeholder -- NoopGoldenSource skips this)
+	golden, err := bv.goldenSource.FetchGoldenValues(ctx, modelID, attestationURL)
+	if err != nil {
+		bv.storeFailure(modelID, attestationURL, fmt.Sprintf("golden values fetch failed: %s", err))
+		return fmt.Errorf("failed to fetch golden values for model %s: %w", modelID, err)
+	}
+	if golden != nil {
+		if err := CompareRegisters(cpuResult, golden, bv.log); err != nil {
+			bv.storeFailure(modelID, attestationURL, fmt.Sprintf("register mismatch: %s", err))
+			return err
+		}
+		bv.log.Infof("backend attestation: golden values match for model %s", modelID)
+	} else {
+		// bv.log.Infof("backend attestation: golden values comparison skipped (no source configured) for model %s", modelID)
+	}
+
+	// 9. Cache the successful attestation
+	cpuHash := fmt.Sprintf("%x", sha256.Sum256([]byte(cpuQuote)))
+	gpuHash := fmt.Sprintf("%x", sha256.Sum256([]byte(gpuRawJSON)))
+	now := time.Now()
+
+	snapshot := &BackendAttestationSnapshot{
+		ModelID:        modelID,
+		AttestationURL: attestationURL,
+		CPUQuoteHash:   cpuHash,
+		GPUQuoteHash:   gpuHash,
+		TLSFingerprint: tlsFingerprint,
+		CPUReportData:  cpuResult.ReportData,
+		GPUReportData:  gpuData.Nonce,
+		TEEType:        cpuResult.Type,
+		VerifiedAt:     now,
+		Status:         StatusPassed,
+	}
+
+	if workloadResult != nil {
+		snapshot.WorkloadStatus = string(workloadResult.Status)
+		snapshot.VMTemplateName = workloadResult.TemplateName
+		snapshot.ArtifactsVersion = workloadResult.ArtifactsVer
+	}
+
+	bv.mu.Lock()
+	bv.cache[modelID] = snapshot
+	bv.mu.Unlock()
+
+	bv.log.Infof("backend attestation: cached verified snapshot for model %s", modelID)
+	return nil
+}
+
+// FastVerifyBackend performs a lightweight per-request check.
+// Always re-fetches /cpu and compares sha256(quote) + TLS fingerprint against
+// the cached attestation snapshot (~50ms). If the quote hash changes, triggers
+// full re-attestation. TLS fingerprint mismatch is an immediate error (possible MITM).
+func (bv *BackendVerifier) FastVerifyBackend(ctx context.Context, modelID string) error {
+	bv.mu.RLock()
+	snapshot, exists := bv.cache[modelID]
+	bv.mu.RUnlock()
+
+	if !exists {
+		bv.log.Infof("backend fast-verify: no cache for model %s, skipping (not attested)", modelID)
+		return fmt.Errorf("no attestation snapshot for model %s", modelID)
+	}
+
+	if snapshot.Status != StatusPassed {
+		return fmt.Errorf("backend attestation status is %s for model %s: %s", snapshot.Status, modelID, snapshot.Error)
+	}
+
+	cpuURL := snapshot.AttestationURL + "/cpu"
+	cpuQuote, tlsFingerprint, err := LoadAttestationQuote(ctx, bv.attestationClient, cpuURL)
+	if err != nil {
+		return fmt.Errorf("backend fast-verify failed for model %s: %w", modelID, err)
+	}
+
+	currentHash := fmt.Sprintf("%x", sha256.Sum256([]byte(cpuQuote)))
+
+	if currentHash != snapshot.CPUQuoteHash {
+		bv.log.Warnf("backend fast-verify: CPU quote hash mismatch for model %s, performing full re-attestation", modelID)
+		return bv.AttestBackend(ctx, modelID, snapshot.AttestationURL)
+	}
+
+	if !strings.EqualFold(tlsFingerprint, snapshot.TLSFingerprint) {
+		bv.log.Warnf("backend fast-verify: TLS fingerprint mismatch for model %s (cached=%s, live=%s)", modelID, snapshot.TLSFingerprint, tlsFingerprint)
+		return fmt.Errorf("backend TLS certificate changed for model %s (possible MITM)", modelID)
+	}
+
+	bv.log.Debugf("backend fast-verify: model %s verified", modelID)
+	return nil
+}
+
+// GetStatus returns the attestation snapshot for a model, or nil if not attested.
+func (bv *BackendVerifier) GetStatus(modelID string) *BackendAttestationSnapshot {
+	bv.mu.RLock()
+	defer bv.mu.RUnlock()
+
+	snapshot, exists := bv.cache[modelID]
+	if !exists {
+		return nil
+	}
+
+	copied := *snapshot
+	return &copied
+}
+
+// GetAllStatuses returns attestation snapshots for all cached models.
+func (bv *BackendVerifier) GetAllStatuses() map[string]*BackendAttestationSnapshot {
+	bv.mu.RLock()
+	defer bv.mu.RUnlock()
+
+	result := make(map[string]*BackendAttestationSnapshot, len(bv.cache))
+	for k, v := range bv.cache {
+		copied := *v
+		result[k] = &copied
+	}
+	return result
+}
+
+// PinnedHTTPClient returns an HTTP client whose TLS transport is pinned to the
+// certificate fingerprint from the model's attestation snapshot.
+func (bv *BackendVerifier) PinnedHTTPClient(modelID string) (*http.Client, error) {
+	bv.mu.RLock()
+	snapshot, exists := bv.cache[modelID]
+	bv.mu.RUnlock()
+
+	if !exists || snapshot.Status != StatusPassed {
+		return nil, fmt.Errorf("no valid attestation for model %s", modelID)
+	}
+
+	expectedFingerprint := snapshot.TLSFingerprint
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion:         tls.VersionTLS12,
+				InsecureSkipVerify: true, //nolint:gosec // verified via attestation binding
+				VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+					if len(rawCerts) == 0 {
+						return fmt.Errorf("no peer certificate presented")
+					}
+					hash := sha256.Sum256(rawCerts[0])
+					actual := hex.EncodeToString(hash[:])
+					if !strings.EqualFold(actual, expectedFingerprint) {
+						return fmt.Errorf("TLS cert pinning mismatch: expected %s, got %s", expectedFingerprint, actual)
+					}
+					return nil
+				},
+			},
+		},
+	}, nil
+}
+
+// VerifyCPUGPUBinding checks that the CPU and GPU attestation quotes are bound together.
+// The second half (bytes 32-63, hex chars 64-127) of the CPU reportData should match
+// the GPU attestation's reportData (which serves as the GPU nonce).
+func VerifyCPUGPUBinding(cpuReportData string, gpuReportData string) error {
+	cpuReportData = strings.ToLower(strings.TrimSpace(cpuReportData))
+	gpuReportData = strings.ToLower(strings.TrimSpace(gpuReportData))
+
+	// CPU reportData layout:
+	//   chars 0-63  (bytes 0-31): TLS cert fingerprint
+	//   chars 64+   (bytes 32+):  GPU attestation nonce
+	const tlsFingerprintHexLen = 64
+
+	if len(cpuReportData) <= tlsFingerprintHexLen {
+		return fmt.Errorf("CPU reportData too short (%d hex chars) to contain GPU binding", len(cpuReportData))
+	}
+
+	gpuNonceFromCPU := cpuReportData[tlsFingerprintHexLen:]
+
+	if gpuReportData == "" {
+		return fmt.Errorf("GPU reportData is empty, cannot verify binding")
+	}
+
+	// Compare the GPU nonce embedded in CPU reportData against GPU's reportData.
+	// Use the shorter of the two for comparison in case of trailing zeros.
+	compareLen := len(gpuNonceFromCPU)
+	if len(gpuReportData) < compareLen {
+		compareLen = len(gpuReportData)
+	}
+	if compareLen == 0 {
+		return fmt.Errorf("no data available for CPU-GPU binding comparison")
+	}
+
+	if gpuNonceFromCPU[:compareLen] != gpuReportData[:compareLen] {
+		return fmt.Errorf("CPU-GPU binding mismatch: cpu_reportdata_suffix=%s, gpu_reportdata=%s",
+			gpuNonceFromCPU[:compareLen], gpuReportData[:compareLen])
+	}
+
+	return nil
+}
+
+func (bv *BackendVerifier) fetchDockerCompose(ctx context.Context, attestationURL string) (string, error) {
+	composeURL := attestationURL + "/docker-compose"
+	bv.log.Infof("fetching docker-compose from %s", composeURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, composeURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request for %s: %w", composeURL, err)
+	}
+
+	resp, err := bv.attestationClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch docker-compose from %s: %w", composeURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("docker-compose endpoint returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read docker-compose response: %w", err)
+	}
+
+	content := string(body)
+
+	// The SecretVM :29343/docker-compose endpoint wraps the YAML in an HTML page.
+	// Extract the raw content from inside <pre>...</pre> tags.
+	content = extractPreContent(content)
+
+	return content, nil
+}
+
+// extractPreContent extracts text between <pre> and </pre> tags,
+// decodes HTML entities (e.g. &amp; -> &, &#34; -> "), and strips
+// any trailing zero-width spaces inserted by the HTML renderer.
+// The SecretVM attestation server serves docker-compose as an HTML
+// page with the YAML inside <pre> tags, HTML-escaped.
+func extractPreContent(rawHTML string) string {
+	lower := strings.ToLower(rawHTML)
+	start := strings.Index(lower, "<pre>")
+	if start == -1 {
+		return rawHTML
+	}
+	start += len("<pre>")
+	end := strings.Index(lower[start:], "</pre>")
+	if end == -1 {
+		return rawHTML
+	}
+	content := html.UnescapeString(rawHTML[start : start+end])
+	content = strings.TrimRight(content, "\u200b")
+	return content
+}
+
+func (bv *BackendVerifier) storeFailure(modelID, attestationURL, errMsg string) {
+	bv.mu.Lock()
+	defer bv.mu.Unlock()
+
+	bv.cache[modelID] = &BackendAttestationSnapshot{
+		ModelID:        modelID,
+		AttestationURL: attestationURL,
+		Status:         StatusFailed,
+		Error:          errMsg,
+		VerifiedAt:     time.Now(),
+	}
+}

--- a/proxy-router/internal/attestation/backend_verifier.go
+++ b/proxy-router/internal/attestation/backend_verifier.go
@@ -250,37 +250,41 @@ func (bv *BackendVerifier) FastVerifyBackend(ctx context.Context, modelID string
 	bv.mu.RUnlock()
 
 	if !exists {
-		bv.log.Infof("backend fast-verify: no cache for model %s, skipping (not attested)", modelID)
 		return fmt.Errorf("no attestation snapshot for model %s", modelID)
 	}
 
 	if snapshot.Status != StatusPassed {
-		return fmt.Errorf("backend attestation status is %s for model %s: %s", snapshot.Status, modelID, snapshot.Error)
+		bv.log.Infof("LLM attestation status is %s for model %s (%s), retrying full attestation", snapshot.Status, modelID, snapshot.Error)
+		return bv.AttestBackend(ctx, modelID, snapshot.AttestationURL)
 	}
 
 	cpuURL := snapshot.AttestationURL + "/cpu"
 	cpuQuote, tlsFingerprint, err := LoadAttestationQuote(ctx, bv.attestationClient, cpuURL)
 	if err != nil {
-		return fmt.Errorf("backend fast-verify failed for model %s: %w", modelID, err)
+		return fmt.Errorf("LLM fast-verify failed for model %s: %w", modelID, err)
 	}
 
 	currentHash := fmt.Sprintf("%x", sha256.Sum256([]byte(cpuQuote)))
 
 	if currentHash != snapshot.CPUQuoteHash {
-		bv.log.Warnf("backend fast-verify: CPU quote hash mismatch for model %s, performing full re-attestation", modelID)
+		bv.log.Warnf("LLM fast-verify: CPU quote hash mismatch for model %s, performing full re-attestation", modelID)
 		return bv.AttestBackend(ctx, modelID, snapshot.AttestationURL)
 	}
 
 	if !strings.EqualFold(tlsFingerprint, snapshot.TLSFingerprint) {
-		bv.log.Warnf("backend fast-verify: TLS fingerprint mismatch for model %s (cached=%s, live=%s)", modelID, snapshot.TLSFingerprint, tlsFingerprint)
-		return fmt.Errorf("backend TLS certificate changed for model %s (possible MITM)", modelID)
+		bv.log.Warnf("LLM fast-verify: TLS fingerprint mismatch for model %s (cached=%s, live=%s)", modelID, snapshot.TLSFingerprint, tlsFingerprint)
+		return fmt.Errorf("LLM TLS certificate changed for model %s (possible MITM)", modelID)
 	}
 
-	bv.log.Debugf("backend fast-verify: model %s verified", modelID)
+	bv.log.Debugf("LLM fast-verify: model %s verified", modelID)
 	return nil
 }
 
 // GetStatus returns the attestation snapshot for a model, or nil if not attested.
+func (bv *BackendVerifier) GetBackendStatus(modelID string) *BackendAttestationSnapshot {
+	return bv.GetStatus(modelID)
+}
+
 func (bv *BackendVerifier) GetStatus(modelID string) *BackendAttestationSnapshot {
 	bv.mu.RLock()
 	defer bv.mu.RUnlock()

--- a/proxy-router/internal/attestation/backend_verifier_test.go
+++ b/proxy-router/internal/attestation/backend_verifier_test.go
@@ -127,21 +127,21 @@ func TestVerifyTLSBinding_EmptyReportData(t *testing.T) {
 // --- BackendVerifier cache and status ---
 
 func TestBackendVerifier_GetStatus_Unknown(t *testing.T) {
-	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
 	if status := bv.GetStatus("nonexistent"); status != nil {
 		t.Fatalf("expected nil, got: %+v", status)
 	}
 }
 
 func TestBackendVerifier_GetAllStatuses_Empty(t *testing.T) {
-	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
 	if statuses := bv.GetAllStatuses(); len(statuses) != 0 {
 		t.Fatalf("expected 0 statuses, got %d", len(statuses))
 	}
 }
 
 func TestBackendVerifier_StoreFailure(t *testing.T) {
-	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
 	bv.storeFailure("model-1", "https://test:29343", "test error")
 
 	status := bv.GetStatus("model-1")
@@ -159,7 +159,7 @@ func TestBackendVerifier_StoreFailure(t *testing.T) {
 // --- FastVerifyBackend ---
 
 func TestBackendVerifier_FastVerify_NoCache(t *testing.T) {
-	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
 	err := bv.FastVerifyBackend(context.Background(), "no-such-model")
 	if err == nil {
 		t.Fatal("expected error")
@@ -170,7 +170,7 @@ func TestBackendVerifier_FastVerify_NoCache(t *testing.T) {
 }
 
 func TestBackendVerifier_FastVerify_FailedStatus(t *testing.T) {
-	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
 	bv.storeFailure("model-1", "https://test:29343", "prev failure")
 
 	err := bv.FastVerifyBackend(context.Background(), "model-1")
@@ -195,7 +195,7 @@ func TestBackendVerifier_FastVerify_CacheHit(t *testing.T) {
 
 	_, fingerprint := selfSignedCert(t)
 
-	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
 	bv.attestationClient = attestServer.Client()
 
 	bv.mu.Lock()
@@ -270,7 +270,7 @@ func TestBackendVerifier_AttestBackend_FullFlow(t *testing.T) {
 	portalServer := httptest.NewServer(portalMux)
 	defer portalServer.Close()
 
-	bv := NewBackendVerifier(portalServer.URL+"/api/quote-parse", nil, "", nil, testLog())
+	bv := NewBackendVerifier(portalServer.URL+"/api/quote-parse", nil, nil, testLog())
 	bv.attestationClient = NewAttestationHTTPClient()
 
 	err := bv.AttestBackend(context.Background(), "test-model", attestServer.URL)
@@ -335,8 +335,8 @@ func TestBackendVerifier_AttestBackend_WithNRAS(t *testing.T) {
 
 	// Mock NRAS server
 	nrasMux := http.NewServeMux()
-	nrasMux.HandleFunc("/v2/attest/gpu", func(w http.ResponseWriter, r *http.Request) {
-		var req NRASRequest
+	nrasMux.HandleFunc("/v4/attest/gpu", func(w http.ResponseWriter, r *http.Request) {
+		var req GPUAttestationData
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Errorf("NRAS: failed to decode request: %s", err)
 			w.WriteHeader(http.StatusBadRequest)
@@ -345,8 +345,8 @@ func TestBackendVerifier_AttestBackend_WithNRAS(t *testing.T) {
 		if req.Arch != "HOPPER" {
 			t.Errorf("NRAS: expected arch HOPPER, got %s", req.Arch)
 		}
-		if len(req.Evidences) != 1 {
-			t.Errorf("NRAS: expected 1 evidence, got %d", len(req.Evidences))
+		if len(req.EvidenceList) != 1 {
+			t.Errorf("NRAS: expected 1 evidence, got %d", len(req.EvidenceList))
 		}
 
 		resp := []json.RawMessage{
@@ -359,8 +359,9 @@ func TestBackendVerifier_AttestBackend_WithNRAS(t *testing.T) {
 	nrasServer := httptest.NewServer(nrasMux)
 	defer nrasServer.Close()
 
-	bv := NewBackendVerifier(portalServer.URL+"/api/quote-parse", nil, nrasServer.URL, nil, testLog())
+	bv := NewBackendVerifier(portalServer.URL+"/api/quote-parse", nil, nil, testLog())
 	bv.attestationClient = NewAttestationHTTPClient()
+	bv.nrasVerifier.baseURL = nrasServer.URL
 
 	err := bv.AttestBackend(context.Background(), "test-model-nras", attestServer.URL)
 	if err != nil {
@@ -379,7 +380,7 @@ func TestBackendVerifier_AttestBackend_WithNRAS(t *testing.T) {
 // --- PinnedHTTPClient ---
 
 func TestBackendVerifier_PinnedHTTPClient_NoModel(t *testing.T) {
-	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
 	_, err := bv.PinnedHTTPClient("no-model")
 	if err == nil {
 		t.Fatal("expected error")
@@ -387,7 +388,7 @@ func TestBackendVerifier_PinnedHTTPClient_NoModel(t *testing.T) {
 }
 
 func TestBackendVerifier_PinnedHTTPClient_Success(t *testing.T) {
-	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
 
 	bv.mu.Lock()
 	bv.cache["model-1"] = &BackendAttestationSnapshot{
@@ -407,7 +408,7 @@ func TestBackendVerifier_PinnedHTTPClient_Success(t *testing.T) {
 }
 
 func TestBackendVerifier_PinnedHTTPClient_FailedStatus(t *testing.T) {
-	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
 	bv.storeFailure("model-1", "https://test:29343", "broken")
 
 	_, err := bv.PinnedHTTPClient("model-1")

--- a/proxy-router/internal/attestation/backend_verifier_test.go
+++ b/proxy-router/internal/attestation/backend_verifier_test.go
@@ -1,0 +1,430 @@
+package attestation
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+)
+
+func selfSignedCert(t *testing.T) (tls.Certificate, string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{Organization: []string{"test"}},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert := tls.Certificate{Certificate: [][]byte{certDER}, PrivateKey: priv}
+	h := sha256.Sum256(certDER)
+	return cert, hex.EncodeToString(h[:])
+}
+
+func testLog() lib.ILogger {
+	return &lib.LoggerMock{}
+}
+
+// --- VerifyCPUGPUBinding ---
+
+func TestVerifyCPUGPUBinding_Valid(t *testing.T) {
+	gpuNonce := "aabbccdd11223344556677889900aabbccdd11223344556677889900aabb1122"
+	tlsFingerprint := "0011223344556677889900aabbccddeeff0011223344556677889900aabbccdd"
+	cpuReportData := tlsFingerprint + gpuNonce
+
+	if err := VerifyCPUGPUBinding(cpuReportData, gpuNonce); err != nil {
+		t.Fatalf("expected no error, got: %s", err)
+	}
+}
+
+func TestVerifyCPUGPUBinding_Mismatch(t *testing.T) {
+	tlsFingerprint := "0011223344556677889900aabbccddeeff0011223344556677889900aabbccdd"
+	gpuNonce := "aabbccdd11223344556677889900aabbccdd11223344556677889900aabb1122"
+	wrongGPU := "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000"
+	cpuReportData := tlsFingerprint + gpuNonce
+
+	err := VerifyCPUGPUBinding(cpuReportData, wrongGPU)
+	if err == nil {
+		t.Fatal("expected mismatch error")
+	}
+	if !strings.Contains(err.Error(), "CPU-GPU binding mismatch") {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func TestVerifyCPUGPUBinding_ShortReportData(t *testing.T) {
+	err := VerifyCPUGPUBinding("aabbccdd", "1234")
+	if err == nil {
+		t.Fatal("expected error for short reportData")
+	}
+}
+
+func TestVerifyCPUGPUBinding_EmptyGPU(t *testing.T) {
+	cpuReportData := strings.Repeat("aa", 64)
+	err := VerifyCPUGPUBinding(cpuReportData, "")
+	if err == nil {
+		t.Fatal("expected error for empty GPU reportData")
+	}
+}
+
+// --- VerifyTLSBinding ---
+
+func TestVerifyTLSBinding_Valid(t *testing.T) {
+	fingerprint := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	reportData := fingerprint + "0000000000000000000000000000000000000000000000000000000000000000"
+
+	if err := VerifyTLSBinding(fingerprint, reportData); err != nil {
+		t.Fatalf("expected no error, got: %s", err)
+	}
+}
+
+func TestVerifyTLSBinding_Mismatch(t *testing.T) {
+	fingerprint := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	reportData := "1111111111111111111111111111111111111111111111111111111111111111" + "0000"
+
+	err := VerifyTLSBinding(fingerprint, reportData)
+	if err == nil {
+		t.Fatal("expected mismatch error")
+	}
+}
+
+func TestVerifyTLSBinding_EmptyFingerprint(t *testing.T) {
+	err := VerifyTLSBinding("", "aabb")
+	if err == nil {
+		t.Fatal("expected error for empty fingerprint")
+	}
+}
+
+func TestVerifyTLSBinding_EmptyReportData(t *testing.T) {
+	err := VerifyTLSBinding("aabb", "")
+	if err == nil {
+		t.Fatal("expected error for empty reportData")
+	}
+}
+
+// --- BackendVerifier cache and status ---
+
+func TestBackendVerifier_GetStatus_Unknown(t *testing.T) {
+	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	if status := bv.GetStatus("nonexistent"); status != nil {
+		t.Fatalf("expected nil, got: %+v", status)
+	}
+}
+
+func TestBackendVerifier_GetAllStatuses_Empty(t *testing.T) {
+	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	if statuses := bv.GetAllStatuses(); len(statuses) != 0 {
+		t.Fatalf("expected 0 statuses, got %d", len(statuses))
+	}
+}
+
+func TestBackendVerifier_StoreFailure(t *testing.T) {
+	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	bv.storeFailure("model-1", "https://test:29343", "test error")
+
+	status := bv.GetStatus("model-1")
+	if status == nil {
+		t.Fatal("expected status")
+	}
+	if status.Status != StatusFailed {
+		t.Fatalf("expected StatusFailed, got %s", status.Status)
+	}
+	if status.Error != "test error" {
+		t.Fatalf("expected 'test error', got '%s'", status.Error)
+	}
+}
+
+// --- FastVerifyBackend ---
+
+func TestBackendVerifier_FastVerify_NoCache(t *testing.T) {
+	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	err := bv.FastVerifyBackend(context.Background(), "no-such-model")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "no attestation snapshot") {
+		t.Fatalf("unexpected: %s", err)
+	}
+}
+
+func TestBackendVerifier_FastVerify_FailedStatus(t *testing.T) {
+	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	bv.storeFailure("model-1", "https://test:29343", "prev failure")
+
+	err := bv.FastVerifyBackend(context.Background(), "model-1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "status is failed") {
+		t.Fatalf("unexpected: %s", err)
+	}
+}
+
+func TestBackendVerifier_FastVerify_CacheHit(t *testing.T) {
+	cpuQuote := "stable-cpu-quote-hex"
+	cpuHash := fmt.Sprintf("%x", sha256.Sum256([]byte(cpuQuote)))
+
+	attestMux := http.NewServeMux()
+	attestMux.HandleFunc("/cpu", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, cpuQuote)
+	})
+	attestServer := httptest.NewTLSServer(attestMux)
+	defer attestServer.Close()
+
+	_, fingerprint := selfSignedCert(t)
+
+	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	bv.attestationClient = attestServer.Client()
+
+	bv.mu.Lock()
+	bv.cache["test-model"] = &BackendAttestationSnapshot{
+		ModelID:        "test-model",
+		AttestationURL: attestServer.URL,
+		CPUQuoteHash:   cpuHash,
+		TLSFingerprint: fingerprint,
+		Status:         StatusPassed,
+	}
+	bv.mu.Unlock()
+
+	// fingerprints won't match (the test TLS server's cert differs from our generated cert),
+	// but this validates the flow reaches the comparison step
+	err := bv.FastVerifyBackend(context.Background(), "test-model")
+	// We expect a TLS fingerprint mismatch since our pre-populated fingerprint
+	// differs from the httptest server's actual cert
+	if err == nil {
+		// If it passes, the hash comparison path worked (unexpected but not wrong
+		// if the test TLS cert happened to match)
+		return
+	}
+	if strings.Contains(err.Error(), "TLS certificate changed") {
+		// Expected: the live cert differs from the pre-populated fingerprint
+		return
+	}
+	t.Fatalf("unexpected error: %s", err)
+}
+
+// --- AttestBackend full flow ---
+
+func TestBackendVerifier_AttestBackend_FullFlow(t *testing.T) {
+	cert, fingerprint := selfSignedCert(t)
+
+	gpuNonce := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	cpuReportData := fingerprint + gpuNonce
+
+	gpuJSON := fmt.Sprintf(`{
+		"nonce": "%s",
+		"arch": "HOPPER",
+		"evidence_list": [{"certificate": "dGVzdA==", "evidence": "dGVzdA=="}]
+	}`, gpuNonce)
+
+	attestMux := http.NewServeMux()
+	attestMux.HandleFunc("/cpu", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "deadbeefcpu")
+	})
+	attestMux.HandleFunc("/gpu", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, gpuJSON)
+	})
+	attestServer := httptest.NewTLSServer(attestMux)
+	defer attestServer.Close()
+	attestServer.TLS.Certificates = []tls.Certificate{cert}
+
+	portalMux := http.NewServeMux()
+	portalMux.HandleFunc("/api/quote-parse", func(w http.ResponseWriter, _ *http.Request) {
+		resp := ParseQuoteResponse{
+			Quote: &QuoteFields{
+				MRTD:       "aaaa",
+				RTMR0:      "bbbb",
+				RTMR1:      "cccc",
+				RTMR2:      "dddd",
+				RTMR3:      "eeee",
+				ReportData: cpuReportData,
+			},
+			Status: &QuoteStatus{AttestationType: "tdx"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+	portalServer := httptest.NewServer(portalMux)
+	defer portalServer.Close()
+
+	bv := NewBackendVerifier(portalServer.URL+"/api/quote-parse", nil, "", nil, testLog())
+	bv.attestationClient = NewAttestationHTTPClient()
+
+	err := bv.AttestBackend(context.Background(), "test-model", attestServer.URL)
+	if err != nil {
+		t.Fatalf("AttestBackend failed: %s", err)
+	}
+
+	status := bv.GetStatus("test-model")
+	if status == nil {
+		t.Fatal("expected status")
+	}
+	if status.Status != StatusPassed {
+		t.Fatalf("expected StatusPassed, got %s (error: %s)", status.Status, status.Error)
+	}
+	if status.TEEType != TEETypeTDX {
+		t.Fatalf("expected TDX, got %s", status.TEEType)
+	}
+}
+
+func TestBackendVerifier_AttestBackend_WithNRAS(t *testing.T) {
+	cert, fingerprint := selfSignedCert(t)
+
+	gpuNonce := "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	cpuReportData := fingerprint + gpuNonce
+
+	gpuJSON := fmt.Sprintf(`{
+		"nonce": "%s",
+		"arch": "HOPPER",
+		"evidence_list": [{"certificate": "dGVzdA==", "evidence": "dGVzdA=="}]
+	}`, gpuNonce)
+
+	attestMux := http.NewServeMux()
+	attestMux.HandleFunc("/cpu", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "deadbeefcpu")
+	})
+	attestMux.HandleFunc("/gpu", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, gpuJSON)
+	})
+	attestServer := httptest.NewTLSServer(attestMux)
+	defer attestServer.Close()
+	attestServer.TLS.Certificates = []tls.Certificate{cert}
+
+	portalMux := http.NewServeMux()
+	portalMux.HandleFunc("/api/quote-parse", func(w http.ResponseWriter, _ *http.Request) {
+		resp := ParseQuoteResponse{
+			Quote: &QuoteFields{
+				MRTD:       "aaaa",
+				RTMR0:      "bbbb",
+				RTMR1:      "cccc",
+				RTMR2:      "dddd",
+				RTMR3:      "eeee",
+				ReportData: cpuReportData,
+			},
+			Status: &QuoteStatus{AttestationType: "tdx"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+	portalServer := httptest.NewServer(portalMux)
+	defer portalServer.Close()
+
+	// Mock NRAS server
+	nrasMux := http.NewServeMux()
+	nrasMux.HandleFunc("/v2/attest/gpu", func(w http.ResponseWriter, r *http.Request) {
+		var req NRASRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("NRAS: failed to decode request: %s", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if req.Arch != "HOPPER" {
+			t.Errorf("NRAS: expected arch HOPPER, got %s", req.Arch)
+		}
+		if len(req.Evidences) != 1 {
+			t.Errorf("NRAS: expected 1 evidence, got %d", len(req.Evidences))
+		}
+
+		resp := []json.RawMessage{
+			[]byte(`["JWT", "eyOverallToken"]`),
+			[]byte(`{"GPU-0": "eyGPU0Token"}`),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+	nrasServer := httptest.NewServer(nrasMux)
+	defer nrasServer.Close()
+
+	bv := NewBackendVerifier(portalServer.URL+"/api/quote-parse", nil, nrasServer.URL, nil, testLog())
+	bv.attestationClient = NewAttestationHTTPClient()
+
+	err := bv.AttestBackend(context.Background(), "test-model-nras", attestServer.URL)
+	if err != nil {
+		t.Fatalf("AttestBackend with NRAS failed: %s", err)
+	}
+
+	status := bv.GetStatus("test-model-nras")
+	if status == nil {
+		t.Fatal("expected status")
+	}
+	if status.Status != StatusPassed {
+		t.Fatalf("expected StatusPassed, got %s (error: %s)", status.Status, status.Error)
+	}
+}
+
+// --- PinnedHTTPClient ---
+
+func TestBackendVerifier_PinnedHTTPClient_NoModel(t *testing.T) {
+	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	_, err := bv.PinnedHTTPClient("no-model")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestBackendVerifier_PinnedHTTPClient_Success(t *testing.T) {
+	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+
+	bv.mu.Lock()
+	bv.cache["model-1"] = &BackendAttestationSnapshot{
+		ModelID:        "model-1",
+		TLSFingerprint: "aabbccdd",
+		Status:         StatusPassed,
+	}
+	bv.mu.Unlock()
+
+	client, err := bv.PinnedHTTPClient("model-1")
+	if err != nil {
+		t.Fatalf("expected client, got: %s", err)
+	}
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
+}
+
+func TestBackendVerifier_PinnedHTTPClient_FailedStatus(t *testing.T) {
+	bv := NewBackendVerifier("http://unused", nil, "", nil, testLog())
+	bv.storeFailure("model-1", "https://test:29343", "broken")
+
+	_, err := bv.PinnedHTTPClient("model-1")
+	if err == nil {
+		t.Fatal("expected error for failed model")
+	}
+}
+
+// --- NoopGoldenSource ---
+
+func TestNoopGoldenSource(t *testing.T) {
+	src := &NoopGoldenSource{}
+	golden, err := src.FetchGoldenValues(context.Background(), "any", "any")
+	if err != nil {
+		t.Fatalf("expected no error, got: %s", err)
+	}
+	if golden != nil {
+		t.Fatalf("expected nil, got: %+v", golden)
+	}
+}

--- a/proxy-router/internal/attestation/golden_test.go
+++ b/proxy-router/internal/attestation/golden_test.go
@@ -1,0 +1,398 @@
+package attestation
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/sigstore/sigstore-go/pkg/bundle"
+	"github.com/sigstore/sigstore-go/pkg/root"
+	"github.com/sigstore/sigstore-go/pkg/verify"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Unit tests for parseAttestationPayload (no network, fast)
+// ---------------------------------------------------------------------------
+
+func TestParseAttestationPayload_DirectStatement(t *testing.T) {
+	statement := InTotoStatement{
+		Type:          "https://in-toto.io/Statement/v0.1",
+		PredicateType: teePredicateType,
+		Predicate: TEEPredicate{
+			TEEImage:       "ghcr.io/morpheusais/morpheus-lumerin-node-tee@sha256:abc123",
+			TEEImageDigest: "sha256:abc123",
+			ComposeSHA256:  "def456",
+			Measurements: TEEMeasurements{
+				IntelTDX: &TDXMeasurements{
+					RTMR3:           "aabbccdd00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabb",
+					SecretVMRelease: "v0.0.25",
+				},
+			},
+		},
+	}
+
+	payload, err := json.Marshal(statement)
+	require.NoError(t, err)
+
+	values, err := parseAttestationPayload(payload)
+	require.NoError(t, err)
+	assert.Equal(t, "aabbccdd00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabb", values.RTMR3)
+	assert.Empty(t, values.Measurement)
+}
+
+func TestParseAttestationPayload_DSSEEnvelope(t *testing.T) {
+	statement := InTotoStatement{
+		Type:          "https://in-toto.io/Statement/v0.1",
+		PredicateType: teePredicateType,
+		Predicate: TEEPredicate{
+			Measurements: TEEMeasurements{
+				IntelTDX: &TDXMeasurements{
+					RTMR3: "deadbeef",
+				},
+			},
+		},
+	}
+
+	statementBytes, err := json.Marshal(statement)
+	require.NoError(t, err)
+
+	envelope := DSSEEnvelope{
+		PayloadType: "application/vnd.in-toto+json",
+		Payload:     base64.StdEncoding.EncodeToString(statementBytes),
+	}
+
+	payload, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	values, err := parseAttestationPayload(payload)
+	require.NoError(t, err)
+	assert.Equal(t, "deadbeef", values.RTMR3)
+}
+
+func TestParseAttestationPayload_DSSEEnvelope_RawURLEncoding(t *testing.T) {
+	statement := InTotoStatement{
+		Type:          "https://in-toto.io/Statement/v0.1",
+		PredicateType: teePredicateType,
+		Predicate: TEEPredicate{
+			Measurements: TEEMeasurements{
+				AMDSEV: &SEVMeasurements{
+					Measurement: "sev-measurement-hash",
+				},
+			},
+		},
+	}
+
+	statementBytes, err := json.Marshal(statement)
+	require.NoError(t, err)
+
+	envelope := DSSEEnvelope{
+		PayloadType: "application/vnd.in-toto+json",
+		Payload:     base64.RawURLEncoding.EncodeToString(statementBytes),
+	}
+
+	payload, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	values, err := parseAttestationPayload(payload)
+	require.NoError(t, err)
+	assert.Empty(t, values.RTMR3)
+	assert.Equal(t, "sev-measurement-hash", values.Measurement)
+}
+
+func TestParseAttestationPayload_WrongPredicateType(t *testing.T) {
+	statement := InTotoStatement{
+		Type:          "https://in-toto.io/Statement/v0.1",
+		PredicateType: "https://slsa.dev/provenance/v0.2",
+		Predicate:     TEEPredicate{},
+	}
+
+	payload, err := json.Marshal(statement)
+	require.NoError(t, err)
+
+	_, err = parseAttestationPayload(payload)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "wrong predicate type")
+}
+
+func TestParseAttestationPayload_InvalidJSON(t *testing.T) {
+	_, err := parseAttestationPayload([]byte("not json"))
+	assert.Error(t, err)
+}
+
+func TestParseAttestationPayload_EmptyMeasurements(t *testing.T) {
+	statement := InTotoStatement{
+		Type:          "https://in-toto.io/Statement/v0.1",
+		PredicateType: teePredicateType,
+		Predicate: TEEPredicate{
+			Measurements: TEEMeasurements{},
+		},
+	}
+
+	payload, err := json.Marshal(statement)
+	require.NoError(t, err)
+
+	values, err := parseAttestationPayload(payload)
+	require.NoError(t, err)
+	assert.Empty(t, values.RTMR3)
+	assert.Empty(t, values.Measurement)
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for GoldenSource caching
+// ---------------------------------------------------------------------------
+
+func TestGoldenSource_CacheHit(t *testing.T) {
+	log := lib.NewTestLogger()
+	gs := NewGoldenSource("ghcr.io/example/test", log)
+
+	expected := &GoldenValues{RTMR3: "cached-value"}
+	gs.cache["v1.0.0"] = &cachedEntry{
+		values:    expected,
+		fetchedAt: time.Now(),
+	}
+
+	values, err := gs.FetchGoldenValues(context.Background(), "v1.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, "cached-value", values.RTMR3)
+}
+
+func TestGoldenSource_CacheExpired_NoNetwork(t *testing.T) {
+	log := lib.NewTestLogger()
+	gs := NewGoldenSource("ghcr.io/nonexistent/image", log)
+
+	stale := &GoldenValues{RTMR3: "stale-value"}
+	gs.cache["v1.0.0"] = &cachedEntry{
+		values:    stale,
+		fetchedAt: time.Now().Add(-1 * time.Hour),
+	}
+
+	values, err := gs.FetchGoldenValues(context.Background(), "v1.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, "stale-value", values.RTMR3, "should fall back to stale cache on network error")
+}
+
+func TestGoldenSource_DefaultImageRepo(t *testing.T) {
+	log := lib.NewTestLogger()
+	gs := NewGoldenSource("", log)
+	assert.Equal(t, defaultImageRepo, gs.imageRepo)
+}
+
+// ---------------------------------------------------------------------------
+// Integration test: verify real cosign attestation from GHCR
+//
+// Run with:
+//   TEE_TEST_IMAGE=ghcr.io/morpheusais/morpheus-lumerin-node-tee \
+//   TEE_TEST_VERSION=v5.14.6 \
+//   go test -v -run TestGoldenSource_RealImage -count=1 ./internal/attestation/
+//
+// Set TEE_TEST_EXPECTED_RTMR3 to also assert the extracted value.
+// ---------------------------------------------------------------------------
+
+func TestGoldenSource_RealImage(t *testing.T) {
+	imageRepo := os.Getenv("TEE_TEST_IMAGE")
+	version := os.Getenv("TEE_TEST_VERSION")
+	if imageRepo == "" || version == "" {
+		t.Skip("TEE_TEST_IMAGE and TEE_TEST_VERSION not set; skipping real-image integration test")
+	}
+
+	log := lib.NewTestLogger()
+	gs := NewGoldenSource(imageRepo, log)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	values, err := gs.FetchGoldenValues(ctx, version)
+	require.NoError(t, err, "cosign attestation verification should succeed")
+
+	t.Logf("--- Golden values from %s:%s ---", imageRepo, version)
+	t.Logf("RTMR3:       %s", values.RTMR3)
+	t.Logf("MRTD:        %s", values.MRTD)
+	t.Logf("RTMR0:       %s", values.RTMR0)
+	t.Logf("RTMR1:       %s", values.RTMR1)
+	t.Logf("RTMR2:       %s", values.RTMR2)
+	t.Logf("Measurement: %s", values.Measurement)
+
+	if expectedRTMR3 := os.Getenv("TEE_TEST_EXPECTED_RTMR3"); expectedRTMR3 != "" {
+		assert.Equal(t, expectedRTMR3, values.RTMR3, "RTMR3 should match expected value")
+	}
+
+	// Verify caching works on the second call
+	values2, err := gs.FetchGoldenValues(ctx, version)
+	require.NoError(t, err)
+	assert.Equal(t, values.RTMR3, values2.RTMR3, "cached result should match")
+}
+
+// ---------------------------------------------------------------------------
+// Integration test: verify real image and compare against live provider quote
+//
+// Run with:
+//   TEE_TEST_IMAGE=ghcr.io/morpheusais/morpheus-lumerin-node-tee \
+//   TEE_TEST_VERSION=v5.14.6 \
+//   TEE_TEST_PROVIDER_URL=morpheus.example.com:3333 \
+//   TEE_PORTAL_URL=https://secretai.scrtlabs.com/api/parse-quote \
+//   go test -v -run TestFullVerification -count=1 ./internal/attestation/
+// ---------------------------------------------------------------------------
+
+func TestFullVerification(t *testing.T) {
+	imageRepo := os.Getenv("TEE_TEST_IMAGE")
+	version := os.Getenv("TEE_TEST_VERSION")
+	providerURL := os.Getenv("TEE_TEST_PROVIDER_URL")
+	if imageRepo == "" || version == "" || providerURL == "" {
+		t.Skip("TEE_TEST_IMAGE, TEE_TEST_VERSION, and TEE_TEST_PROVIDER_URL not set; skipping full verification test")
+	}
+
+	portalURL := os.Getenv("TEE_PORTAL_URL")
+	log := lib.NewTestLogger()
+	verifier := NewVerifier(portalURL, imageRepo, log)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	err := verifier.VerifyProvider(ctx, providerURL, version)
+	if err != nil {
+		t.Fatalf("full TEE verification failed: %s", err)
+	}
+	t.Logf("Full TEE verification PASSED for provider %s (version %s)", providerURL, version)
+}
+
+// ---------------------------------------------------------------------------
+// Standalone: fetch and print attestation predicate (like cosign verify-attestation | jq)
+//
+// Run with:
+//   TEE_TEST_IMAGE=ghcr.io/morpheusais/morpheus-lumerin-node-tee \
+//   TEE_TEST_VERSION=v5.14.6 \
+//   go test -v -run TestDumpAttestationPredicate -count=1 ./internal/attestation/
+// ---------------------------------------------------------------------------
+
+func TestDumpAttestationPredicate(t *testing.T) {
+	imageRepo := os.Getenv("TEE_TEST_IMAGE")
+	version := os.Getenv("TEE_TEST_VERSION")
+	if imageRepo == "" || version == "" {
+		t.Skip("TEE_TEST_IMAGE and TEE_TEST_VERSION not set; skipping attestation dump test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	imageRef := fmt.Sprintf("%s:%s", imageRepo, version)
+	t.Logf("Fetching and verifying cosign attestations for %s ...", imageRef)
+
+	ref, err := name.ParseReference(imageRef)
+	require.NoError(t, err)
+
+	desc, err := remote.Get(ref, remote.WithContext(ctx))
+	require.NoError(t, err)
+
+	referrerTag := strings.Replace(desc.Digest.String(), ":", "-", 1)
+	referrerRef, err := name.ParseReference(fmt.Sprintf("%s:%s", ref.Context().String(), referrerTag))
+	require.NoError(t, err)
+
+	referrerIndex, err := remote.Index(referrerRef, remote.WithContext(ctx))
+	require.NoError(t, err)
+
+	indexManifest, err := referrerIndex.IndexManifest()
+	require.NoError(t, err)
+
+	trustedRoot, err := root.FetchTrustedRoot()
+	require.NoError(t, err)
+
+	certID, err := verify.NewShortCertificateIdentity(defaultOIDCIssuer, "", "", defaultIdentityRegexp)
+	require.NoError(t, err)
+
+	sev, err := verify.NewSignedEntityVerifier(
+		trustedRoot,
+		verify.WithSignedCertificateTimestamps(1),
+		verify.WithTransparencyLog(1),
+		verify.WithObserverTimestamps(1),
+	)
+	require.NoError(t, err)
+
+	t.Logf("Total referrers found: %d", len(indexManifest.Manifests))
+
+	for i, refDesc := range indexManifest.Manifests {
+		t.Logf("[%d] digest=%s artifactType=%s", i, refDesc.Digest, refDesc.ArtifactType)
+
+		imgRef := ref.Context().Digest(refDesc.Digest.String())
+		img, err := remote.Image(imgRef, remote.WithContext(ctx))
+		if err != nil {
+			t.Logf("[%d] fetch error: %s", i, err)
+			continue
+		}
+
+		dumpBundleLayers(t, i, img, sev, certID)
+	}
+}
+
+func dumpBundleLayers(t *testing.T, idx int, img v1.Image, sev *verify.Verifier, certID verify.CertificateIdentity) {
+	t.Helper()
+
+	layers, err := img.Layers()
+	if err != nil {
+		t.Logf("[%d] layers error: %s", idx, err)
+		return
+	}
+
+	for _, layer := range layers {
+		mt, _ := layer.MediaType()
+		if string(mt) != sigstoreBundleMediaType {
+			continue
+		}
+
+		reader, err := layer.Uncompressed()
+		if err != nil {
+			continue
+		}
+		data, err := io.ReadAll(reader)
+		reader.Close()
+		if err != nil {
+			continue
+		}
+
+		var b bundle.Bundle
+		if err := json.Unmarshal(data, &b); err != nil {
+			t.Logf("[%d] bundle parse error: %s", idx, err)
+			continue
+		}
+
+		_, err = sev.Verify(&b, verify.NewPolicy(
+			verify.WithoutArtifactUnsafe(),
+			verify.WithCertificateIdentity(certID),
+		))
+		if err != nil {
+			t.Logf("[%d] verification failed: %s", idx, err)
+			continue
+		}
+		t.Logf("[%d] VERIFIED", idx)
+
+		envelope, err := b.Envelope()
+		if err != nil {
+			continue
+		}
+		stmt, err := envelope.Statement()
+		if err != nil {
+			continue
+		}
+
+		t.Logf("[%d] predicateType: %s", idx, stmt.GetPredicateType())
+		predJSON, _ := stmt.GetPredicate().MarshalJSON()
+		var pretty json.RawMessage
+		if json.Unmarshal(predJSON, &pretty) == nil {
+			out, _ := json.MarshalIndent(pretty, "", "  ")
+			t.Logf("[%d] predicate:\n%s", idx, string(out))
+		}
+	}
+}
+

--- a/proxy-router/internal/attestation/nras_verifier.go
+++ b/proxy-router/internal/attestation/nras_verifier.go
@@ -1,0 +1,153 @@
+package attestation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+)
+
+const (
+	nrasBaseURL       = "https://nras.attestation.nvidia.com"
+	nrasGPUAttestPath = "/v4/attest/gpu"
+)
+
+// GPUEvidence represents a single GPU's attestation evidence from the SecretVM /gpu endpoint.
+type GPUEvidence struct {
+	Evidence    string `json:"evidence"`
+	Certificate string `json:"certificate"`
+}
+
+// GPUAttestationData is the JSON structure returned by the SecretVM /gpu endpoint.
+type GPUAttestationData struct {
+	Nonce        string        `json:"nonce"`
+	Arch         string        `json:"arch"`
+	EvidenceList []GPUEvidence `json:"evidence_list"`
+}
+
+// NRASResult holds the parsed response from NRAS.
+type NRASResult struct {
+	OverallToken string
+	GPUTokens    map[string]string
+}
+
+// NRASVerifier verifies GPU attestation evidence via NVIDIA Remote Attestation Service.
+// It sends the GPU evidence collected from the SecretVM /gpu endpoint to NRAS,
+// which validates the NVIDIA certificate chain and evidence signature,
+// and returns signed Entity Attestation Token (EAT) JWTs.
+type NRASVerifier struct {
+	client  *http.Client
+	baseURL string
+	log     lib.ILogger
+}
+
+func NewNRASVerifier(log lib.ILogger) *NRASVerifier {
+	return &NRASVerifier{
+		client:  NewPortalHTTPClient(),
+		baseURL: nrasBaseURL,
+		log:     log,
+	}
+}
+
+// VerifyGPU sends GPU attestation evidence to NRAS for verification.
+// The gpuData is the raw JSON response from the SecretVM /gpu endpoint.
+// Returns the overall JWT token and per-GPU tokens on success.
+func (nv *NRASVerifier) VerifyGPU(ctx context.Context, gpuData *GPUAttestationData) (*NRASResult, error) {
+	if len(gpuData.EvidenceList) == 0 {
+		return nil, fmt.Errorf("GPU attestation data contains no evidence entries")
+	}
+
+	// Send the GPU attestation data as-is to NRAS (same as secretvm-verify JS library).
+	// GPUAttestationData JSON tags match what NRAS expects: nonce, arch, evidence_list.
+	body, err := json.Marshal(gpuData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal NRAS request: %w", err)
+	}
+
+	attestURL := nv.baseURL + nrasGPUAttestPath
+	noncePreview := gpuData.Nonce
+	if len(noncePreview) > 16 {
+		noncePreview = noncePreview[:16] + "..."
+	}
+	nv.log.Infof("NRAS: sending GPU evidence to %s (arch=%s, nonce=%s, gpus=%d)",
+		attestURL, gpuData.Arch, noncePreview, len(gpuData.EvidenceList))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, attestURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create NRAS request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := nv.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("NRAS request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read NRAS response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("NRAS returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return parseNRASResponse(respBody)
+}
+
+// parseNRASResponse parses the NRAS response format:
+// [ ["JWT", "<overall-token>"], { "GPU-0": "<token>", ... } ]
+func parseNRASResponse(body []byte) (*NRASResult, error) {
+	var raw []json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse NRAS response as array: %w", err)
+	}
+
+	if len(raw) < 2 {
+		return nil, fmt.Errorf("NRAS response has fewer than 2 elements (got %d)", len(raw))
+	}
+
+	// First element: ["JWT", "<overall-token>"]
+	var overallPair []string
+	if err := json.Unmarshal(raw[0], &overallPair); err != nil {
+		return nil, fmt.Errorf("failed to parse NRAS overall token pair: %w", err)
+	}
+	if len(overallPair) < 2 {
+		return nil, fmt.Errorf("NRAS overall token pair has fewer than 2 elements")
+	}
+
+	// Second element: { "GPU-0": "<token>", ... }
+	var gpuTokens map[string]string
+	if err := json.Unmarshal(raw[1], &gpuTokens); err != nil {
+		return nil, fmt.Errorf("failed to parse NRAS GPU tokens: %w", err)
+	}
+
+	return &NRASResult{
+		OverallToken: overallPair[1],
+		GPUTokens:    gpuTokens,
+	}, nil
+}
+
+// ParseGPUAttestationData parses the raw JSON response from the SecretVM /gpu endpoint.
+func ParseGPUAttestationData(rawJSON string) (*GPUAttestationData, error) {
+	var data GPUAttestationData
+	if err := json.Unmarshal([]byte(rawJSON), &data); err != nil {
+		return nil, fmt.Errorf("failed to parse GPU attestation JSON: %w", err)
+	}
+	if data.Nonce == "" {
+		return nil, fmt.Errorf("GPU attestation data missing nonce field")
+	}
+	if data.Arch == "" {
+		return nil, fmt.Errorf("GPU attestation data missing arch field")
+	}
+	if len(data.EvidenceList) == 0 {
+		return nil, fmt.Errorf("GPU attestation data has empty evidence_list")
+	}
+	return &data, nil
+}

--- a/proxy-router/internal/attestation/nras_verifier_test.go
+++ b/proxy-router/internal/attestation/nras_verifier_test.go
@@ -1,0 +1,192 @@
+package attestation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+)
+
+func TestParseGPUAttestationData_Valid(t *testing.T) {
+	raw := `{
+		"nonce": "a768bb3a38c48d3636b9e8250a3b12da05f557eca0b484bf9d8fa5719c0341bd",
+		"arch": "HOPPER",
+		"evidence_list": [
+			{"certificate": "LS0tLS1CRUdJTg==", "evidence": "EeAB/6do"}
+		]
+	}`
+
+	data, err := ParseGPUAttestationData(raw)
+	if err != nil {
+		t.Fatalf("expected no error, got: %s", err)
+	}
+	if data.Nonce != "a768bb3a38c48d3636b9e8250a3b12da05f557eca0b484bf9d8fa5719c0341bd" {
+		t.Fatalf("unexpected nonce: %s", data.Nonce)
+	}
+	if data.Arch != "HOPPER" {
+		t.Fatalf("unexpected arch: %s", data.Arch)
+	}
+	if len(data.EvidenceList) != 1 {
+		t.Fatalf("expected 1 evidence, got %d", len(data.EvidenceList))
+	}
+}
+
+func TestParseGPUAttestationData_MissingNonce(t *testing.T) {
+	raw := `{"arch": "HOPPER", "evidence_list": [{"certificate": "x", "evidence": "y"}]}`
+	_, err := ParseGPUAttestationData(raw)
+	if err == nil {
+		t.Fatal("expected error for missing nonce")
+	}
+}
+
+func TestParseGPUAttestationData_MissingArch(t *testing.T) {
+	raw := `{"nonce": "abc", "evidence_list": [{"certificate": "x", "evidence": "y"}]}`
+	_, err := ParseGPUAttestationData(raw)
+	if err == nil {
+		t.Fatal("expected error for missing arch")
+	}
+}
+
+func TestParseGPUAttestationData_EmptyEvidenceList(t *testing.T) {
+	raw := `{"nonce": "abc", "arch": "HOPPER", "evidence_list": []}`
+	_, err := ParseGPUAttestationData(raw)
+	if err == nil {
+		t.Fatal("expected error for empty evidence_list")
+	}
+}
+
+func TestParseGPUAttestationData_InvalidJSON(t *testing.T) {
+	_, err := ParseGPUAttestationData("not json")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestParseNRASResponse_Valid(t *testing.T) {
+	resp := `[["JWT", "eyOverall"], {"GPU-0": "eyGPU0", "GPU-1": "eyGPU1"}]`
+	result, err := parseNRASResponse([]byte(resp))
+	if err != nil {
+		t.Fatalf("expected no error, got: %s", err)
+	}
+	if result.OverallToken != "eyOverall" {
+		t.Fatalf("unexpected overall token: %s", result.OverallToken)
+	}
+	if len(result.GPUTokens) != 2 {
+		t.Fatalf("expected 2 GPU tokens, got %d", len(result.GPUTokens))
+	}
+	if result.GPUTokens["GPU-0"] != "eyGPU0" {
+		t.Fatalf("unexpected GPU-0 token: %s", result.GPUTokens["GPU-0"])
+	}
+}
+
+func TestParseNRASResponse_InvalidFormat(t *testing.T) {
+	_, err := parseNRASResponse([]byte(`"not an array"`))
+	if err == nil {
+		t.Fatal("expected error for non-array response")
+	}
+}
+
+func TestParseNRASResponse_TooFewElements(t *testing.T) {
+	_, err := parseNRASResponse([]byte(`[["JWT","tok"]]`))
+	if err == nil {
+		t.Fatal("expected error for too few elements")
+	}
+}
+
+func TestNRASVerifier_VerifyGPU_Success(t *testing.T) {
+	nrasMux := http.NewServeMux()
+	nrasMux.HandleFunc("/v4/attest/gpu", func(w http.ResponseWriter, r *http.Request) {
+		var req GPUAttestationData
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("failed to decode: %s", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if req.Arch != "HOPPER" {
+			t.Errorf("expected HOPPER, got %s", req.Arch)
+		}
+		if req.Nonce != "testnonce123" {
+			t.Errorf("expected testnonce123, got %s", req.Nonce)
+		}
+		if len(req.EvidenceList) != 1 {
+			t.Errorf("expected 1 evidence, got %d", len(req.EvidenceList))
+		}
+
+		resp := []json.RawMessage{
+			[]byte(`["JWT", "eyOverallToken"]`),
+			[]byte(`{"GPU-0": "eyGPU0Token"}`),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+	server := httptest.NewServer(nrasMux)
+	defer server.Close()
+
+	nv := NewNRASVerifier(&lib.LoggerMock{})
+	nv.baseURL = server.URL
+
+	gpuData := &GPUAttestationData{
+		Nonce: "testnonce123",
+		Arch:  "HOPPER",
+		EvidenceList: []GPUEvidence{
+			{Certificate: "dGVzdA==", Evidence: "dGVzdA=="},
+		},
+	}
+
+	result, err := nv.VerifyGPU(context.Background(), gpuData)
+	if err != nil {
+		t.Fatalf("expected no error, got: %s", err)
+	}
+	if result.OverallToken != "eyOverallToken" {
+		t.Fatalf("unexpected overall token: %s", result.OverallToken)
+	}
+	if result.GPUTokens["GPU-0"] != "eyGPU0Token" {
+		t.Fatalf("unexpected GPU-0 token: %s", result.GPUTokens["GPU-0"])
+	}
+}
+
+func TestNRASVerifier_VerifyGPU_ServerError(t *testing.T) {
+	nrasMux := http.NewServeMux()
+	nrasMux.HandleFunc("/v4/attest/gpu", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error": "internal error"}`))
+	})
+	server := httptest.NewServer(nrasMux)
+	defer server.Close()
+
+	nv := NewNRASVerifier(&lib.LoggerMock{})
+	nv.baseURL = server.URL
+
+	gpuData := &GPUAttestationData{
+		Nonce:        "testnonce",
+		Arch:         "HOPPER",
+		EvidenceList: []GPUEvidence{{Certificate: "x", Evidence: "y"}},
+	}
+
+	_, err := nv.VerifyGPU(context.Background(), gpuData)
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("expected status 500 in error, got: %s", err)
+	}
+}
+
+func TestNRASVerifier_VerifyGPU_EmptyEvidence(t *testing.T) {
+	nv := NewNRASVerifier(&lib.LoggerMock{})
+
+	gpuData := &GPUAttestationData{
+		Nonce:        "testnonce",
+		Arch:         "HOPPER",
+		EvidenceList: []GPUEvidence{},
+	}
+
+	_, err := nv.VerifyGPU(context.Background(), gpuData)
+	if err == nil {
+		t.Fatal("expected error for empty evidence")
+	}
+}

--- a/proxy-router/internal/attestation/rtmr.go
+++ b/proxy-router/internal/attestation/rtmr.go
@@ -1,0 +1,45 @@
+package attestation
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"strings"
+)
+
+// CalculateRTMR3 computes the expected RTMR3 value from a docker-compose.yaml
+// content and a rootfs_data hash (hex string from the artifact registry).
+func CalculateRTMR3(dockerComposeBytes []byte, rootfsDataHex string) string {
+	composeHash := sha256.Sum256(dockerComposeBytes)
+	log := []string{
+		hex.EncodeToString(composeHash[:]),
+		strings.ToLower(strings.TrimPrefix(rootfsDataHex, "0x")),
+	}
+	return replayRtmr(log)
+}
+
+// replayRtmr replays the RTMR extend operation over a sequence of hex-encoded entries.
+// Starting from 48 zero bytes, for each entry:
+//   - Decode from hex, right-pad to 48 bytes with zeros
+//   - Compute SHA-384(current_mr || padded_entry)
+//   - Take first 48 bytes as new mr
+//
+// Returns the final mr as a lowercase hex string.
+func replayRtmr(log []string) string {
+	var mr [48]byte
+
+	for _, entry := range log {
+		entryBytes, _ := hex.DecodeString(entry)
+
+		var padded [48]byte
+		copy(padded[:], entryBytes)
+
+		var buf [96]byte
+		copy(buf[:48], mr[:])
+		copy(buf[48:], padded[:])
+
+		mr = sha512.Sum384(buf[:])
+	}
+
+	return hex.EncodeToString(mr[:])
+}

--- a/proxy-router/internal/attestation/tdx_quote.go
+++ b/proxy-router/internal/attestation/tdx_quote.go
@@ -1,0 +1,65 @@
+package attestation
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+const (
+	tdxQuoteHeaderSize    = 48
+	tdxTdReportBodySize   = 584
+	tdxMinQuoteSize       = tdxQuoteHeaderSize + tdxTdReportBodySize
+	tdxExpectedVersion    = 4
+	tdxExpectedTeeType    = 0x81
+)
+
+type TdxQuoteFields struct {
+	MRTD       string
+	RTMR0      string
+	RTMR1      string
+	RTMR2      string
+	RTMR3      string
+	ReportData string
+}
+
+func ParseTdxQuoteFields(quoteHex string) (*TdxQuoteFields, error) {
+	raw, err := hex.DecodeString(strings.TrimSpace(quoteHex))
+	if err != nil {
+		return nil, fmt.Errorf("invalid hex encoding: %w", err)
+	}
+
+	if len(raw) < tdxMinQuoteSize {
+		return nil, fmt.Errorf("quote too short: got %d bytes, need at least %d", len(raw), tdxMinQuoteSize)
+	}
+
+	version := binary.LittleEndian.Uint16(raw[0:2])
+	if version != tdxExpectedVersion {
+		return nil, fmt.Errorf("unexpected quote version: got %d, expected %d", version, tdxExpectedVersion)
+	}
+
+	teeType := binary.LittleEndian.Uint32(raw[4:8])
+	if teeType != tdxExpectedTeeType {
+		return nil, fmt.Errorf("unexpected TEE type: got 0x%x, expected 0x%x", teeType, tdxExpectedTeeType)
+	}
+
+	return &TdxQuoteFields{
+		MRTD:       hex.EncodeToString(raw[184:232]),
+		RTMR0:      hex.EncodeToString(raw[376:424]),
+		RTMR1:      hex.EncodeToString(raw[424:472]),
+		RTMR2:      hex.EncodeToString(raw[472:520]),
+		RTMR3:      hex.EncodeToString(raw[520:568]),
+		ReportData: hex.EncodeToString(raw[568:632]),
+	}, nil
+}
+
+func IsTdxQuote(quoteHex string) bool {
+	raw, err := hex.DecodeString(strings.TrimSpace(quoteHex))
+	if err != nil || len(raw) < 8 {
+		return false
+	}
+	version := binary.LittleEndian.Uint16(raw[0:2])
+	teeType := binary.LittleEndian.Uint32(raw[4:8])
+	return version == tdxExpectedVersion && teeType == tdxExpectedTeeType
+}

--- a/proxy-router/internal/attestation/verifier.go
+++ b/proxy-router/internal/attestation/verifier.go
@@ -44,9 +44,9 @@ func (c *collateralField) UnmarshalJSON(data []byte) error {
 }
 
 const (
-	attestationPort  = "29343"
-	defaultPortalURL = "https://secretai.scrtlabs.com/api/quote-parse"
-	verifyTimeout    = 30 * time.Second
+	AttestationPort  = "29343"
+	DefaultPortalURL = "https://secretai.scrtlabs.com/api/quote-parse"
+	VerifyTimeout    = 30 * time.Second
 )
 
 // ParseQuoteRequest is the POST body for the SecretAI Portal quote-parse API.
@@ -130,30 +130,38 @@ type Verifier struct {
 	quoteCache map[string]*verifiedQuoteEntry
 }
 
+// NewPortalHTTPClient creates an HTTP client for the SecretAI Portal API.
+func NewPortalHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: VerifyTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+		},
+	}
+}
+
+// NewAttestationHTTPClient creates an HTTP client for TEE attestation endpoints.
+// Uses InsecureSkipVerify because the self-signed cert is verified via reportdata binding.
+func NewAttestationHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: VerifyTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion:         tls.VersionTLS12,
+				InsecureSkipVerify: true, //nolint:gosec // verified via reportdata
+			},
+		},
+	}
+}
+
 func NewVerifier(portalURL string, imageRepo string, log lib.ILogger) *Verifier {
 	if portalURL == "" {
-		portalURL = defaultPortalURL
-	}
-
-	portalTransport := &http.Transport{
-		TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
-	}
-
-	// The attestation endpoint on :29343 uses a self-signed TLS certificate
-	// generated inside the TEE. We skip standard CA verification here because
-	// the certificate is verified via reportdata binding instead -- a stronger
-	// guarantee than CA trust, since the cert fingerprint is embedded in the
-	// hardware-signed attestation quote.
-	attestationTransport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: true, //nolint:gosec // verified via reportdata
-		},
+		portalURL = DefaultPortalURL
 	}
 
 	return &Verifier{
-		portalClient:      &http.Client{Timeout: verifyTimeout, Transport: portalTransport},
-		attestationClient: &http.Client{Timeout: verifyTimeout, Transport: attestationTransport},
+		portalClient:      NewPortalHTTPClient(),
+		attestationClient: NewAttestationHTTPClient(),
 		portalURL:         portalURL,
 		goldenSrc:         NewGoldenSource(imageRepo, log),
 		log:               log,
@@ -200,9 +208,11 @@ func (v *Verifier) VerifyProvider(ctx context.Context, providerEndpoint string, 
 
 	v.log.Infof("attestation quote is valid (type: %s) for provider %s", result.Type, providerEndpoint)
 
-	if err := v.verifyTLSBinding(tlsFingerprint, result.ReportData); err != nil {
+	if err := VerifyTLSBinding(tlsFingerprint, result.ReportData); err != nil {
 		return fmt.Errorf("TLS binding verification failed (possible spoofing): %w", err)
 	}
+
+	v.log.Infof("TLS certificate fingerprint matches reportdata (anti-spoofing check passed)")
 
 	golden, err := v.goldenSrc.FetchGoldenValues(ctx, version)
 	if err != nil {
@@ -211,7 +221,7 @@ func (v *Verifier) VerifyProvider(ctx context.Context, providerEndpoint string, 
 
 	v.log.Infof("Got golden values: %+v", golden)
 
-	if err := v.compareRegisters(result, golden); err != nil {
+	if err := CompareRegisters(result, golden, v.log); err != nil {
 		v.log.Warnf("failed to compare registers: %s", err)
 		return err
 	}
@@ -230,7 +240,7 @@ func (v *Verifier) VerifyProvider(ctx context.Context, providerEndpoint string, 
 	return nil
 }
 
-// verifyTLSBinding checks that the SHA-256 fingerprint of the TLS certificate
+// VerifyTLSBinding checks that the SHA-256 fingerprint of the TLS certificate
 // presented by the attestation endpoint matches the reportdata field in the
 // hardware-signed attestation quote.
 //
@@ -238,7 +248,7 @@ func (v *Verifier) VerifyProvider(ctx context.Context, providerEndpoint string, 
 // fingerprint in the first 32 bytes (64 hex chars) of reportdata. Because the
 // TLS private key never leaves the TEE, a spoofed server cannot present a
 // certificate whose fingerprint matches a stolen quote's reportdata.
-func (v *Verifier) verifyTLSBinding(tlsFingerprint string, reportData string) error {
+func VerifyTLSBinding(tlsFingerprint string, reportData string) error {
 	if tlsFingerprint == "" {
 		return fmt.Errorf("no TLS certificate fingerprint captured from attestation endpoint")
 	}
@@ -260,7 +270,6 @@ func (v *Verifier) verifyTLSBinding(tlsFingerprint string, reportData string) er
 			tlsFingerprint, reportPrefix)
 	}
 
-	v.log.Infof("TLS certificate fingerprint matches reportdata (anti-spoofing check passed)")
 	return nil
 }
 
@@ -347,9 +356,9 @@ func (v *Verifier) fullVerifyWithPing(ctx context.Context, providerEndpoint stri
 	return v.VerifyProvider(ctx, providerEndpoint, version)
 }
 
-// compareRegisters checks every register present in the golden values against
-// the values extracted from the provider's attestation quote.
-func (v *Verifier) compareRegisters(result *AttestationResult, golden *GoldenValues) error {
+// CompareRegisters checks every register present in the golden values against
+// the values extracted from the attestation quote.
+func CompareRegisters(result *AttestationResult, golden *GoldenValues, log lib.ILogger) error {
 	type regPair struct {
 		name   string
 		golden string
@@ -376,7 +385,9 @@ func (v *Verifier) compareRegisters(result *AttestationResult, golden *GoldenVal
 	var mismatches []string
 	for _, p := range pairs {
 		if p.golden == "" {
-			v.log.Debugf("register %s: golden value empty, skipping", p.name)
+			if log != nil {
+				log.Debugf("register %s: golden value empty, skipping", p.name)
+			}
 			continue
 		}
 		if p.actual == "" {
@@ -385,8 +396,8 @@ func (v *Verifier) compareRegisters(result *AttestationResult, golden *GoldenVal
 		}
 		if !strings.EqualFold(p.golden, p.actual) {
 			mismatches = append(mismatches, fmt.Sprintf("%s: expected %s, got %s", p.name, p.golden, p.actual))
-		} else {
-			v.log.Infof("register %s: matches golden value", p.name)
+		} else if log != nil {
+			log.Infof("register %s: matches golden value", p.name)
 		}
 	}
 
@@ -394,23 +405,21 @@ func (v *Verifier) compareRegisters(result *AttestationResult, golden *GoldenVal
 		return fmt.Errorf("register mismatch: %s", strings.Join(mismatches, "; "))
 	}
 
-	v.log.Infof("all checked registers match golden values")
+	if log != nil {
+		log.Infof("all checked registers match golden values")
+	}
 	return nil
 }
 
-// loadAttestationQuote fetches the raw hex-encoded attestation quote from the
-// provider and returns the SHA-256 fingerprint of the peer's TLS certificate.
-func (v *Verifier) loadAttestationQuote(ctx context.Context, attestationBaseURL string) (hexQuote string, tlsFingerprint string, err error) {
-	cpuURL := attestationBaseURL + "/cpu"
-
-	v.log.Infof("fetching attestation quote from %s", cpuURL)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cpuURL, nil)
+// LoadAttestationQuote fetches a raw hex-encoded attestation quote from the
+// given URL path and returns the SHA-256 fingerprint of the peer's TLS certificate.
+func LoadAttestationQuote(ctx context.Context, client *http.Client, quoteURL string) (hexQuote string, tlsFingerprint string, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, quoteURL, nil)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := v.attestationClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to fetch attestation quote: %w", err)
 	}
@@ -423,8 +432,6 @@ func (v *Verifier) loadAttestationQuote(ctx context.Context, attestationBaseURL 
 	if resp.TLS != nil && len(resp.TLS.PeerCertificates) > 0 {
 		hash := sha256.Sum256(resp.TLS.PeerCertificates[0].Raw)
 		tlsFingerprint = hex.EncodeToString(hash[:])
-	} else {
-		v.log.Warnf("no TLS peer certificate received from %s", cpuURL)
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -434,32 +441,46 @@ func (v *Verifier) loadAttestationQuote(ctx context.Context, attestationBaseURL 
 
 	hexQuote = strings.TrimSpace(string(body))
 	if hexQuote == "" {
-		return "", "", fmt.Errorf("empty attestation quote from provider")
+		return "", "", fmt.Errorf("empty attestation quote")
 	}
-
-	v.log.Infof("received attestation quote from %s (%d bytes)", cpuURL, len(hexQuote))
 
 	return hexQuote, tlsFingerprint, nil
 }
 
-// verifyQuote sends the hex attestation quote to the SecretAI Portal parse-quote API
-// for cryptographic verification and field extraction.
-func (v *Verifier) verifyQuote(ctx context.Context, hexQuote string) (*AttestationResult, error) {
-	v.log.Infof("sending quote to SecretAI portal for cryptographic verification (%s)", v.portalURL)
+// loadAttestationQuote is the instance method that delegates to the package-level function.
+func (v *Verifier) loadAttestationQuote(ctx context.Context, attestationBaseURL string) (hexQuote string, tlsFingerprint string, err error) {
+	cpuURL := attestationBaseURL + "/cpu"
+	v.log.Infof("fetching attestation quote from %s", cpuURL)
 
+	hexQuote, tlsFingerprint, err = LoadAttestationQuote(ctx, v.attestationClient, cpuURL)
+	if err != nil {
+		return "", "", err
+	}
+
+	if tlsFingerprint == "" {
+		v.log.Warnf("no TLS peer certificate received from %s", cpuURL)
+	}
+
+	v.log.Infof("received attestation quote from %s (%d bytes)", cpuURL, len(hexQuote))
+	return hexQuote, tlsFingerprint, nil
+}
+
+// VerifyQuote sends the hex attestation quote to the SecretAI Portal parse-quote API
+// for cryptographic verification and field extraction.
+func VerifyQuote(ctx context.Context, portalClient *http.Client, portalURL string, hexQuote string) (*AttestationResult, error) {
 	reqBody := ParseQuoteRequest{Quote: hexQuote}
 	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.portalURL, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, portalURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := v.portalClient.Do(req)
+	resp, err := portalClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("portal request failed: %w", err)
 	}
@@ -480,11 +501,8 @@ func (v *Verifier) verifyQuote(ctx context.Context, hexQuote string) (*Attestati
 	}
 
 	if parsed.Error != "" {
-		v.log.Warnf("portal returned error: %s", parsed.Error)
 		return &AttestationResult{Valid: false, Error: parsed.Error}, nil
 	}
-
-	v.log.Infof("portal verified quote successfully, parsing fields")
 
 	q := parsed.Quote
 	mrtd := qf(q, "mr_td")
@@ -498,7 +516,6 @@ func (v *Verifier) verifyQuote(ctx context.Context, hexQuote string) (*Attestati
 	hasTDX := mrtd != "" && rtmr0 != "" && rtmr1 != "" && rtmr2 != ""
 	hasSEV := measurement != "" || reportData != ""
 
-	// status.attestation_type can also indicate TDX/SEV
 	if !hasTDX && parsed.Status != nil && strings.EqualFold(parsed.Status.AttestationType, "tdx") {
 		hasTDX = true
 	}
@@ -533,6 +550,21 @@ func (v *Verifier) verifyQuote(ctx context.Context, hexQuote string) (*Attestati
 	}, nil
 }
 
+// verifyQuote is the instance method that delegates to the package-level function.
+func (v *Verifier) verifyQuote(ctx context.Context, hexQuote string) (*AttestationResult, error) {
+	v.log.Infof("sending quote to SecretAI portal for cryptographic verification (%s)", v.portalURL)
+	result, err := VerifyQuote(ctx, v.portalClient, v.portalURL, hexQuote)
+	if err != nil {
+		return nil, err
+	}
+	if result.Error != "" {
+		v.log.Warnf("portal returned error: %s", result.Error)
+	} else {
+		v.log.Infof("portal verified quote successfully")
+	}
+	return result, nil
+}
+
 func qf(q *QuoteFields, field string) string {
 	if q == nil {
 		return ""
@@ -557,22 +589,27 @@ func qf(q *QuoteFields, field string) string {
 	}
 }
 
-// deriveAttestationURL constructs the SecretVM attestation base URL from a provider endpoint.
-// Provider endpoint format: "host:port" (e.g., "morpheus.dev.lumerin.io:3333")
-// Attestation URL format: "https://host:29343" (standard SecretVM attestation port)
-func deriveAttestationURL(providerEndpoint string) (string, error) {
-	if strings.Contains(providerEndpoint, "://") {
-		parsed, err := url.Parse(providerEndpoint)
+// DeriveAttestationURL constructs the SecretVM attestation base URL from an endpoint.
+// Input format: "host:port" or "https://host:port/path"
+// Output format: "https://host:29343"
+func DeriveAttestationURL(endpoint string) (string, error) {
+	if strings.Contains(endpoint, "://") {
+		parsed, err := url.Parse(endpoint)
 		if err != nil {
-			return "", fmt.Errorf("invalid provider endpoint URL: %w", err)
+			return "", fmt.Errorf("invalid endpoint URL: %w", err)
 		}
 		host := parsed.Hostname()
-		return fmt.Sprintf("https://%s:%s", host, attestationPort), nil
+		return fmt.Sprintf("https://%s:%s", host, AttestationPort), nil
 	}
 
-	host, _, err := net.SplitHostPort(providerEndpoint)
+	host, _, err := net.SplitHostPort(endpoint)
 	if err != nil {
-		host = providerEndpoint
+		host = endpoint
 	}
-	return fmt.Sprintf("https://%s:%s", host, attestationPort), nil
+	return fmt.Sprintf("https://%s:%s", host, AttestationPort), nil
+}
+
+// deriveAttestationURL is the old unexported alias kept for internal compatibility.
+func deriveAttestationURL(providerEndpoint string) (string, error) {
+	return DeriveAttestationURL(providerEndpoint)
 }

--- a/proxy-router/internal/attestation/workload_rytn_test.go
+++ b/proxy-router/internal/attestation/workload_rytn_test.go
@@ -1,0 +1,250 @@
+package attestation
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+)
+
+const rytnAttestationURL = "https://secretai-rytn.scrtlabs.com:29343"
+
+func skipIfNoNetwork(t *testing.T) {
+	if os.Getenv("TEE_INTEGRATION_TEST") == "" {
+		t.Skip("set TEE_INTEGRATION_TEST=1 to run live integration tests")
+	}
+}
+
+func insecureClient() *http.Client {
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion:         tls.VersionTLS12,
+				InsecureSkipVerify: true, //nolint:gosec
+			},
+		},
+	}
+}
+
+func fetchRaw(t *testing.T, url string) []byte {
+	t.Helper()
+	client := insecureClient()
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s failed: %s", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("GET %s returned %d", url, resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading %s: %s", url, err)
+	}
+	return body
+}
+
+// TestIntegration_RytnLive fetches CPU quote, docker-compose, and registry
+// from live endpoints and verifies the workload. Mirrors the app's AttestBackend flow.
+func TestIntegration_RytnLive(t *testing.T) {
+	skipIfNoNetwork(t)
+
+	// 1. Fetch CPU quote from live endpoint
+	cpuQuoteRaw := fetchRaw(t, rytnAttestationURL+"/cpu")
+	cpuQuoteHex := strings.TrimSpace(string(cpuQuoteRaw))
+	t.Logf("CPU quote: %d hex chars (%d bytes decoded)", len(cpuQuoteHex), len(cpuQuoteHex)/2)
+
+	// 2. Parse TDX fields
+	fields, err := ParseTdxQuoteFields(cpuQuoteHex)
+	if err != nil {
+		t.Fatalf("ParseTdxQuoteFields: %s", err)
+	}
+	t.Logf("MRTD:  %s", fields.MRTD)
+	t.Logf("RTMR0: %s", fields.RTMR0)
+	t.Logf("RTMR1: %s", fields.RTMR1)
+	t.Logf("RTMR2: %s", fields.RTMR2)
+	t.Logf("RTMR3: %s", fields.RTMR3)
+
+	// 3. Fetch docker-compose from live endpoint (raw, no trimming)
+	composeBody := fetchRaw(t, rytnAttestationURL+"/docker-compose")
+	composeHash := sha256.Sum256(composeBody)
+	t.Logf("docker-compose: %d bytes, sha256=%s", len(composeBody), hex.EncodeToString(composeHash[:]))
+	t.Logf("docker-compose first 200 chars: %q", string(composeBody[:min(200, len(composeBody))]))
+	t.Logf("docker-compose last 100 chars: %q", string(composeBody[max(0, len(composeBody)-100):]))
+
+	// 4. Download registry from GitHub
+	registryBody := fetchRaw(t, DefaultRegistryURL)
+	entries := parseTdxRegistryCSV(string(registryBody))
+	t.Logf("Registry: %d entries from %s", len(entries), DefaultRegistryURL)
+
+	registry := NewArtifactRegistry("http://unused", 1*time.Hour, &lib.LoggerMock{})
+	registry.mu.Lock()
+	registry.entries = entries
+	registry.lastFetched = time.Now()
+	registry.mu.Unlock()
+
+	// 5. Find matching artifacts
+	candidates := registry.FindMatchingArtifacts(fields.MRTD, fields.RTMR0, fields.RTMR1, fields.RTMR2)
+	t.Logf("Matching candidates: %d", len(candidates))
+
+	for i, c := range candidates {
+		calculated := CalculateRTMR3(composeBody, c.RootfsData)
+		t.Logf("  candidate[%d]: template=%s ver=%s env=%s", i, c.TemplateName, c.ArtifactsVer, c.VMType)
+		t.Logf("    rootfs_data:      %s", c.RootfsData)
+		t.Logf("    calculated RTMR3: %s", calculated)
+		t.Logf("    quote RTMR3:      %s", fields.RTMR3)
+		t.Logf("    match:            %v", calculated == fields.RTMR3)
+	}
+
+	// 6. Run full VerifyWorkload
+	result := VerifyWorkload(registry, cpuQuoteHex, string(composeBody), &lib.LoggerMock{})
+	t.Logf("VerifyWorkload result: status=%s template=%s ver=%s env=%s", result.Status, result.TemplateName, result.ArtifactsVer, result.Env)
+
+	if result.Status != WorkloadAuthentic {
+		t.Logf("MISMATCH DETECTED - comparing with local file...")
+
+		// Also try with the local file to see if it differs
+		_, f, _, _ := runtime.Caller(0)
+		localCompose, localErr := os.ReadFile(filepath.Join(filepath.Dir(f), "..", "..", "secretvm-verify", "rytn-docker-compose.yaml"))
+		if localErr == nil {
+			localHash := sha256.Sum256(localCompose)
+			t.Logf("Local rytn-docker-compose.yaml: %d bytes, sha256=%s", len(localCompose), hex.EncodeToString(localHash[:]))
+			localResult := VerifyWorkload(registry, cpuQuoteHex, string(localCompose), &lib.LoggerMock{})
+			t.Logf("VerifyWorkload with local file: status=%s", localResult.Status)
+
+			if len(composeBody) != len(localCompose) {
+				t.Logf("SIZE DIFFERS: live=%d local=%d (diff=%d bytes)", len(composeBody), len(localCompose), len(composeBody)-len(localCompose))
+			}
+		}
+
+		t.Fatalf("expected authentic_match, got %s", result.Status)
+	}
+}
+
+// TestIntegration_RytnLocalFiles uses local cpu_quote.txt and rytn-docker-compose.yaml
+// with the live registry from GitHub.
+func TestIntegration_RytnLocalFiles(t *testing.T) {
+	_, f, _, _ := runtime.Caller(0)
+	base := filepath.Join(filepath.Dir(f), "..", "..", "secretvm-verify")
+
+	quoteBytes, err := os.ReadFile(filepath.Join(base, "cpu_quote.txt"))
+	if err != nil {
+		t.Skipf("cpu_quote.txt not found: %s", err)
+	}
+	composeBytes, err := os.ReadFile(filepath.Join(base, "rytn-docker-compose.yaml"))
+	if err != nil {
+		t.Skipf("rytn-docker-compose.yaml not found: %s", err)
+	}
+
+	cpuQuoteHex := strings.TrimSpace(string(quoteBytes))
+
+	fields, err := ParseTdxQuoteFields(cpuQuoteHex)
+	if err != nil {
+		t.Fatalf("ParseTdxQuoteFields: %s", err)
+	}
+
+	composeHash := sha256.Sum256(composeBytes)
+	t.Logf("Local compose: %d bytes, sha256=%s", len(composeBytes), hex.EncodeToString(composeHash[:]))
+	t.Logf("Quote RTMR3: %s", fields.RTMR3)
+
+	// Try with local CSV first
+	csvBytes, csvErr := os.ReadFile(filepath.Join(base, "artifacts_registry", "tdx.csv"))
+	if csvErr != nil {
+		t.Skipf("tdx.csv not found: %s", csvErr)
+	}
+
+	registry := NewArtifactRegistry("http://unused", 1*time.Hour, &lib.LoggerMock{})
+	entries := parseTdxRegistryCSV(string(csvBytes))
+	registry.mu.Lock()
+	registry.entries = entries
+	registry.lastFetched = time.Now()
+	registry.mu.Unlock()
+	t.Logf("Local registry: %d entries", len(entries))
+
+	candidates := registry.FindMatchingArtifacts(fields.MRTD, fields.RTMR0, fields.RTMR1, fields.RTMR2)
+	t.Logf("Matching candidates: %d", len(candidates))
+
+	for i, c := range candidates {
+		calculated := CalculateRTMR3(composeBytes, c.RootfsData)
+		t.Logf("  candidate[%d]: template=%s ver=%s rootfs=%s", i, c.TemplateName, c.ArtifactsVer, c.RootfsData)
+		t.Logf("    calculated=%s quote=%s match=%v", calculated, fields.RTMR3, calculated == fields.RTMR3)
+	}
+
+	result := VerifyWorkload(registry, cpuQuoteHex, string(composeBytes), &lib.LoggerMock{})
+	t.Logf("Result: status=%s template=%s ver=%s env=%s", result.Status, result.TemplateName, result.ArtifactsVer, result.Env)
+
+	if result.Status != WorkloadAuthentic {
+		t.Fatalf("expected authentic_match, got %s", result.Status)
+	}
+}
+
+// TestIntegration_RytnBackendVerifier runs the full BackendVerifier.AttestBackend flow
+// against the live rytn endpoint, mirroring exactly what the app does.
+func TestIntegration_RytnBackendVerifier(t *testing.T) {
+	skipIfNoNetwork(t)
+
+	ctx := context.Background()
+
+	registry := NewArtifactRegistry(DefaultRegistryURL, 1*time.Hour, &lib.LoggerMock{})
+	registry.Start(ctx)
+
+	if !registry.IsLoaded() {
+		t.Fatal("registry failed to load")
+	}
+	t.Logf("Registry loaded with entries")
+
+	bv := NewBackendVerifier(
+		DefaultPortalURL,
+		&NoopGoldenSource{},
+		registry,
+		&lib.LoggerMock{},
+	)
+
+	err := bv.AttestBackend(ctx, "test-model", rytnAttestationURL)
+	if err != nil {
+		t.Logf("AttestBackend error: %s", err)
+
+		status := bv.GetStatus("test-model")
+		if status != nil {
+			t.Logf("Status: %s, Error: %s", status.Status, status.Error)
+			t.Logf("WorkloadStatus: %s, Template: %s, Ver: %s", status.WorkloadStatus, status.VMTemplateName, status.ArtifactsVersion)
+		}
+
+		t.Fatalf("AttestBackend failed: %s", err)
+	}
+
+	status := bv.GetStatus("test-model")
+	t.Logf("SUCCESS: status=%s workload=%s template=%s ver=%s",
+		status.Status, status.WorkloadStatus, status.VMTemplateName, status.ArtifactsVersion)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func init() {
+	// Suppress unused import error for fmt
+	_ = fmt.Sprintf
+}

--- a/proxy-router/internal/attestation/workload_verifier.go
+++ b/proxy-router/internal/attestation/workload_verifier.go
@@ -1,0 +1,83 @@
+package attestation
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+)
+
+type WorkloadStatus string
+
+const (
+	WorkloadAuthentic         WorkloadStatus = "authentic_match"
+	WorkloadAuthenticMismatch WorkloadStatus = "authentic_mismatch"
+	WorkloadNotAuthentic      WorkloadStatus = "not_authentic"
+)
+
+type WorkloadResult struct {
+	Status       WorkloadStatus
+	TemplateName string
+	VMType       string
+	ArtifactsVer string
+	Env          string
+}
+
+func VerifyTdxWorkload(registry *ArtifactRegistry, cpuQuoteHex string, dockerComposeYaml string, log lib.ILogger) WorkloadResult {
+	fields, err := ParseTdxQuoteFields(cpuQuoteHex)
+	if err != nil {
+		if log != nil {
+			log.Warnf("workload: failed to parse TDX quote: %s", err)
+		}
+		return WorkloadResult{Status: WorkloadNotAuthentic}
+	}
+
+	candidates := registry.FindMatchingArtifacts(fields.MRTD, fields.RTMR0, fields.RTMR1, fields.RTMR2)
+	if len(candidates) == 0 {
+		if log != nil {
+			log.Warnf("workload: no registry entries match MRTD=%s RTMR0=%s", fields.MRTD[:16]+"...", fields.RTMR0[:16]+"...")
+		}
+		return WorkloadResult{Status: WorkloadNotAuthentic}
+	}
+
+	best := registry.PickNewestVersion(candidates)
+
+	composeBytes := []byte(dockerComposeYaml)
+	composeHash := sha256.Sum256(composeBytes)
+	if log != nil {
+		log.Infof("workload: compose size=%d bytes, sha256=%s, quote RTMR3=%s, candidates=%d",
+			len(composeBytes), hex.EncodeToString(composeHash[:]), fields.RTMR3, len(candidates))
+	}
+
+	for i, entry := range candidates {
+		expected := CalculateRTMR3(composeBytes, entry.RootfsData)
+		if log != nil {
+			log.Infof("workload: candidate[%d] template=%s ver=%s rootfs=%s calculated_rtmr3=%s match=%v",
+				i, entry.TemplateName, entry.ArtifactsVer, entry.RootfsData, expected, expected == fields.RTMR3)
+		}
+		if expected == fields.RTMR3 {
+			return WorkloadResult{
+				Status:       WorkloadAuthentic,
+				TemplateName: entry.TemplateName,
+				VMType:       entry.VMType,
+				ArtifactsVer: entry.ArtifactsVer,
+				Env:          entry.VMType,
+			}
+		}
+	}
+
+	return WorkloadResult{
+		Status:       WorkloadAuthenticMismatch,
+		TemplateName: best.TemplateName,
+		VMType:       best.VMType,
+		ArtifactsVer: best.ArtifactsVer,
+		Env:          best.VMType,
+	}
+}
+
+func VerifyWorkload(registry *ArtifactRegistry, cpuQuoteData string, dockerComposeYaml string, log lib.ILogger) WorkloadResult {
+	if IsTdxQuote(cpuQuoteData) {
+		return VerifyTdxWorkload(registry, cpuQuoteData, dockerComposeYaml, log)
+	}
+	return WorkloadResult{Status: WorkloadNotAuthentic}
+}

--- a/proxy-router/internal/attestation/workload_verifier_test.go
+++ b/proxy-router/internal/attestation/workload_verifier_test.go
@@ -1,0 +1,173 @@
+package attestation
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+)
+
+const (
+	testDataRelPath    = "../../secretvm-verify/test-data"
+	registryCSVRelPath = "../../secretvm-verify/artifacts_registry/tdx.csv"
+)
+
+func readTestFixture(t *testing.T, filename string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(testDataRelPath, filename))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", filename, err)
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func testRegistry(t *testing.T) *ArtifactRegistry {
+	t.Helper()
+	csvData, err := os.ReadFile(registryCSVRelPath)
+	if err != nil {
+		t.Fatalf("read registry CSV: %v", err)
+	}
+	reg := NewArtifactRegistry("", 0, &lib.LoggerMock{})
+	reg.entries = parseTdxRegistryCSV(string(csvData))
+	reg.lastFetched = time.Now()
+	return reg
+}
+
+func TestParseTdxQuoteFields_Valid(t *testing.T) {
+	quoteHex := readTestFixture(t, "tdx_cpu_docker_check_quote.txt")
+	fields, err := ParseTdxQuoteFields(quoteHex)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, tc := range []struct {
+		name string
+		val  string
+	}{
+		{"MRTD", fields.MRTD},
+		{"RTMR0", fields.RTMR0},
+		{"RTMR1", fields.RTMR1},
+		{"RTMR2", fields.RTMR2},
+	} {
+		if len(tc.val) != 96 {
+			t.Fatalf("%s length = %d, want 96", tc.name, len(tc.val))
+		}
+		if _, err := hex.DecodeString(tc.val); err != nil {
+			t.Fatalf("%s not valid hex: %v", tc.name, err)
+		}
+	}
+	if fields.RTMR3 == "" {
+		t.Fatal("RTMR3 is empty")
+	}
+}
+
+func TestParseTdxQuoteFields_TooShort(t *testing.T) {
+	_, err := ParseTdxQuoteFields("0400020081000000")
+	if err == nil {
+		t.Fatal("expected error for short quote")
+	}
+}
+
+func TestParseTdxQuoteFields_InvalidHex(t *testing.T) {
+	_, err := ParseTdxQuoteFields("zzzz_not_hex_at_all!!!")
+	if err == nil {
+		t.Fatal("expected error for invalid hex")
+	}
+}
+
+func TestIsTdxQuote_Valid(t *testing.T) {
+	quoteHex := readTestFixture(t, "tdx_cpu_docker_check_quote.txt")
+	if !IsTdxQuote(quoteHex) {
+		t.Fatal("expected true for valid TDX quote")
+	}
+}
+
+func TestIsTdxQuote_Invalid(t *testing.T) {
+	if IsTdxQuote("not_a_quote_at_all") {
+		t.Fatal("expected false for garbage input")
+	}
+}
+
+func TestCalculateRTMR3_Deterministic(t *testing.T) {
+	compose := []byte("services:\n  app:\n    image: test:latest\n")
+	rootfs := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+	r1 := CalculateRTMR3(compose, rootfs)
+	r2 := CalculateRTMR3(compose, rootfs)
+	if r1 != r2 {
+		t.Fatalf("non-deterministic: %s != %s", r1, r2)
+	}
+	if len(r1) != 96 {
+		t.Fatalf("result length = %d, want 96", len(r1))
+	}
+}
+
+func TestReplayRtmr_EmptyLog(t *testing.T) {
+	result := replayRtmr(nil)
+	want := strings.Repeat("0", 96)
+	if result != want {
+		t.Fatalf("got %s, want %s", result, want)
+	}
+}
+
+func TestVerifyTdxWorkload_AuthenticMatch(t *testing.T) {
+	reg := testRegistry(t)
+	quoteHex := readTestFixture(t, "tdx_cpu_docker_check_quote.txt")
+	composeYaml := readTestFixture(t, "tdx_cpu_docker_check_compose.yaml")
+
+	result := VerifyTdxWorkload(reg, quoteHex, composeYaml, nil)
+	if result.Status != WorkloadAuthentic {
+		t.Fatalf("status = %s, want %s", result.Status, WorkloadAuthentic)
+	}
+}
+
+func TestVerifyTdxWorkload_AuthenticMismatch(t *testing.T) {
+	reg := testRegistry(t)
+	quoteHex := readTestFixture(t, "tdx_cpu_docker_check_quote.txt")
+	composeYaml := readTestFixture(t, "tdx_cpu_docker_check_compose.yaml") + "\n# tampered"
+
+	result := VerifyTdxWorkload(reg, quoteHex, composeYaml, nil)
+	if result.Status != WorkloadAuthenticMismatch {
+		t.Fatalf("status = %s, want %s", result.Status, WorkloadAuthenticMismatch)
+	}
+}
+
+func TestVerifyTdxWorkload_NotAuthentic(t *testing.T) {
+	reg := testRegistry(t)
+	quoteHex := readTestFixture(t, "tdx_cpu_docker_check_quote.txt")
+
+	raw, err := hex.DecodeString(quoteHex)
+	if err != nil {
+		t.Fatalf("decode quote: %v", err)
+	}
+	raw[184] ^= 0xFF
+	raw[185] ^= 0xFF
+	corrupted := hex.EncodeToString(raw)
+
+	result := VerifyTdxWorkload(reg, corrupted, "anything", nil)
+	if result.Status != WorkloadNotAuthentic {
+		t.Fatalf("status = %s, want %s", result.Status, WorkloadNotAuthentic)
+	}
+}
+
+func TestVerifyWorkload_TdxQuote(t *testing.T) {
+	reg := testRegistry(t)
+	quoteHex := readTestFixture(t, "tdx_cpu_docker_check_quote.txt")
+	composeYaml := readTestFixture(t, "tdx_cpu_docker_check_compose.yaml")
+
+	result := VerifyWorkload(reg, quoteHex, composeYaml, nil)
+	if result.Status != WorkloadAuthentic {
+		t.Fatalf("status = %s, want %s", result.Status, WorkloadAuthentic)
+	}
+}
+
+func TestVerifyWorkload_NonTdxQuote(t *testing.T) {
+	reg := testRegistry(t)
+	result := VerifyWorkload(reg, "SGVsbG8gV29ybGQ=", "anything", nil)
+	if result.Status != WorkloadNotAuthentic {
+		t.Fatalf("status = %s, want %s", result.Status, WorkloadNotAuthentic)
+	}
+}

--- a/proxy-router/internal/blockchainapi/model_tags.go
+++ b/proxy-router/internal/blockchainapi/model_tags.go
@@ -6,9 +6,23 @@ import (
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/blockchainapi/structs"
 )
 
+// IsTeeModel returns true if the model has any TEE tag ("tee" or "tee-gpu").
+// Used for Phase 1 P-node attestation on the consumer side.
 func IsTeeModel(tags []string) bool {
 	for _, raw := range tags {
-		if strings.ToLower(raw) == "tee" {
+		tag := strings.ToLower(raw)
+		if tag == "tee" || tag == "tee-gpu" {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTeeGPUModel returns true if the model has the "tee-gpu" tag.
+// Used for Phase 2 backend LLM attestation on the provider side.
+func IsTeeGPUModel(tags []string) bool {
+	for _, raw := range tags {
+		if strings.ToLower(raw) == "tee-gpu" {
 			return true
 		}
 	}

--- a/proxy-router/internal/blockchainapi/model_tags.go
+++ b/proxy-router/internal/blockchainapi/model_tags.go
@@ -6,23 +6,11 @@ import (
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/blockchainapi/structs"
 )
 
-// IsTeeModel returns true if the model has any TEE tag ("tee" or "tee-gpu").
-// Used for Phase 1 P-node attestation on the consumer side.
+// IsTeeModel returns true if the model has the "tee" tag.
+// Enables both P-node attestation (consumer) and backend LLM attestation (provider).
 func IsTeeModel(tags []string) bool {
 	for _, raw := range tags {
-		tag := strings.ToLower(raw)
-		if tag == "tee" || tag == "tee-gpu" {
-			return true
-		}
-	}
-	return false
-}
-
-// IsTeeGPUModel returns true if the model has the "tee-gpu" tag.
-// Used for Phase 2 backend LLM attestation on the provider side.
-func IsTeeGPUModel(tags []string) bool {
-	for _, raw := range tags {
-		if strings.ToLower(raw) == "tee-gpu" {
+		if strings.ToLower(raw) == "tee" {
 			return true
 		}
 	}

--- a/proxy-router/internal/blockchainapi/service.go
+++ b/proxy-router/internal/blockchainapi/service.go
@@ -144,6 +144,13 @@ func NewBlockchainService(
 	}
 }
 
+func (s *BlockchainService) requestLog(ctx context.Context) lib.ILogger {
+	if id := lib.RequestIDFromContext(ctx); id != "" {
+		return s.log.With("request_id", id)
+	}
+	return s.log
+}
+
 func (s *BlockchainService) GetLatestBlock(ctx context.Context) (uint64, error) {
 	return s.ethClient.BlockNumber(ctx)
 }
@@ -319,6 +326,8 @@ func (s *BlockchainService) rateBids(bidIds [][32]byte, bids []m.IBidStorageBid,
 }
 
 func (s *BlockchainService) OpenSession(ctx context.Context, approval, approvalSig []byte, stake *big.Int, directPayment bool, agentUsername string, isTee bool) (common.Hash, error) {
+	log := s.requestLog(ctx)
+
 	isAgent, err := s.authConfig.IsAllowanceEnough(agentUsername, s.morTokenAddr.Hex(), stake)
 	if err != nil {
 		return common.Hash{}, lib.WrapError(ErrAgentUserAllowance, err)
@@ -345,7 +354,7 @@ func (s *BlockchainService) OpenSession(ctx context.Context, approval, approvalS
 	wouldOverflow := new(big.Int).Sub(maxUint256, currentAllowance).Cmp(stake) < 0
 
 	if wouldOverflow {
-		s.log.Warnf("skipping increaseAllowance: current allowance %s + stake %s would overflow uint256", currentAllowance.String(), stake.String())
+		log.Warnf("skipping increaseAllowance: current allowance %s + stake %s would overflow uint256", currentAllowance.String(), stake.String())
 		needsApproval = false
 	}
 
@@ -375,7 +384,7 @@ func (s *BlockchainService) OpenSession(ctx context.Context, approval, approvalS
 		if isAgent {
 			err = s.authConfig.AuthStorage.SetAgentTx(approveReceipt.TxHash.Hex(), agentUsername, approveReceipt.BlockNumber)
 			if err != nil {
-				s.log.Errorf("failed to set agent tx: %s", err)
+				log.Errorf("failed to set agent tx: %s", err)
 			}
 		}
 	}
@@ -409,12 +418,12 @@ func (s *BlockchainService) OpenSession(ctx context.Context, approval, approvalS
 		amountBigInt := lib.BigInt{Int: *stake}
 		err = s.authConfig.DecreaseAllowance(agentUsername, s.morTokenAddr.Hex(), amountBigInt)
 		if err != nil {
-			s.log.Errorf("failed to decrease allowance: %s", err)
+			log.Errorf("failed to decrease allowance: %s", err)
 			return common.Hash{}, err
 		}
 		err = s.authConfig.AuthStorage.SetAgentTx(sessionReceipt.TxHash.Hex(), agentUsername, sessionReceipt.BlockNumber)
 		if err != nil {
-			s.log.Errorf("failed to set agent tx: %s", err)
+			log.Errorf("failed to set agent tx: %s", err)
 		}
 	}
 
@@ -1151,26 +1160,27 @@ func (s *BlockchainService) OpenSessionByModelId(ctx context.Context, modelID co
 	}
 	var failures []providerFailure
 
-	scoredBids := s.rateBids(bidIDs, bids, providerStats, providers, modelStats, minStake, s.log)
+	log := s.requestLog(ctx)
+	scoredBids := s.rateBids(bidIDs, bids, providerStats, providers, modelStats, minStake, log)
 	for i, bid := range scoredBids {
 		providerAddr := bid.Bid.Provider
 		if providerAddr == omitProvider {
-			s.log.Infof("skipping provider #%d %s", i, providerAddr.String())
+			log.Infof("skipping provider #%d %s", i, providerAddr.String())
 			failures = append(failures, providerFailure{Provider: providerAddr.String(), Reason: "skipped: omitted provider"})
 			continue
 		}
 
 		if providerAddr == userAddr {
-			s.log.Infof("skipping own bid #%d %s", i, bid.Bid.Id)
+			log.Infof("skipping own bid #%d %s", i, bid.Bid.Id)
 			continue
 		}
 
-		s.log.Infof("trying to open session with provider #%d %s", i, bid.Bid.Provider.String())
+		log.Infof("trying to open session with provider #%d %s", i, bid.Bid.Provider.String())
 		durationCopy := new(big.Int).Set(duration)
 
 		hash, tryNext, err := s.tryOpenSession(ctx, &bid.Bid, durationCopy, supply, budget, userAddr, directPayment, isFailoverEnabled, agentUsername, isTee)
 		if err != nil {
-			s.log.Errorf("failed to open session with provider %s: %s", bid.Bid.Provider.String(), err.Error())
+			log.Errorf("failed to open session with provider %s: %s", bid.Bid.Provider.String(), err.Error())
 			failures = append(failures, providerFailure{Provider: providerAddr.String(), Reason: err.Error()})
 			if tryNext {
 				continue
@@ -1232,6 +1242,8 @@ func (s *BlockchainService) GetAllBidsWithRating(ctx context.Context, modelAgent
 }
 
 func (s *BlockchainService) tryOpenSession(ctx context.Context, bid *structs.Bid, duration, supply, budget *big.Int, userAddr common.Address, directPayment bool, failoverEnabled bool, agentUsername string, isTeeSession bool) (common.Hash, bool, error) {
+	log := s.requestLog(ctx)
+
 	provider, err := s.providerRegistry.GetProviderById(ctx, bid.Provider)
 	if err != nil {
 		return common.Hash{}, false, lib.WrapError(ErrProvider, err)
@@ -1239,10 +1251,10 @@ func (s *BlockchainService) tryOpenSession(ctx context.Context, bid *structs.Bid
 
 	if isTeeSession && s.attestationVerifier != nil {
 		if err := s.attestationVerifier.VerifyProviderQuick(ctx, provider.Endpoint, bid.Provider.Hex(), true); err != nil {
-			s.log.Warnf("TEE attestation failed for provider %s: %s", bid.Provider, err)
+			log.Warnf("TEE attestation failed for provider %s: %s", bid.Provider, err)
 			return common.Hash{}, true, fmt.Errorf("TEE attestation failed: %w", err)
 		}
-		s.log.Infof("TEE attestation passed for provider %s", bid.Provider)
+		log.Infof("TEE attestation passed for provider %s", bid.Provider)
 	}
 
 	sessionCost := (&big.Int{}).Mul(&bid.PricePerSecond.Int, duration)
@@ -1255,7 +1267,7 @@ func (s *BlockchainService) tryOpenSession(ctx context.Context, bid *structs.Bid
 		amountTransferred = stake
 	}
 
-	s.log.Infof("attempting to initiate session %s", map[string]string{
+	log.Infof("attempting to initiate session %s", map[string]string{
 		"provider":          bid.Provider.String(),
 		"directPayment":     strconv.FormatBool(directPayment),
 		"duration":          duration.String(),

--- a/proxy-router/internal/blockchainapi/service.go
+++ b/proxy-router/internal/blockchainapi/service.go
@@ -538,6 +538,14 @@ func (s *BlockchainService) DeregisterModel(ctx context.Context, modelId common.
 	return tx, nil
 }
 
+func (s *BlockchainService) GetModelTags(ctx context.Context, modelID common.Hash) ([]string, error) {
+	m, err := s.modelRegistry.GetModelById(ctx, modelID)
+	if err != nil {
+		return nil, err
+	}
+	return m.Tags, nil
+}
+
 func (s *BlockchainService) ModelExists(ctx context.Context, modelID common.Hash) (bool, error) {
 	m, err := s.modelRegistry.GetModelById(ctx, modelID)
 

--- a/proxy-router/internal/config/config.go
+++ b/proxy-router/internal/config/config.go
@@ -85,8 +85,10 @@ type Config struct {
 		TcpMaxSynBacklog string `env:"SYS_TCP_MAX_SYN_BACKLOG" flag:"sys-tcp-max-syn-backlog" desc:""`
 	}
 	TEE struct {
-		PortalURL string `env:"TEE_PORTAL_URL"  flag:"tee-portal-url"  validate:"omitempty,url" desc:"SecretAI Portal API URL for TEE attestation quote parsing"`
-		ImageRepo string `env:"TEE_IMAGE_REPO"  flag:"tee-image-repo"  validate:"omitempty"     desc:"GHCR image repo for cosign attestation verification (e.g. ghcr.io/morpheusais/morpheus-lumerin-node-tee)"`
+		PortalURL                  string        `env:"TEE_PORTAL_URL"  flag:"tee-portal-url"  validate:"omitempty,url" desc:"SecretAI Portal API URL for TEE attestation quote parsing"`
+		ImageRepo                  string        `env:"TEE_IMAGE_REPO"  flag:"tee-image-repo"  validate:"omitempty"     desc:"GHCR image repo for cosign attestation verification (e.g. ghcr.io/morpheusais/morpheus-lumerin-node-tee)"`
+		ArtifactRegistryURL             string        `env:"ARTIFACT_REGISTRY_URL" flag:"artifact-registry-url" validate:"omitempty,url" desc:"URL for SecretVM TDX artifact registry CSV"`
+		ArtifactRegistryRefreshInterval time.Duration `env:"ARTIFACT_REGISTRY_REFRESH_INTERVAL" flag:"artifact-registry-refresh-interval" validate:"omitempty" desc:"how often to refresh the artifact registry"`
 	}
 	Web struct {
 		Address   string `env:"WEB_ADDRESS"    flag:"web-address"    validate:"required,hostname_port" desc:"http server address host:port"`
@@ -219,6 +221,7 @@ func (cfg *Config) SetDefaults() {
 	if cfg.TEE.ImageRepo == "" {
 		cfg.TEE.ImageRepo = "ghcr.io/morpheusais/morpheus-lumerin-node-tee"
 	}
+
 
 	cfg.Log.FolderPath = filepath.FromSlash(cfg.Log.FolderPath)
 	cfg.Proxy.StoragePath = filepath.FromSlash(cfg.Proxy.StoragePath)

--- a/proxy-router/internal/config/models-config-schema.json
+++ b/proxy-router/internal/config/models-config-schema.json
@@ -56,12 +56,6 @@
             "description": "The policy to be used for capacity management",
             "type": "string",
             "enum": ["simple", "idle_timeout"]
-          },
-          "isTee": {
-            "title": "Is TEE",
-            "description": "Whether this model's backend requires TEE attestation verification. The attestation URL is always derived from the apiUrl host with port 29343.",
-            "type": "boolean",
-            "default": false
           }
         },
         "required": ["modelId", "modelName", "apiType", "apiUrl"]

--- a/proxy-router/internal/config/models-config-schema.json
+++ b/proxy-router/internal/config/models-config-schema.json
@@ -56,6 +56,12 @@
             "description": "The policy to be used for capacity management",
             "type": "string",
             "enum": ["simple", "idle_timeout"]
+          },
+          "isTee": {
+            "title": "Is TEE",
+            "description": "Whether this model's backend requires TEE attestation verification. The attestation URL is always derived from the apiUrl host with port 29343.",
+            "type": "boolean",
+            "default": false
           }
         },
         "required": ["modelId", "modelName", "apiType", "apiUrl"]

--- a/proxy-router/internal/config/models_config.go
+++ b/proxy-router/internal/config/models_config.go
@@ -47,6 +47,7 @@ type ModelConfig struct {
 	ConcurrentSlots int               `json:"concurrentSlots" validate:"number"`
 	CapacityPolicy  string            `json:"capacityPolicy"`
 	Parameters      map[string]string `json:"parameters"`
+	IsTee           bool              `json:"isTee"`
 }
 
 type ModelConfigs map[string]ModelConfig

--- a/proxy-router/internal/config/models_config.go
+++ b/proxy-router/internal/config/models_config.go
@@ -47,7 +47,6 @@ type ModelConfig struct {
 	ConcurrentSlots int               `json:"concurrentSlots" validate:"number"`
 	CapacityPolicy  string            `json:"capacityPolicy"`
 	Parameters      map[string]string `json:"parameters"`
-	IsTee           bool              `json:"isTee"`
 }
 
 type ModelConfigs map[string]ModelConfig

--- a/proxy-router/internal/handlers/httphandlers/logging.go
+++ b/proxy-router/internal/handlers/httphandlers/logging.go
@@ -7,31 +7,40 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// RequestLogger is a middleware for logging HTTP requests
+// RequestLogger is a middleware for logging HTTP requests.
+// It generates a request_id for every incoming request (unless one was
+// already set by a downstream handler) and stores it in both the gin
+// context and the stdlib context so that all layers can retrieve it
+// via lib.RequestIDFromContext.
 func RequestLogger(logger lib.ILogger) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Start timer
+		requestID := c.GetHeader("X-Request-Id")
+		if requestID == "" {
+			requestID = lib.GenerateRequestID()
+		}
+		c.Set("request_id", requestID)
+		c.Request = c.Request.WithContext(lib.ContextWithRequestID(c.Request.Context(), requestID))
+		c.Writer.Header().Set("X-Request-Id", requestID)
+
 		path := c.Request.URL.Path
 		raw := c.Request.URL.RawQuery
 
 		start := time.Now()
-		logger.Infof("[HTTP-REQ] %s %s",
+		logger.Infof("[HTTP-REQ] %s %s request_id=%s",
 			c.Request.Method,
 			path,
+			requestID,
 		)
 
-		// Process request
 		c.Next()
 
 		if raw != "" {
 			path = path + "?" + raw
 		}
 
-		// Log details
 		status := c.Writer.Status()
 		latency := time.Since(start).Round(time.Millisecond)
-		requestID, _ := c.Get("request_id")
-		logger.Infof("[HTTP-RES] %s %s [%d] %v request_id=%v",
+		logger.Infof("[HTTP-RES] %s %s [%d] %v request_id=%s",
 			c.Request.Method,
 			path,
 			status,

--- a/proxy-router/internal/lib/tx_escalator.go
+++ b/proxy-router/internal/lib/tx_escalator.go
@@ -148,6 +148,11 @@ func (e *TransactionEscalator) SendWithEscalation(
 	builder TxBuilder,
 	isLegacy bool,
 ) (*types.Receipt, error) {
+	log := e.log
+	if id := RequestIDFromContext(ctx); id != "" {
+		log = log.With("request_id", id)
+	}
+
 	// Create timeout context for the entire escalation process
 	timeoutCtx, cancel := context.WithTimeout(ctx, e.config.MaxTotalTime)
 	defer cancel()
@@ -174,7 +179,7 @@ func (e *TransactionEscalator) SendWithEscalation(
 
 		// Check max gas limit
 		if e.config.MaxGasPrice != nil && gasPrices.MaxPrice().Cmp(e.config.MaxGasPrice) > 0 {
-			e.log.Warnf("Gas price %v exceeds max limit %v, stopping escalation",
+			log.Warnf("Gas price %v exceeds max limit %v, stopping escalation",
 				gasPrices.MaxPrice(), e.config.MaxGasPrice)
 			return nil, WrapError(ErrMaxGasExceeded, lastErr)
 		}
@@ -196,25 +201,25 @@ func (e *TransactionEscalator) SendWithEscalation(
 			if IsNonceTooLowError(err) {
 				// If we have previously submitted txs, check if one was mined
 				if len(submittedTxs) > 0 {
-					e.log.Infof("Nonce too low - checking if previous tx was mined")
+					log.Infof("Nonce too low - checking if previous tx was mined")
 					if receipt := e.checkSubmittedTxs(ctx, submittedTxs); receipt != nil {
-						e.log.Infof("Previous tx was mined: %s", receipt.TxHash.Hex())
+						log.Infof("Previous tx was mined: %s", receipt.TxHash.Hex())
 						return receipt, nil
 					}
 				}
 				// Nonce conflict from concurrent request - refresh and retry
 				if nonceRefreshCount < maxNonceRefreshes {
 					nonceRefreshCount++
-					e.log.Warnf("Nonce conflict (attempt %d), refreshing nonce and retrying: %v", attempt+1, err)
+					log.Warnf("Nonce conflict (attempt %d), refreshing nonce and retrying: %v", attempt+1, err)
 					// Don't count this as an escalation attempt, just retry with fresh nonce
 					attempt--
 					continue
 				}
-				e.log.Errorf("Max nonce refreshes exceeded, giving up")
+				log.Errorf("Max nonce refreshes exceeded, giving up")
 			}
 			// Check if this is a replacement issue (need to bump more)
 			if IsReplacementError(err) && attempt < e.config.MaxAttempts-1 {
-				e.log.Warnf("Tx rejected (replacement underpriced), bumping gas: %v", err)
+				log.Warnf("Tx rejected (replacement underpriced), bumping gas: %v", err)
 				gasPrices.Bump(e.config.BumpPercent)
 				continue
 			}
@@ -226,13 +231,13 @@ func (e *TransactionEscalator) SendWithEscalation(
 		nonceRefreshCount = 0
 
 		submittedTxs = append(submittedTxs, tx)
-		e.log.Infof("Tx submitted (attempt %d/%d): %s, gasPrice: %v",
+		log.Infof("Tx submitted (attempt %d/%d): %s, gasPrice: %v",
 			attempt+1, e.config.MaxAttempts, tx.Hash().Hex(), gasPrices.MaxPrice())
 
 		// Wait for mining with check interval
 		receipt, err := e.waitForMining(timeoutCtx, tx, e.config.CheckInterval)
 		if err == nil {
-			e.log.Infof("Tx mined successfully: %s (attempt %d)", tx.Hash().Hex(), attempt+1)
+			log.Infof("Tx mined successfully: %s (attempt %d)", tx.Hash().Hex(), attempt+1)
 			return receipt, nil
 		}
 
@@ -245,13 +250,13 @@ func (e *TransactionEscalator) SendWithEscalation(
 
 		// Before escalating, check if any previous tx got mined in the meantime
 		if receipt := e.checkSubmittedTxs(ctx, submittedTxs); receipt != nil {
-			e.log.Infof("Previous tx was mined during escalation: %s", receipt.TxHash.Hex())
+			log.Infof("Previous tx was mined during escalation: %s", receipt.TxHash.Hex())
 			return receipt, nil
 		}
 
 		// Not mined yet, escalate if we have attempts left
 		if attempt < e.config.MaxAttempts-1 {
-			e.log.Warnf("Tx %s not mined after %v, escalating gas (attempt %d/%d)",
+			log.Warnf("Tx %s not mined after %v, escalating gas (attempt %d/%d)",
 				tx.Hash().Hex(), e.config.CheckInterval, attempt+1, e.config.MaxAttempts)
 			gasPrices.Bump(e.config.BumpPercent)
 		}
@@ -259,7 +264,7 @@ func (e *TransactionEscalator) SendWithEscalation(
 
 	// Final check - maybe a tx got mined while we were processing
 	if receipt := e.checkSubmittedTxs(ctx, submittedTxs); receipt != nil {
-		e.log.Infof("Tx was mined on final check: %s", receipt.TxHash.Hex())
+		log.Infof("Tx was mined on final check: %s", receipt.TxHash.Hex())
 		return receipt, nil
 	}
 

--- a/proxy-router/internal/proxyapi/capacity_manager_test.go
+++ b/proxy-router/internal/proxyapi/capacity_manager_test.go
@@ -1,0 +1,49 @@
+package proxyapi
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/config"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/storages"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdleTimeoutCapacityManager_HasCapacity(t *testing.T) {
+	now := time.Now().Unix()
+	storage := storages.NewTestStorage()
+	sessionStorage := storages.NewSessionStorage(storage)
+
+	session := &storages.Session{
+		Id:       "0xsession1",
+		ModelID:  "0xmodel1",
+		EndsAt:   big.NewInt(now + 3600),
+		UserAddr: "0xuser",
+	}
+	require.NoError(t, sessionStorage.AddSession(session))
+
+	modelCfg := &config.ModelConfig{
+		ConcurrentSlots: 1,
+		CapacityPolicy:  "idle_timeout",
+	}
+	manager := NewIdleTimeoutCapacityManager(modelCfg, sessionStorage, &lib.LoggerMock{})
+
+	// Recent activity should count as active, filling the single slot.
+	require.NoError(t, sessionStorage.AddActivity(session.ModelID, &storages.PromptActivity{
+		SessionID: session.Id,
+		StartTime: now - 30,
+		EndTime:   now - 10,
+	}))
+	require.False(t, manager.HasCapacity(session.ModelID))
+
+	// Remove old activity and add stale one that is outside 15m idle timeout.
+	require.NoError(t, sessionStorage.RemoveOldActivities(session.ModelID, now))
+	require.NoError(t, sessionStorage.AddActivity(session.ModelID, &storages.PromptActivity{
+		SessionID: session.Id,
+		StartTime: now - 2000,
+		EndTime:   now - 1800,
+	}))
+	require.True(t, manager.HasCapacity(session.ModelID))
+}

--- a/proxy-router/internal/proxyapi/controller_http.go
+++ b/proxy-router/internal/proxyapi/controller_http.go
@@ -16,6 +16,7 @@ import (
 
 	constants "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/aiengine"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/attestation"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/blockchainapi/structs"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/chatstorage/genericchatstorage"
 	gcs "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/chatstorage/genericchatstorage"
@@ -42,16 +43,22 @@ type AIEngine interface {
 	GetAdapter(ctx context.Context, chatID, modelID, sessionID common.Hash, storeContext, forwardContext bool) (aiengine.AIEngineStream, error)
 }
 
+// BackendAttestationStatusProvider exposes per-model backend attestation snapshots.
+type BackendAttestationStatusProvider interface {
+	GetAllStatuses() map[string]*attestation.BackendAttestationSnapshot
+}
+
 type ProxyController struct {
-	service            *ProxyServiceSender
-	aiEngine           AIEngine
-	chatStorage        gsc.ChatStorageInterface
-	storeChatContext   bool
-	forwardChatContext bool
-	log                lib.ILogger
-	authConfig         system.HTTPAuthConfig
-	ipfsManager        *IpfsManager
-	dockerManager      *DockerManager
+	service                   *ProxyServiceSender
+	aiEngine                  AIEngine
+	chatStorage               gsc.ChatStorageInterface
+	storeChatContext          bool
+	forwardChatContext        bool
+	log                       lib.ILogger
+	authConfig                system.HTTPAuthConfig
+	ipfsManager               *IpfsManager
+	dockerManager             *DockerManager
+	backendAttestationStatus  BackendAttestationStatusProvider
 }
 
 func NewProxyController(service *ProxyServiceSender, aiEngine AIEngine, chatStorage gsc.ChatStorageInterface, storeChatContext, forwardChatContext bool, authConfig system.HTTPAuthConfig, ipfsManager *IpfsManager, log lib.ILogger) *ProxyController {
@@ -72,11 +79,17 @@ func NewProxyController(service *ProxyServiceSender, aiEngine AIEngine, chatStor
 	return c
 }
 
+// SetBackendAttestationStatus sets the provider for backend attestation status queries.
+func (c *ProxyController) SetBackendAttestationStatus(provider BackendAttestationStatusProvider) {
+	c.backendAttestationStatus = provider
+}
+
 func (s *ProxyController) RegisterRoutes(r interfaces.Router) {
 	r.POST("/proxy/provider/ping", s.Ping)
 	r.POST("/proxy/sessions/initiate", s.authConfig.CheckAuth("initiate_session"), s.InitiateSession)
 	r.POST("/v1/chat/completions", s.authConfig.CheckAuth("chat"), s.Prompt)
 	r.GET("/v1/models", s.authConfig.CheckAuth("get_local_models"), s.Models)
+	r.GET("/v1/models/attestation", s.authConfig.CheckAuth("get_local_models"), s.ModelsAttestation)
 	r.GET("/v1/agents", s.authConfig.CheckAuth("get_local_agents"), s.Agents)
 	r.GET("/v1/agents/tools", s.authConfig.CheckAuth("get_agent_tools"), s.GetAgentTools)
 	r.POST("/v1/agents/tools", s.authConfig.CheckAuth("call_agent_tool"), s.CallAgentTool)
@@ -285,6 +298,28 @@ func (c *ProxyController) Models(ctx *gin.Context) {
 		return
 	}
 	ctx.JSON(http.StatusOK, models)
+}
+
+// ModelsAttestation godoc
+//
+//	@Summary	Get backend TEE attestation status for all configured models
+//	@Tags		system
+//	@Produce	json
+//	@Success	200	{array}	attestation.BackendAttestationSnapshot
+//	@Security	BasicAuth
+//	@Router		/v1/models/attestation [get]
+func (c *ProxyController) ModelsAttestation(ctx *gin.Context) {
+	if c.backendAttestationStatus == nil {
+		ctx.JSON(http.StatusOK, []struct{}{})
+		return
+	}
+
+	statuses := c.backendAttestationStatus.GetAllStatuses()
+	result := make([]*attestation.BackendAttestationSnapshot, 0, len(statuses))
+	for _, s := range statuses {
+		result = append(result, s)
+	}
+	ctx.JSON(http.StatusOK, result)
 }
 
 // GetLocalAgents godoc

--- a/proxy-router/internal/proxyapi/controller_morrpc.go
+++ b/proxy-router/internal/proxyapi/controller_morrpc.go
@@ -51,7 +51,6 @@ func NewMORRPCController(service *ProxyReceiver, validator *validator.Validate, 
 }
 
 func (s *MORRPCController) Handle(ctx context.Context, msg m.RPCMessage, sourceLog lib.ILogger, sendResponse SendResponse) error {
-	sourceLog = sourceLog.With("request_id", msg.ID)
 	sourceLog.Debugf("received TCP message with method %s", msg.Method)
 	switch msg.Method {
 	case "network.ping":

--- a/proxy-router/internal/proxyapi/proxy_receiver.go
+++ b/proxy-router/internal/proxyapi/proxy_receiver.go
@@ -20,10 +20,14 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// BackendTEEVerifier is used by ProxyReceiver to fast-verify LLM backend TEE
-// attestation before forwarding inference requests.
+// BackendTEEVerifier is used by ProxyReceiver for Phase 2 LLM TEE attestation.
 type BackendTEEVerifier interface {
 	FastVerifyBackend(ctx context.Context, modelID string) error
+}
+
+// ModelTagsProvider fetches blockchain model tags for TEE tag detection.
+type ModelTagsProvider interface {
+	GetModelTags(ctx context.Context, modelID common.Hash) ([]string, error)
 }
 
 type ProxyReceiver struct {
@@ -37,6 +41,7 @@ type ProxyReceiver struct {
 	service           BidGetter
 	sessionRepo       *sessionrepo.SessionRepositoryCached
 	backendVerifier   BackendTEEVerifier
+	modelTagsProvider ModelTagsProvider
 }
 
 func NewProxyReceiver(privateKeyHex, publicKeyHex lib.HexString, sessionStorage *storages.SessionStorage, aiEngine *aiengine.AiEngine, chainID *big.Int, modelConfigLoader *config.ModelConfigLoader, blockchainService BidGetter, sessionRepo *sessionrepo.SessionRepositoryCached) *ProxyReceiver {
@@ -53,9 +58,28 @@ func NewProxyReceiver(privateKeyHex, publicKeyHex lib.HexString, sessionStorage 
 	}
 }
 
-// SetBackendVerifier sets the backend TEE verifier for per-prompt attestation checks.
 func (s *ProxyReceiver) SetBackendVerifier(bv BackendTEEVerifier) {
 	s.backendVerifier = bv
+}
+
+func (s *ProxyReceiver) SetModelTagsProvider(p ModelTagsProvider) {
+	s.modelTagsProvider = p
+}
+
+func (s *ProxyReceiver) isTeeGpuModel(ctx context.Context, modelID common.Hash) bool {
+	if s.modelTagsProvider == nil {
+		return false
+	}
+	tags, err := s.modelTagsProvider.GetModelTags(ctx, modelID)
+	if err != nil {
+		return false
+	}
+	for _, t := range tags {
+		if strings.ToLower(t) == "tee-gpu" {
+			return true
+		}
+	}
+	return false
 }
 
 // handleSessionError is a helper function to log errors and return consistent output
@@ -323,13 +347,11 @@ func (s *ProxyReceiver) SessionPrompt(ctx context.Context, requestID string, use
 		defer os.Remove(audioTranscriptionReq.FilePath)
 	}
 
-	// Verify backend LLM TEE attestation before forwarding (Phase 2)
-	if s.backendVerifier != nil {
-		modelCfg := s.modelConfigLoader.ModelConfigFromID(session.ModelID().Hex())
-		if modelCfg.IsTee {
-			if verifyErr := s.backendVerifier.FastVerifyBackend(ctx, session.ModelID().Hex()); verifyErr != nil {
-				return handleError(verifyErr, "backend TEE verification failed", sourceLog)
-			}
+	// Phase 2: verify LLM TEE attestation for "tee-gpu" tagged models.
+	// isTeeGpu is set from blockchain tags when the session is loaded.
+	if s.backendVerifier != nil && session.IsTeeGpu() {
+		if verifyErr := s.backendVerifier.FastVerifyBackend(ctx, session.ModelID().Hex()); verifyErr != nil {
+			return handleError(verifyErr, "LLM TEE verification failed", sourceLog)
 		}
 	}
 
@@ -387,6 +409,15 @@ func (s *ProxyReceiver) SessionRequest(ctx context.Context, msgID string, reqID 
 	}
 
 	modelID := bid.ModelAgentId.String()
+
+	// Phase 2: verify LLM TEE attestation before accepting session
+	if s.backendVerifier != nil && s.isTeeGpuModel(ctx, bid.ModelAgentId) {
+		if err := s.backendVerifier.FastVerifyBackend(ctx, modelID); err != nil {
+			log.Errorf("LLM TEE verification failed for model %s: %s", modelID, err)
+			return nil, fmt.Errorf("LLM TEE verification failed: %w", err)
+		}
+	}
+
 	modelConfig := s.modelConfigLoader.ModelConfigFromID(modelID)
 	capacityManager := CreateCapacityManager(modelConfig, s.sessionStorage, log)
 

--- a/proxy-router/internal/proxyapi/proxy_receiver.go
+++ b/proxy-router/internal/proxyapi/proxy_receiver.go
@@ -20,6 +20,12 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// BackendTEEVerifier is used by ProxyReceiver to fast-verify LLM backend TEE
+// attestation before forwarding inference requests.
+type BackendTEEVerifier interface {
+	FastVerifyBackend(ctx context.Context, modelID string) error
+}
+
 type ProxyReceiver struct {
 	privateKeyHex     lib.HexString
 	publicKeyHex      lib.HexString
@@ -30,6 +36,7 @@ type ProxyReceiver struct {
 	modelConfigLoader *config.ModelConfigLoader
 	service           BidGetter
 	sessionRepo       *sessionrepo.SessionRepositoryCached
+	backendVerifier   BackendTEEVerifier
 }
 
 func NewProxyReceiver(privateKeyHex, publicKeyHex lib.HexString, sessionStorage *storages.SessionStorage, aiEngine *aiengine.AiEngine, chainID *big.Int, modelConfigLoader *config.ModelConfigLoader, blockchainService BidGetter, sessionRepo *sessionrepo.SessionRepositoryCached) *ProxyReceiver {
@@ -44,6 +51,11 @@ func NewProxyReceiver(privateKeyHex, publicKeyHex lib.HexString, sessionStorage 
 		sessionStorage:    sessionStorage,
 		sessionRepo:       sessionRepo,
 	}
+}
+
+// SetBackendVerifier sets the backend TEE verifier for per-prompt attestation checks.
+func (s *ProxyReceiver) SetBackendVerifier(bv BackendTEEVerifier) {
+	s.backendVerifier = bv
 }
 
 // handleSessionError is a helper function to log errors and return consistent output
@@ -309,6 +321,16 @@ func (s *ProxyReceiver) SessionPrompt(ctx context.Context, requestID string, use
 		}
 	} else if audioTranscriptionReq != nil && audioTranscriptionReq.FilePath != "" {
 		defer os.Remove(audioTranscriptionReq.FilePath)
+	}
+
+	// Verify backend LLM TEE attestation before forwarding (Phase 2)
+	if s.backendVerifier != nil {
+		modelCfg := s.modelConfigLoader.ModelConfigFromID(session.ModelID().Hex())
+		if modelCfg.IsTee {
+			if verifyErr := s.backendVerifier.FastVerifyBackend(ctx, session.ModelID().Hex()); verifyErr != nil {
+				return handleError(verifyErr, "backend TEE verification failed", sourceLog)
+			}
+		}
 	}
 
 	// Start timing and get adapter

--- a/proxy-router/internal/proxyapi/proxy_receiver.go
+++ b/proxy-router/internal/proxyapi/proxy_receiver.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// BackendTEEVerifier is used by ProxyReceiver for Phase 2 LLM TEE attestation.
+// BackendTEEVerifier is used by ProxyReceiver for backend LLM TEE attestation.
 type BackendTEEVerifier interface {
 	FastVerifyBackend(ctx context.Context, modelID string) error
 }
@@ -66,7 +66,7 @@ func (s *ProxyReceiver) SetModelTagsProvider(p ModelTagsProvider) {
 	s.modelTagsProvider = p
 }
 
-func (s *ProxyReceiver) isTeeGpuModel(ctx context.Context, modelID common.Hash) bool {
+func (s *ProxyReceiver) isTeeModel(ctx context.Context, modelID common.Hash) bool {
 	if s.modelTagsProvider == nil {
 		return false
 	}
@@ -75,7 +75,7 @@ func (s *ProxyReceiver) isTeeGpuModel(ctx context.Context, modelID common.Hash) 
 		return false
 	}
 	for _, t := range tags {
-		if strings.ToLower(t) == "tee-gpu" {
+		if strings.ToLower(t) == "tee" {
 			return true
 		}
 	}
@@ -347,9 +347,7 @@ func (s *ProxyReceiver) SessionPrompt(ctx context.Context, requestID string, use
 		defer os.Remove(audioTranscriptionReq.FilePath)
 	}
 
-	// Phase 2: verify LLM TEE attestation for "tee-gpu" tagged models.
-	// isTeeGpu is set from blockchain tags when the session is loaded.
-	if s.backendVerifier != nil && session.IsTeeGpu() {
+	if s.backendVerifier != nil && session.IsTee() {
 		if verifyErr := s.backendVerifier.FastVerifyBackend(ctx, session.ModelID().Hex()); verifyErr != nil {
 			return handleError(verifyErr, "LLM TEE verification failed", sourceLog)
 		}
@@ -410,8 +408,7 @@ func (s *ProxyReceiver) SessionRequest(ctx context.Context, msgID string, reqID 
 
 	modelID := bid.ModelAgentId.String()
 
-	// Phase 2: verify LLM TEE attestation before accepting session
-	if s.backendVerifier != nil && s.isTeeGpuModel(ctx, bid.ModelAgentId) {
+	if s.backendVerifier != nil && s.isTeeModel(ctx, bid.ModelAgentId) {
 		if err := s.backendVerifier.FastVerifyBackend(ctx, modelID); err != nil {
 			log.Errorf("LLM TEE verification failed for model %s: %s", modelID, err)
 			return nil, fmt.Errorf("LLM TEE verification failed: %w", err)

--- a/proxy-router/internal/proxyapi/proxy_sender.go
+++ b/proxy-router/internal/proxyapi/proxy_sender.go
@@ -147,7 +147,10 @@ func (p *ProxyServiceSender) Ping(ctx context.Context, providerURL string, provi
 }
 
 func (p *ProxyServiceSender) InitiateSession(ctx context.Context, user common.Address, provider common.Address, spend *big.Int, bidID common.Hash, providerURL string) (*msgs.SessionRes, error) {
-	requestID := "1"
+	requestID := lib.RequestIDFromContext(ctx)
+	if requestID == "" {
+		requestID = lib.GenerateRequestID()
+	}
 
 	prKey, err := p.privateKey.GetPrivateKey()
 	if err != nil {
@@ -204,7 +207,10 @@ func (p *ProxyServiceSender) InitiateSession(ctx context.Context, user common.Ad
 }
 
 func (p *ProxyServiceSender) GetSessionReportFromProvider(ctx context.Context, sessionID common.Hash) (*msgs.SessionReportRes, error) {
-	requestID := "1"
+	requestID := lib.RequestIDFromContext(ctx)
+	if requestID == "" {
+		requestID = lib.GenerateRequestID()
+	}
 
 	prKey, err := p.privateKey.GetPrivateKey()
 	if err != nil {
@@ -296,6 +302,11 @@ func (p *ProxyServiceSender) GetSessionReportFromUser(ctx context.Context, sessi
 		return nil, nil, ErrMissingPrKey
 	}
 
+	requestID := lib.RequestIDFromContext(ctx)
+	if requestID == "" {
+		requestID = lib.GenerateRequestID()
+	}
+
 	response, err := p.morRPC.SessionReportResponse(
 		uint32(tps),
 		uint32(ttft),
@@ -303,7 +314,7 @@ func (p *ProxyServiceSender) GetSessionReportFromUser(ctx context.Context, sessi
 		uint32(session.OutputTokens()),
 		sessionID,
 		prKey,
-		"1",
+		requestID,
 		p.chainID,
 	)
 
@@ -321,7 +332,10 @@ func (p *ProxyServiceSender) GetSessionReportFromUser(ctx context.Context, sessi
 }
 
 func (p *ProxyServiceSender) CallAgentTool(ctx context.Context, sessionID common.Hash, toolName string, input map[string]interface{}) (string, error) {
-	requestID := "1"
+	requestID := lib.RequestIDFromContext(ctx)
+	if requestID == "" {
+		requestID = lib.GenerateRequestID()
+	}
 
 	session, err := p.sessionRepo.GetSession(ctx, sessionID)
 	if err != nil {
@@ -386,7 +400,10 @@ func (p *ProxyServiceSender) CallAgentTool(ctx context.Context, sessionID common
 }
 
 func (p *ProxyServiceSender) GetAgentTools(ctx context.Context, sessionID common.Hash) (string, error) {
-	requestID := "1"
+	requestID := lib.RequestIDFromContext(ctx)
+	if requestID == "" {
+		requestID = lib.GenerateRequestID()
+	}
 
 	prKey, err := p.privateKey.GetPrivateKey()
 	if err != nil {

--- a/proxy-router/internal/proxyapi/proxy_sender.go
+++ b/proxy-router/internal/proxyapi/proxy_sender.go
@@ -32,6 +32,7 @@ var (
 	ErrMissingPrKey     = fmt.Errorf("missing private key")
 	ErrCreateReq        = fmt.Errorf("failed to create request")
 	ErrProvider         = fmt.Errorf("provider request failed")
+	ErrTeeAttestation   = fmt.Errorf("p-node tee attestation failed")
 	ErrInvalidSig       = fmt.Errorf("received invalid signature from provider")
 	ErrFailedStore      = fmt.Errorf("failed store user")
 	ErrInvalidResponse  = fmt.Errorf("invalid response")
@@ -638,7 +639,7 @@ func (p *ProxyServiceSender) SendPromptV2(ctx context.Context, sessionID common.
 
 	if err := p.verifyTEEAttestation(ctx, provider.Url, provider.Addr, session.IsTee()); err != nil {
 		log.Warnf("TEE attestation check failed: %s", err)
-		return nil, lib.WrapError(ErrProvider, err)
+		return nil, lib.WrapError(ErrTeeAttestation, err)
 	}
 
 	// Acquire session semaphore to ensure only 1 concurrent request per session

--- a/proxy-router/internal/proxyctl/proxyctl.go
+++ b/proxy-router/internal/proxyctl/proxyctl.go
@@ -71,6 +71,7 @@ type Proxy struct {
 	modelConfigLoader    *config.ModelConfigLoader
 	blockchainService    *blockchainapi.BlockchainService
 	sessionExpiryHandler *blockchainapi.SessionExpiryHandler
+	backendVerifier      proxyapi.BackendTEEVerifier
 
 	state         lib.AtomicValue[ProxyState]
 	tsk           *lib.Task
@@ -78,7 +79,7 @@ type Proxy struct {
 }
 
 // NewProxyCtl creates a new Proxy controller instance
-func NewProxyCtl(eventListerer *blockchainapi.EventsListener, wallet interfaces.PrKeyProvider, chainID *big.Int, log lib.ILogger, tcpLog *lib.Logger, proxyAddr string, sessionStorage *storages.SessionStorage, modelConfigLoader *config.ModelConfigLoader, valid *validator.Validate, aiEngine *aiengine.AiEngine, blockchainService *blockchainapi.BlockchainService, sessionRepo *sessionrepo.SessionRepositoryCached, sessionExpiryHandler *blockchainapi.SessionExpiryHandler) *Proxy {
+func NewProxyCtl(eventListerer *blockchainapi.EventsListener, wallet interfaces.PrKeyProvider, chainID *big.Int, log lib.ILogger, tcpLog *lib.Logger, proxyAddr string, sessionStorage *storages.SessionStorage, modelConfigLoader *config.ModelConfigLoader, valid *validator.Validate, aiEngine *aiengine.AiEngine, blockchainService *blockchainapi.BlockchainService, sessionRepo *sessionrepo.SessionRepositoryCached, sessionExpiryHandler *blockchainapi.SessionExpiryHandler, backendVerifier proxyapi.BackendTEEVerifier) *Proxy {
 	return &Proxy{
 		eventListener:        eventListerer,
 		chainID:              chainID,
@@ -93,6 +94,7 @@ func NewProxyCtl(eventListerer *blockchainapi.EventsListener, wallet interfaces.
 		blockchainService:    blockchainService,
 		sessionRepo:          sessionRepo,
 		sessionExpiryHandler: sessionExpiryHandler,
+		backendVerifier:      backendVerifier,
 		serverStarted:        make(chan struct{}),
 	}
 }
@@ -187,6 +189,9 @@ func (p *Proxy) run(ctx context.Context, prKey lib.HexString) error {
 	}
 
 	proxyReceiver := proxyapi.NewProxyReceiver(prKey, pubKey, p.sessionStorage, p.aiEngine, p.chainID, p.modelConfigLoader, p.blockchainService, p.sessionRepo)
+	if p.backendVerifier != nil {
+		proxyReceiver.SetBackendVerifier(p.backendVerifier)
+	}
 	morTcpHandler := proxyapi.NewMORRPCController(proxyReceiver, p.validator, p.sessionRepo, p.sessionStorage, prKey)
 	tcpHandler := tcphandlers.NewTCPHandler(
 		p.tcpLog, morTcpHandler,

--- a/proxy-router/internal/proxyctl/proxyctl.go
+++ b/proxy-router/internal/proxyctl/proxyctl.go
@@ -192,6 +192,7 @@ func (p *Proxy) run(ctx context.Context, prKey lib.HexString) error {
 	if p.backendVerifier != nil {
 		proxyReceiver.SetBackendVerifier(p.backendVerifier)
 	}
+	proxyReceiver.SetModelTagsProvider(p.blockchainService)
 	morTcpHandler := proxyapi.NewMORRPCController(proxyReceiver, p.validator, p.sessionRepo, p.sessionStorage, prKey)
 	tcpHandler := tcphandlers.NewTCPHandler(
 		p.tcpLog, morTcpHandler,

--- a/proxy-router/internal/repositories/session/session_model.go
+++ b/proxy-router/internal/repositories/session/session_model.go
@@ -21,7 +21,6 @@ type SessionModel struct {
 	failoverEnabled  bool
 	directPayment    bool
 	isTee            bool
-	isTeeGpu         bool
 }
 
 func (s *SessionModel) ID() common.Hash {
@@ -92,10 +91,3 @@ func (s *SessionModel) SetIsTee(v bool) {
 	s.isTee = v
 }
 
-func (s *SessionModel) IsTeeGpu() bool {
-	return s.isTeeGpu
-}
-
-func (s *SessionModel) SetIsTeeGpu(v bool) {
-	s.isTeeGpu = v
-}

--- a/proxy-router/internal/repositories/session/session_model.go
+++ b/proxy-router/internal/repositories/session/session_model.go
@@ -21,6 +21,7 @@ type SessionModel struct {
 	failoverEnabled  bool
 	directPayment    bool
 	isTee            bool
+	isTeeGpu         bool
 }
 
 func (s *SessionModel) ID() common.Hash {
@@ -89,4 +90,12 @@ func (s *SessionModel) IsTee() bool {
 
 func (s *SessionModel) SetIsTee(v bool) {
 	s.isTee = v
+}
+
+func (s *SessionModel) IsTeeGpu() bool {
+	return s.isTeeGpu
+}
+
+func (s *SessionModel) SetIsTeeGpu(v bool) {
+	s.isTeeGpu = v
 }

--- a/proxy-router/internal/repositories/session/session_repo.go
+++ b/proxy-router/internal/repositories/session/session_repo.go
@@ -92,13 +92,13 @@ func (r *SessionRepositoryCached) getSessionFromBlockchain(ctx context.Context, 
 		return nil, err
 	}
 
-	isTeeGpu := false
+	isTee := false
 	if r.modelTags != nil {
 		tags, err := r.modelTags.GetModelTags(ctx, bid.ModelId)
 		if err == nil {
 			for _, t := range tags {
-				if strings.ToLower(t) == "tee-gpu" {
-					isTeeGpu = true
+				if strings.ToLower(t) == "tee" {
+					isTee = true
 					break
 				}
 			}
@@ -116,7 +116,7 @@ func (r *SessionRepositoryCached) getSessionFromBlockchain(ctx context.Context, 
 		failoverEnabled:  false,
 		directPayment:    session.IsDirectPaymentFromUser,
 		agentUsername:    "admin",
-		isTeeGpu:        isTeeGpu,
+		isTee:           isTee,
 	}, nil
 }
 
@@ -143,7 +143,6 @@ func (r *SessionRepositoryCached) getSessionFromCache(id common.Hash) (*SessionM
 		failoverEnabled:  ses.FailoverEnabled,
 		agentUsername:    ses.AgentUsername,
 		isTee:           ses.IsTee,
-		isTeeGpu:        ses.IsTeeGpu,
 	}, nil
 }
 
@@ -162,6 +161,5 @@ func (r *SessionRepositoryCached) saveSessionToCache(ses *SessionModel) error {
 		DirectPayment:    ses.directPayment,
 		AgentUsername:    ses.agentUsername,
 		IsTee:           ses.isTee,
-		IsTeeGpu:        ses.isTeeGpu,
 	})
 }

--- a/proxy-router/internal/repositories/session/session_repo.go
+++ b/proxy-router/internal/repositories/session/session_repo.go
@@ -2,6 +2,7 @@ package sessionrepo
 
 import (
 	"context"
+	"strings"
 
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/repositories/registries"
@@ -9,11 +10,16 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+type ModelTagsProvider interface {
+	GetModelTags(ctx context.Context, modelID common.Hash) ([]string, error)
+}
+
 type SessionRepositoryCached struct {
-	storage *storages.SessionStorage
-	reg     *registries.SessionRouter
-	mkt     *registries.Marketplace
-	log     lib.ILogger
+	storage      *storages.SessionStorage
+	reg          *registries.SessionRouter
+	mkt          *registries.Marketplace
+	modelTags    ModelTagsProvider
+	log          lib.ILogger
 }
 
 func NewSessionRepositoryCached(storage *storages.SessionStorage, reg *registries.SessionRouter, mkt *registries.Marketplace, log lib.ILogger) *SessionRepositoryCached {
@@ -23,6 +29,10 @@ func NewSessionRepositoryCached(storage *storages.SessionStorage, reg *registrie
 		mkt:     mkt,
 		log:     log,
 	}
+}
+
+func (r *SessionRepositoryCached) SetModelTagsProvider(p ModelTagsProvider) {
+	r.modelTags = p
 }
 
 // GetSession returns a session by its ID from the read-through cache
@@ -82,6 +92,19 @@ func (r *SessionRepositoryCached) getSessionFromBlockchain(ctx context.Context, 
 		return nil, err
 	}
 
+	isTeeGpu := false
+	if r.modelTags != nil {
+		tags, err := r.modelTags.GetModelTags(ctx, bid.ModelId)
+		if err == nil {
+			for _, t := range tags {
+				if strings.ToLower(t) == "tee-gpu" {
+					isTeeGpu = true
+					break
+				}
+			}
+		}
+	}
+
 	return &SessionModel{
 		id:               id,
 		userAddr:         session.User,
@@ -93,6 +116,7 @@ func (r *SessionRepositoryCached) getSessionFromBlockchain(ctx context.Context, 
 		failoverEnabled:  false,
 		directPayment:    session.IsDirectPaymentFromUser,
 		agentUsername:    "admin",
+		isTeeGpu:        isTeeGpu,
 	}, nil
 }
 
@@ -119,6 +143,7 @@ func (r *SessionRepositoryCached) getSessionFromCache(id common.Hash) (*SessionM
 		failoverEnabled:  ses.FailoverEnabled,
 		agentUsername:    ses.AgentUsername,
 		isTee:           ses.IsTee,
+		isTeeGpu:        ses.IsTeeGpu,
 	}, nil
 }
 
@@ -137,5 +162,6 @@ func (r *SessionRepositoryCached) saveSessionToCache(ses *SessionModel) error {
 		DirectPayment:    ses.directPayment,
 		AgentUsername:    ses.agentUsername,
 		IsTee:           ses.isTee,
+		IsTeeGpu:        ses.isTeeGpu,
 	})
 }

--- a/proxy-router/internal/storages/session_storage.go
+++ b/proxy-router/internal/storages/session_storage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -162,99 +163,73 @@ func (s *SessionStorage) GetSessionsForModel(modelID string) ([]string, error) {
 	return sessionIDs, nil
 }
 
-// AddActivity atomically reads the existing activities, appends the new one, and writes back
-// in a single BadgerDB transaction to prevent race conditions.
+func formatActivityPrefix(modelID string) []byte {
+	return []byte(fmt.Sprintf("activity:%s:", strings.ToLower(modelID)))
+}
+
+func formatActivityKey(modelID string, endTime int64, sessionID string) []byte {
+	return []byte(fmt.Sprintf("activity:%s:%d:%s", strings.ToLower(modelID), endTime, strings.ToLower(sessionID)))
+}
+
+func parseActivityKeyTimestamp(key []byte) (int64, error) {
+	parts := strings.Split(string(key), ":")
+	if len(parts) < 4 {
+		return 0, fmt.Errorf("invalid activity key format: %s", string(key))
+	}
+	return strconv.ParseInt(parts[2], 10, 64)
+}
+
+// AddActivity stores each activity as an individual key-value entry.
 func (s *SessionStorage) AddActivity(modelID string, activity *PromptActivity) error {
 	modelID = strings.ToLower(modelID)
-	key := []byte(fmt.Sprintf("activity:%s", modelID))
-
-	return s.db.RunInTransaction(func(txn *badger.Txn) error {
-		var activities []*PromptActivity
-
-		item, err := txn.Get(key)
-		if err != nil && !errors.Is(err, badger.ErrKeyNotFound) {
-			return fmt.Errorf("error reading activities for model %s: %w", modelID, err)
-		}
-		if err == nil {
-			var existingJson []byte
-			existingJson, err = item.ValueCopy(nil)
-			if err != nil {
-				return fmt.Errorf("error copying activity value for model %s: %w", modelID, err)
-			}
-			if err := json.Unmarshal(existingJson, &activities); err != nil {
-				return fmt.Errorf("error unmarshaling activities for model %s: %w", modelID, err)
-			}
-		}
-
-		activities = append(activities, activity)
-		activitiesJson, err := json.Marshal(activities)
-		if err != nil {
-			return err
-		}
-
-		entry := badger.NewEntry(key, activitiesJson).WithTTL(ActivityTTL)
-		return txn.SetEntry(entry)
-	})
+	key := formatActivityKey(modelID, activity.EndTime, activity.SessionID)
+	activityJSON, err := json.Marshal(activity)
+	if err != nil {
+		return err
+	}
+	return s.db.SetWithTTL(key, activityJSON, ActivityTTL)
 }
 
 func (s *SessionStorage) GetActivities(modelID string) ([]*PromptActivity, error) {
 	modelID = strings.ToLower(modelID)
-	key := fmt.Sprintf("activity:%s", modelID)
-
-	activitiesJson, err := s.db.Get([]byte(key))
+	_, values, err := s.db.GetPrefixWithValues(formatActivityPrefix(modelID))
 	if err != nil {
-		if errors.Is(err, badger.ErrKeyNotFound) {
-			return []*PromptActivity{}, nil
-		}
 		return nil, fmt.Errorf("error reading activities for model %s: %w", modelID, err)
 	}
 
-	var activities []*PromptActivity
-	if err := json.Unmarshal(activitiesJson, &activities); err != nil {
-		return nil, fmt.Errorf("error unmarshaling activities for model %s: %w", modelID, err)
+	activities := make([]*PromptActivity, 0, len(values))
+	for _, activityJSON := range values {
+		var activity PromptActivity
+		if err := json.Unmarshal(activityJSON, &activity); err != nil {
+			return nil, fmt.Errorf("error unmarshaling activity for model %s: %w", modelID, err)
+		}
+		activities = append(activities, &activity)
 	}
 
 	return activities, nil
 }
 
-// RemoveOldActivities atomically reads, filters, and writes back activities in a single transaction.
+// RemoveOldActivities removes individual activity keys older than beforeTime.
 func (s *SessionStorage) RemoveOldActivities(modelID string, beforeTime int64) error {
 	modelID = strings.ToLower(modelID)
-	key := []byte(fmt.Sprintf("activity:%s", modelID))
+	keys, err := s.db.GetPrefix(formatActivityPrefix(modelID))
+	if err != nil {
+		return fmt.Errorf("error reading activity keys for model %s: %w", modelID, err)
+	}
 
 	return s.db.RunInTransaction(func(txn *badger.Txn) error {
-		item, err := txn.Get(key)
-		if err != nil {
-			if errors.Is(err, badger.ErrKeyNotFound) {
-				return nil
+		for _, key := range keys {
+			endTime, err := parseActivityKeyTimestamp(key)
+			if err != nil {
+				continue
 			}
-			return fmt.Errorf("error reading activities for model %s: %w", modelID, err)
-		}
-
-		existingJson, err := item.ValueCopy(nil)
-		if err != nil {
-			return fmt.Errorf("error copying activity value for model %s: %w", modelID, err)
-		}
-
-		var activities []*PromptActivity
-		if err := json.Unmarshal(existingJson, &activities); err != nil {
-			return fmt.Errorf("error unmarshaling activities for model %s: %w", modelID, err)
-		}
-
-		var updatedActivities []*PromptActivity
-		for _, activity := range activities {
-			if activity.EndTime > beforeTime {
-				updatedActivities = append(updatedActivities, activity)
+			if endTime <= beforeTime {
+				if err := txn.Delete(key); err != nil {
+					return fmt.Errorf("error deleting activity key %s: %w", string(key), err)
+				}
 			}
 		}
-
-		activitiesJson, err := json.Marshal(updatedActivities)
-		if err != nil {
-			return err
-		}
-
-		entry := badger.NewEntry(key, activitiesJson).WithTTL(ActivityTTL)
-		return txn.SetEntry(entry)
+		return nil
 	})
 }
 

--- a/proxy-router/internal/storages/session_storage_test.go
+++ b/proxy-router/internal/storages/session_storage_test.go
@@ -1,8 +1,10 @@
 package storages
 
 import (
+	"encoding/json"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -63,4 +65,65 @@ func TestRemoveSession(t *testing.T) {
 	sessionIds, err := sessionStorage.GetSessionsForModel(session.ModelID)
 	require.NoError(t, err)
 	require.Empty(t, sessionIds)
+}
+
+func TestActivityStorage_AddAndGetActivities(t *testing.T) {
+	storage := NewTestStorage()
+	sessionStorage := NewSessionStorage(storage)
+
+	modelID := "0xabc"
+	a1 := &PromptActivity{SessionID: "0x1", StartTime: 100, EndTime: 101}
+	a2 := &PromptActivity{SessionID: "0x2", StartTime: 200, EndTime: 201}
+
+	require.NoError(t, sessionStorage.AddActivity(modelID, a1))
+	require.NoError(t, sessionStorage.AddActivity(modelID, a2))
+
+	activities, err := sessionStorage.GetActivities(modelID)
+	require.NoError(t, err)
+	require.Len(t, activities, 2)
+
+	got := map[string]PromptActivity{}
+	for _, a := range activities {
+		got[a.SessionID] = *a
+	}
+	require.Equal(t, *a1, got[a1.SessionID])
+	require.Equal(t, *a2, got[a2.SessionID])
+}
+
+func TestActivityStorage_RemoveOldActivities(t *testing.T) {
+	storage := NewTestStorage()
+	sessionStorage := NewSessionStorage(storage)
+
+	modelID := "0xdef"
+	oldActivity := &PromptActivity{SessionID: "0xold", StartTime: 100, EndTime: 110}
+	newActivity := &PromptActivity{SessionID: "0xnew", StartTime: 200, EndTime: 210}
+
+	require.NoError(t, sessionStorage.AddActivity(modelID, oldActivity))
+	require.NoError(t, sessionStorage.AddActivity(modelID, newActivity))
+
+	require.NoError(t, sessionStorage.RemoveOldActivities(modelID, 150))
+
+	activities, err := sessionStorage.GetActivities(modelID)
+	require.NoError(t, err)
+	require.Len(t, activities, 1)
+	require.Equal(t, newActivity.SessionID, activities[0].SessionID)
+	require.Equal(t, newActivity.EndTime, activities[0].EndTime)
+}
+
+func TestActivityStorage_IgnoresLegacyArrayKey(t *testing.T) {
+	storage := NewTestStorage()
+	sessionStorage := NewSessionStorage(storage)
+
+	modelID := "0xlegacy"
+	legacyValue, err := json.Marshal([]*PromptActivity{
+		{SessionID: "0xlegacy", StartTime: 1, EndTime: 2},
+	})
+	require.NoError(t, err)
+
+	legacyKey := []byte("activity:" + modelID)
+	require.NoError(t, storage.SetWithTTL(legacyKey, legacyValue, time.Hour))
+
+	activities, err := sessionStorage.GetActivities(modelID)
+	require.NoError(t, err)
+	require.Empty(t, activities)
 }

--- a/proxy-router/internal/storages/storage.go
+++ b/proxy-router/internal/storages/storage.go
@@ -16,7 +16,7 @@ import (
 // Default configuration values for BadgerDB
 const (
 	DefaultGCInterval      = 5 * time.Minute
-	DefaultGCRatio         = 0.5
+	DefaultGCRatio         = 0.3
 	DefaultMetricsInterval = 5 * time.Minute
 )
 
@@ -39,6 +39,7 @@ func NewStorage(log lib.ILogger, path string) (*Storage, error) {
 	opts.Logger = storageLogger
 	opts.NumVersionsToKeep = 1
 	opts.CompactL0OnClose = true
+	opts.ValueLogFileSize = 128 << 20
 
 	db, err := badger.Open(opts)
 	if err != nil {

--- a/proxy-router/internal/storages/structs.go
+++ b/proxy-router/internal/storages/structs.go
@@ -21,6 +21,7 @@ type Session struct {
 	FailoverEnabled  bool
 	DirectPayment    bool
 	IsTee            bool
+	IsTeeGpu         bool
 }
 
 type User struct {

--- a/proxy-router/internal/storages/structs.go
+++ b/proxy-router/internal/storages/structs.go
@@ -21,7 +21,6 @@ type Session struct {
 	FailoverEnabled  bool
 	DirectPayment    bool
 	IsTee            bool
-	IsTeeGpu         bool
 }
 
 type User struct {

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,13 @@
 ![Simple-Overview](docs/images/simple.png)
 The purpose of this software is to enable interaction with distributed, decentralized LLMs on the Morpheus network through a desktop chat experience.
 
+> **v7.0.0 — Full TEE capability.** The v7 release completes a two-hop Trusted Execution Environment (TEE) trust chain for any model registered on-chain with the `tee` tag:
+>
+> - **Phase 1** — *consumer → P-Node.* A consumer proxy-router (v6.0.0+) cryptographically verifies the provider's P-Node runs the exact official hardened `-tee` image inside a genuine Intel TDX SecretVM, with TLS pinning, at session open and on every prompt.
+> - **Phase 2 (new in v7)** — *P-Node → backend LLM.* The v7+ P-Node itself verifies the backend LLM it forwards inference to (CPU TDX quote, TLS pinning, workload RTMR3 replay of the backend's `docker-compose.yaml`, CPU-GPU nonce binding, and NVIDIA NRAS GPU attestation) at startup and on every prompt.
+>
+> Because Phase 2 runs inside the attested P-Node, **any v6+ consumer is forward-compatible with a v7+ provider** and gains the Phase 2 guarantees automatically — no client-side upgrade required. See [02.3-proxy-router-tee.md](docs/02.3-proxy-router-tee.md), [02.4-proxy-router-secretvm-quickstart.md](docs/02.4-proxy-router-secretvm-quickstart.md), and the developer reference at [proxy-router/docs/tee-backend-verification.md](proxy-router/docs/tee-backend-verification.md).
+
 0. PreRequisites: BASE Layer 2 Blockchain, MOR and ETH on BASE for staking and bidding
 1. Existing, Hosted AI model that is available for inference via the Morpheus network
 2. The proxy-router talks to and listens to the blockchain, routes prompts and inference between the providers’ models and the consumers that purchase and use the models
@@ -47,3 +54,9 @@ manages secure sessions between consumers and providers and routes prompts and r
 
 * [02-Provider-Setup](docs/02-provider-setup.md) - This is the simplest way to get started with the Morpheus Lumerin Node as a Provider.  This will allow you to connect your existing AI-Model to the Morpheus network and offer it for use by consumers.
     * [02.1-Proxy-Router-Docker](docs/02.1-proxy-router-docker.md) - Fast start using existing Docker image and proxy-router configuration
+    * [02.2-Proxy-Router-Akash](docs/02.2-proxy-router-akash.md) - Run the proxy-router on the Akash decentralized cloud
+    * [02.3-Proxy-Router-TEE](docs/02.3-proxy-router-tee.md) - Full TEE (Trusted Execution Environment) reference: build-time baked-in config, RTMR3 attestation, cosign image/manifest verification, and consumer-side verification steps
+    * [02.4-Proxy-Router-SecretVM-Quickstart](docs/02.4-proxy-router-secretvm-quickstart.md) - Shortest path to a v7 TEE provider: deploy the hardened `-tee` image on SecretVM and register a `tee`-tagged model
+    * [02.5-API-Auth](docs/02.5-api-auth.md) - API authentication (cookie/proxy.conf) required since v2.0.0
+
+* [03-Provider-Offer](docs/03-provider-offer.md) - Register your provider, model (optionally with the `tee` tag), and bid on-chain.

--- a/smart-contracts/deploy/data/config_base_mainnet.json
+++ b/smart-contracts/deploy/data/config_base_mainnet.json
@@ -1,6 +1,6 @@
 {
   "MOR": "0x7431ada8a591c955a994a21710752ef9b882b8e3",
-  "fundingAccount": "0x1FE04BC15Cf2c5A2d41a0b3a96725596676eBa1E",
+  "fundingAccount": "0x5160C0311A95E0A1072FA85Df23712A7BA1cD4b1",
   "providerMinStake": "100000000000000000",
   "modelMinStake": "100000000000000000",
   "marketplaceBidFee": "100000000000000000",


### PR DESCRIPTION
## Overview

**v7.0.0 — Full TEE capability.** This release completes the Morpheus TEE trust chain with **Phase 2: Provider-side backend LLM attestation**. v6.x closed the loop between the consumer and the provider's proxy-router (P-Node). v7.0.0 closes the next hop: the P-Node now cryptographically verifies its **own backend LLM** (CPU TDX quote, TLS pinning, workload RTMR3 replay, CPU-GPU nonce binding, NVIDIA NRAS GPU attestation) at startup and on **every inference prompt**.

The major version bump to **7.0.0** marks the completion of the full two-hop TEE verification chain. It is also designed for **seamless forward-compatibility**: v6.0.0+ consumers automatically benefit from Phase 2 guarantees when they connect to v7.0.0+ providers — no client-side upgrade is required.

```
C-Node (v6.0.0+)  ──Phase 1──▶  P-Node -tee image (v7.0.0+)  ──Phase 2──▶  Backend LLM
                  consumer                                     P-Node
                  verifies                                     verifies its
                  P-Node                                       own backend
```

The on-chain `tee` model tag is the single switch that turns on both hops.

---

## Headline: Phase 2 TEE Backend Verification (#699, #700)

Every TEE-tagged model's backend LLM is now attested **by the P-Node itself**, not just assumed trustworthy. The P-Node refuses to forward any inference unless the backend passes all of the following on every request:

| Check | What it proves | Where |
|---|---|---|
| **Portal-verified CPU TDX quote** | Backend runs on genuine Intel TDX hardware | `:29343/cpu` → `TEE_PORTAL_URL` |
| **TLS certificate pinning** | Inference TLS terminates inside the attested enclave — no CDN/MITM can slip in | `reportData[0:32] == SHA-256(TLS cert)` |
| **Workload RTMR3 replay** | The exact set of loaded models (`MODELS=…` line in `docker-compose.yaml`) is what the operator declared | RTMR3 replay vs. backend's `:29343/docker-compose` |
| **MRTD + RTMR0–2 artifact lookup** | Firmware / VM config / kernel / initramfs all match a published SecretVM build | `ArtifactRegistry` CSV (auto-refreshed) |
| **CPU-GPU nonce binding** | GPU evidence cannot be replayed from another box | `reportData[32:64] == GPU nonce` |
| **NVIDIA NRAS v4 attestation** | Independent hardware-level validation of the GPU | NRAS REST + JWT EAT signature check |
| **Per-prompt fast verify** | Backend identity hasn't changed since initial attestation — **runs on every prompt** | hash + TLS fingerprint compare (~50 ms) |
| **Pinned-cert HTTP client** | Onward inference connection refuses any TLS cert whose fingerprint doesn't match | `PinnedHTTPClient.VerifyPeerCertificate` |

**Key files added** (`proxy-router/internal/attestation/`):
- `backend_verifier.go` — `AttestBackend` (full, startup) + `FastVerifyBackend` (per-prompt hot path, no TTL)
- `workload_verifier.go`, `rtmr.go`, `tdx_quote.go` — RTMR3 replay using SHA-384 extend chain
- `artifacts_registry.go` — auto-refresh of the SecretVM TDX artifact registry
- `nras_verifier.go` — NVIDIA NRAS v4 API client with JWT EAT validation
- Backend verifier test suite: `backend_verifier_test.go`, `workload_verifier_test.go`, `workload_rytn_test.go`, `nras_verifier_test.go`, `golden_test.go` (~1,450 LOC of coverage)

**Key integration points:**
- `proxy-router/cmd/main.go` — wires `BackendVerifier` into startup and calls `AttestBackend` once per `tee`-tagged model
- `proxy-router/internal/proxyapi/proxy_receiver.go` — calls `FastVerifyBackend` on the `SessionPrompt` hot path before forwarding any inference
- `proxy-router/internal/aiengine/ai_engine.go` — returns a `PinnedHTTPClient` for TEE models
- `proxy-router/internal/proxyapi/controller_http.go` — new `GET /v1/models/attestation` health endpoint exposing per-model state (`verified` / `pending` / `failed` + last-success timestamp + workload match)

**New environment variables** (`TEE` config block):

| Variable | Default | Purpose |
|---|---|---|
| `TEE_PORTAL_URL` | SecretAI Portal | CPU quote parse + verification endpoint |
| `TEE_IMAGE_REPO` | `ghcr.io/morpheusais/morpheus-lumerin-node-tee` | Image repo for cosign attestation verification |
| `ARTIFACT_REGISTRY_URL` | SecretVM TDX artifacts CSV | MRTD + RTMR0–2 lookup source |
| `ARTIFACT_REGISTRY_REFRESH_INTERVAL` | (configurable) | How often to re-fetch the registry |

---

## The `tee` Tag — One Switch, Two Hops (#708, #709)

Prior to v7.0.0 there were transient plans for a separate `tee-gpu` tag. That's been consolidated: **the single on-chain `tee` tag** now drives the entire trust chain. It turns on **both**:
- **Phase 1** on the consumer: C-Node (v6.0.0+) verifies the P-Node's attestation
- **Phase 2** on the provider: P-Node (v7.0.0+) verifies its own backend LLM

The local `isTee` field in `models-config.json` has been removed in favor of the blockchain tag as the single source of truth. `IsTeeModel(tags)` is the sole helper; `IsTeeGPUModel` is deleted.

---

## Operational Robustness

### P-Node TEE error wrapping (#703, #704)
When the P-Node's Phase 2 backend attestation fails, the error returned to callers is now wrapped in the correct error type so upstream logic (session open, prompt dispatch) handles it consistently and the consumer-visible failure is actionable rather than a generic 500.

### `request_id` propagation in every log (#705)
Every log line emitted along an inference or attestation path now carries the `request_id` from its context, so operators can trace a single prompt end-to-end through consumer → P-Node → backend attestation → inference → response. Critical for v7 operations since Phase 2 failures can surface at any of several points.

### Storage: per-entry Badger activity keys (#692, #693)
Session activity tracking moved from a single aggregate key to per-entry keys. This makes BadgerDB's GC able to reclaim disk space properly as sessions roll over, eliminating a slow-growing storage-bloat issue seen in long-running providers.

### CI/CD: ECS deploy wait-timing hardening (#694, #695, #701, #702, #710)
Multiple refinements to the ECS service stabilization + post-deploy attestation-verification window, eliminating intermittent premature health-check failures that were flakily failing otherwise-successful deploys.

---

## Documentation — Full v7 Doc Pass (#710)

All public-facing and internal TEE documentation was audited and rewritten in this release to accurately describe the two-hop trust chain and the forward-compatibility story:

**User-facing:**
- `readme.md` — new v7.0.0 release callout with the two-hop diagram and forward-compat note
- `docs/02.3-proxy-router-tee.md` — rewrote "What This Guarantees (and What It Doesn't)" with explicit Phase 1 / Phase 2 / remaining-gaps sections
- `docs/02.4-proxy-router-secretvm-quickstart.md` — rewrote "What Consumers See, and What Your P-Node Does" as two distinct hops + v7 troubleshooting
- `docs/03-provider-offer.md` — clarified the `tee` on-chain tag drives both hops
- `docs/models-config.json.md` — noted `isTee` is no longer a local config field (tag-driven)
- `docs/proxy-router.all.env` — documented all new TEE env vars

**Developer reference:**
- `proxy-router/docs/tee-backend-verification.md` — new 286-line developer reference for Phase 2, with mermaid sequence + trust-chain diagrams
- `proxy-router/docs/docs.go`, `swagger.json`, `swagger.yaml` — auto-generated API docs include the new `GET /v1/models/attestation` endpoint

**Internal (`.ai-docs/`):**
- `TEE_Attestation_Architecture.md` — status bumped to v2.0; Phases 1 / 1c / 2a marked DONE with real file paths and PR numbers; new §7.7 full Phase 2 technical write-up
- `TEE_CICD_Supply_Chain_Hardening.md` — v7.0.0 banner; trust-chain diagram updated with completed Phase 1c and Phase 2 boxes

---

## Configuration Updates

- **`.github/workflows/build.yml`** — `VMAJ_NEW=7` (major-version bump); builds from `main` will now tag as `v7.x.x`.
- **`smart-contracts/deploy/data/config_base_mainnet.json`** — `fundingAccount` rotated from `0x1FE04BC15Cf2c5A2d41a0b3a96725596676eBa1E` to `0x5160C0311A95E0A1072FA85Df23712A7BA1cD4b1`.

---

## Consumer / Provider Compatibility Matrix

| Consumer | Provider | TEE behavior |
|---|---|---|
| Pre-v6 | any | No TEE verification |
| v6.0.0+ | v6.x | Phase 1 only (consumer verifies P-Node); backend LLM not attested |
| **v6.0.0+** | **v7.0.0+** | **Full Phase 1 + Phase 2 — the consumer transparently gains Phase 2 guarantees via the attested P-Node binary. No client-side upgrade required.** |
| v7.0.0+ | v7.0.0+ | Full Phase 1 + Phase 2 |

This forward-compatibility is the key design principle of the v7 release — upgrading providers instantly strengthens the network for all existing v6+ consumers.

---

## PRs Included (main → test diff, 28 commits)

### Phase 2 TEE Backend Verification (headline)
- #699 — feat: Phase 2 TEE backend verification
- #700 — Phase 2 (dev → test merge)
- #703 / #704 — wrap in correct error on P-Node TEE attestation fail
- #705 — pass request_id in context in every log
- #708 / #709 — feat: `"tee"` tag for everything (consolidate on single on-chain tag)

### Storage & CI/CD hardening
- #692 / #693 — fix(storage): per-entry Badger activity keys + GC reclaim
- #694 / #695 — refactor(workflows): improve ECS service stabilization timeout handling
- #701 / #702 — fix(cicd): ECS deploy wait timing
- #710 — ECS deploy wait timing + v7.0.0 release docs + version bump
- #711 — merge: dev to test — v7.0.0 release

---

## Verification

All changes were validated on `test` through the automated pipeline:
- Build → cosign sign → RTMR3 compute → deploy to SecretVM test VM → post-deploy attestation verification
- Per-model Phase 2 attestation exposed at `GET /v1/models/attestation` and verified live

---

## Test Plan

- [ ] Verify `VMAJ_NEW=7` produces a clean `v7.0.0` build tag on merge to main
- [ ] Verify `docker-compose.tee.yml` deployed to a SecretVM instance boots cleanly and `GET /v1/models/attestation` returns `verified` per TEE-tagged model
- [ ] Verify a v6.0.0+ consumer opens a session against a v7.0.0+ provider and transparently gets Phase 2 guarantees (no client upgrade)
- [ ] Verify Phase 2 fast-verify fires on every prompt (log `request_id` should appear at both session-open and each prompt)
- [ ] Verify workload RTMR3 mismatch (e.g. altered `docker-compose.yaml`) causes the P-Node to refuse the session
- [ ] Verify TLS certificate change on the backend triggers a hard fail (MITM signal) and refused prompt
- [ ] Verify CPU-GPU nonce mismatch causes attestation failure
- [ ] Verify NRAS outage degrades gracefully (does not block inference) but CPU-GPU binding still enforced
- [ ] Verify `fundingAccount` rotation in `config_base_mainnet.json` is correct before promotion
- [ ] Verify existing non-TEE models are unaffected (zero overhead)
- [ ] All CI checks pass on `main` after merge

---

## Blocked until review + branch protection approval.

Made with [Cursor](https://cursor.com)