### PR TITLE
feat: add AMD SEV-SNP attestation support for TEE providers

### DIFF
--- a/proxy-router/cmd/main.go
+++ b/proxy-router/cmd/main.go
@@ -317,7 +317,7 @@ func start() error {
 
 	aiEngine := aiengine.NewAiEngine(proxyRouterApi, chatStorage, modelConfigLoader, agentConfigLoader, cfg.Proxy.LLMTimeout, appLog)
 
-	// TEE: create artifact registry and backend verifier
+	// TEE: create artifact registries and backend verifier
 	artifactRegistry := attestation.NewArtifactRegistry(
 		cfg.TEE.ArtifactRegistryURL,
 		cfg.TEE.ArtifactRegistryRefreshInterval,
@@ -325,10 +325,18 @@ func start() error {
 	)
 	artifactRegistry.Start(context.Background())
 
+	sevArtifactRegistry := attestation.NewSevArtifactRegistry(
+		cfg.TEE.SevArtifactRegistryURL,
+		cfg.TEE.ArtifactRegistryRefreshInterval,
+		appLog.Named("ARTIFACT_REGISTRY_SEV"),
+	)
+	sevArtifactRegistry.Start(context.Background())
+
 	backendVerifier := attestation.NewBackendVerifier(
 		cfg.TEE.PortalURL,
 		&attestation.NoopGoldenSource{},
 		artifactRegistry,
+		sevArtifactRegistry,
 		appLog.Named("BACKEND_TEE"),
 	)
 	// Startup pre-flight: attest models that have "tee" tag on-chain

--- a/proxy-router/internal/attestation/backend_verifier.go
+++ b/proxy-router/internal/attestation/backend_verifier.go
@@ -69,13 +69,14 @@ type BackendVerifier struct {
 	goldenSource      BackendGoldenSource
 	nrasVerifier      *NRASVerifier
 	artifactRegistry  *ArtifactRegistry
+	sevRegistry       *SevArtifactRegistry
 	log               lib.ILogger
 
 	mu    sync.RWMutex
 	cache map[string]*BackendAttestationSnapshot
 }
 
-func NewBackendVerifier(portalURL string, goldenSource BackendGoldenSource, registry *ArtifactRegistry, log lib.ILogger) *BackendVerifier {
+func NewBackendVerifier(portalURL string, goldenSource BackendGoldenSource, registry *ArtifactRegistry, sevRegistry *SevArtifactRegistry, log lib.ILogger) *BackendVerifier {
 	if portalURL == "" {
 		portalURL = DefaultPortalURL
 	}
@@ -90,6 +91,7 @@ func NewBackendVerifier(portalURL string, goldenSource BackendGoldenSource, regi
 		goldenSource:      goldenSource,
 		nrasVerifier:      NewNRASVerifier(log),
 		artifactRegistry:  registry,
+		sevRegistry:       sevRegistry,
 		log:               log,
 		cache:             make(map[string]*BackendAttestationSnapshot),
 	}
@@ -141,7 +143,7 @@ func (bv *BackendVerifier) AttestBackend(ctx context.Context, modelID string, at
 		if composeErr != nil {
 			bv.log.Warnf("backend attestation: could not fetch docker-compose for model %s: %s (workload verification skipped)", modelID, composeErr)
 		} else {
-			result := VerifyWorkload(bv.artifactRegistry, cpuQuote, dockerCompose, bv.log)
+			result := VerifyWorkload(bv.artifactRegistry, bv.sevRegistry, cpuQuote, dockerCompose, bv.log)
 			workloadResult = &result
 			switch result.Status {
 			case WorkloadAuthentic:
@@ -152,6 +154,8 @@ func (bv *BackendVerifier) AttestBackend(ctx context.Context, modelID string, at
 			case WorkloadNotAuthentic:
 				bv.storeFailure(modelID, attestationURL, "VM is not an authentic SecretVM (MRTD/RTMR values not in registry)")
 				return fmt.Errorf("workload verification failed for model %s: not an authentic SecretVM", modelID)
+			case WorkloadSkipped:
+				bv.log.Infof("backend attestation: workload verification skipped for model %s (SEV quote, not yet supported)", modelID)
 			}
 		}
 	} else {
@@ -349,8 +353,8 @@ func (bv *BackendVerifier) PinnedHTTPClient(modelID string) (*http.Client, error
 // The second half (bytes 32-63, hex chars 64-127) of the CPU reportData should match
 // the GPU attestation's reportData (which serves as the GPU nonce).
 func VerifyCPUGPUBinding(cpuReportData string, gpuReportData string) error {
-	cpuReportData = strings.ToLower(strings.TrimSpace(cpuReportData))
-	gpuReportData = strings.ToLower(strings.TrimSpace(gpuReportData))
+	cpuReportData = strings.ToLower(strings.ReplaceAll(strings.TrimSpace(cpuReportData), " ", ""))
+	gpuReportData = strings.ToLower(strings.ReplaceAll(strings.TrimSpace(gpuReportData), " ", ""))
 
 	// CPU reportData layout:
 	//   chars 0-63  (bytes 0-31): TLS cert fingerprint

--- a/proxy-router/internal/attestation/backend_verifier_test.go
+++ b/proxy-router/internal/attestation/backend_verifier_test.go
@@ -127,21 +127,21 @@ func TestVerifyTLSBinding_EmptyReportData(t *testing.T) {
 // --- BackendVerifier cache and status ---
 
 func TestBackendVerifier_GetStatus_Unknown(t *testing.T) {
-	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, nil, testLog())
 	if status := bv.GetStatus("nonexistent"); status != nil {
 		t.Fatalf("expected nil, got: %+v", status)
 	}
 }
 
 func TestBackendVerifier_GetAllStatuses_Empty(t *testing.T) {
-	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, nil, testLog())
 	if statuses := bv.GetAllStatuses(); len(statuses) != 0 {
 		t.Fatalf("expected 0 statuses, got %d", len(statuses))
 	}
 }
 
 func TestBackendVerifier_StoreFailure(t *testing.T) {
-	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, nil, testLog())
 	bv.storeFailure("model-1", "https://test:29343", "test error")
 
 	status := bv.GetStatus("model-1")
@@ -159,7 +159,7 @@ func TestBackendVerifier_StoreFailure(t *testing.T) {
 // --- FastVerifyBackend ---
 
 func TestBackendVerifier_FastVerify_NoCache(t *testing.T) {
-	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, nil, testLog())
 	err := bv.FastVerifyBackend(context.Background(), "no-such-model")
 	if err == nil {
 		t.Fatal("expected error")
@@ -170,7 +170,7 @@ func TestBackendVerifier_FastVerify_NoCache(t *testing.T) {
 }
 
 func TestBackendVerifier_FastVerify_FailedStatus(t *testing.T) {
-	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, nil, testLog())
 	bv.storeFailure("model-1", "https://test:29343", "prev failure")
 
 	err := bv.FastVerifyBackend(context.Background(), "model-1")
@@ -195,7 +195,7 @@ func TestBackendVerifier_FastVerify_CacheHit(t *testing.T) {
 
 	_, fingerprint := selfSignedCert(t)
 
-	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, nil, testLog())
 	bv.attestationClient = attestServer.Client()
 
 	bv.mu.Lock()
@@ -252,7 +252,7 @@ func TestBackendVerifier_AttestBackend_FullFlow(t *testing.T) {
 	attestServer.TLS.Certificates = []tls.Certificate{cert}
 
 	portalMux := http.NewServeMux()
-	portalMux.HandleFunc("/api/quote-parse", func(w http.ResponseWriter, _ *http.Request) {
+	portalHandler := func(w http.ResponseWriter, _ *http.Request) {
 		resp := ParseQuoteResponse{
 			Quote: &QuoteFields{
 				MRTD:       "aaaa",
@@ -266,11 +266,13 @@ func TestBackendVerifier_AttestBackend_FullFlow(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
-	})
+	}
+	portalMux.HandleFunc("/api/quote-parse", portalHandler)
+	portalMux.HandleFunc("/api/quote-parse-sev", portalHandler)
 	portalServer := httptest.NewServer(portalMux)
 	defer portalServer.Close()
 
-	bv := NewBackendVerifier(portalServer.URL+"/api/quote-parse", nil, nil, testLog())
+	bv := NewBackendVerifier(portalServer.URL+"/api/quote-parse", nil, nil, nil, testLog())
 	bv.attestationClient = NewAttestationHTTPClient()
 
 	err := bv.AttestBackend(context.Background(), "test-model", attestServer.URL)
@@ -315,7 +317,7 @@ func TestBackendVerifier_AttestBackend_WithNRAS(t *testing.T) {
 	attestServer.TLS.Certificates = []tls.Certificate{cert}
 
 	portalMux := http.NewServeMux()
-	portalMux.HandleFunc("/api/quote-parse", func(w http.ResponseWriter, _ *http.Request) {
+	portalHandler := func(w http.ResponseWriter, _ *http.Request) {
 		resp := ParseQuoteResponse{
 			Quote: &QuoteFields{
 				MRTD:       "aaaa",
@@ -329,7 +331,9 @@ func TestBackendVerifier_AttestBackend_WithNRAS(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
-	})
+	}
+	portalMux.HandleFunc("/api/quote-parse", portalHandler)
+	portalMux.HandleFunc("/api/quote-parse-sev", portalHandler)
 	portalServer := httptest.NewServer(portalMux)
 	defer portalServer.Close()
 
@@ -359,7 +363,7 @@ func TestBackendVerifier_AttestBackend_WithNRAS(t *testing.T) {
 	nrasServer := httptest.NewServer(nrasMux)
 	defer nrasServer.Close()
 
-	bv := NewBackendVerifier(portalServer.URL+"/api/quote-parse", nil, nil, testLog())
+	bv := NewBackendVerifier(portalServer.URL+"/api/quote-parse", nil, nil, nil, testLog())
 	bv.attestationClient = NewAttestationHTTPClient()
 	bv.nrasVerifier.baseURL = nrasServer.URL
 
@@ -380,7 +384,7 @@ func TestBackendVerifier_AttestBackend_WithNRAS(t *testing.T) {
 // --- PinnedHTTPClient ---
 
 func TestBackendVerifier_PinnedHTTPClient_NoModel(t *testing.T) {
-	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, nil, testLog())
 	_, err := bv.PinnedHTTPClient("no-model")
 	if err == nil {
 		t.Fatal("expected error")
@@ -388,7 +392,7 @@ func TestBackendVerifier_PinnedHTTPClient_NoModel(t *testing.T) {
 }
 
 func TestBackendVerifier_PinnedHTTPClient_Success(t *testing.T) {
-	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, nil, testLog())
 
 	bv.mu.Lock()
 	bv.cache["model-1"] = &BackendAttestationSnapshot{
@@ -408,7 +412,7 @@ func TestBackendVerifier_PinnedHTTPClient_Success(t *testing.T) {
 }
 
 func TestBackendVerifier_PinnedHTTPClient_FailedStatus(t *testing.T) {
-	bv := NewBackendVerifier("http://unused", nil, nil, testLog())
+	bv := NewBackendVerifier("http://unused", nil, nil, nil, testLog())
 	bv.storeFailure("model-1", "https://test:29343", "broken")
 
 	_, err := bv.PinnedHTTPClient("model-1")

--- a/proxy-router/internal/attestation/sev_gctx.go
+++ b/proxy-router/internal/attestation/sev_gctx.go
@@ -1,0 +1,278 @@
+package attestation
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/binary"
+	"encoding/hex"
+	"strings"
+)
+
+const (
+	ldSize       = 48 // SHA-384 digest size
+	vmsaGPA      = uint64(0xFFFFFFFFF000)
+	vcpuSigEPYC  = 0x00800f12
+	guestFeatures = 0x1
+	bspEIP       = 0xfffffff0
+)
+
+// VcpuMap maps SecretVM template names to vCPU counts.
+var VcpuMap = map[string]int{
+	"small":   1,
+	"medium":  2,
+	"large":   4,
+	"2xlarge": 8,
+	"4xlarge": 16,
+}
+
+// SevOvmfSection represents one OVMF section in the SEV registry.
+type SevOvmfSection struct {
+	GPA         uint64 `json:"gpa"`
+	Size        int    `json:"size"`
+	SectionType int    `json:"section_type"`
+}
+
+// SevArtifactEntry represents one entry in the SEV artifact registry JSON.
+type SevArtifactEntry struct {
+	VMType            string           `json:"vm_type"`
+	ArtifactsVer      string           `json:"artifacts_ver"`
+	KernelHash        string           `json:"kernel_hash"`
+	InitrdHash        string           `json:"initrd_hash"`
+	VcpuType          string           `json:"vcpu_type"`
+	RootfsHash        string           `json:"rootfs_hash"`
+	OvmfHash          string           `json:"ovmf_hash"`
+	SevHashesTableGPA uint64           `json:"sev_hashes_table_gpa"`
+	SevEsResetEIP     uint32           `json:"sev_es_reset_eip"`
+	OvmfSections      []SevOvmfSection `json:"ovmf_sections"`
+	CmdlineExtra      string           `json:"cmdline_extra,omitempty"`
+}
+
+// SevFamilyID holds parsed SEV family_id fields from the attestation report.
+type SevFamilyID struct {
+	VMType       string
+	TemplateName string
+	Vcpus        int
+}
+
+// ParseSevFamilyID parses the 16-byte family_id field from a SEV-SNP report.
+// Expects format "<vmType>-<templateName>-sev" (e.g. "prod-small-sev").
+func ParseSevFamilyID(familyIDBytes []byte) *SevFamilyID {
+	s := strings.TrimRight(string(familyIDBytes[:16]), "\x00#")
+	if !strings.HasSuffix(s, "-sev") {
+		return nil
+	}
+	core := s[:len(s)-4] // strip "-sev"
+	idx := strings.Index(core, "-")
+	if idx < 0 {
+		return nil
+	}
+	vmType := core[:idx]
+	templateName := core[idx+1:]
+	vcpus, ok := VcpuMap[templateName]
+	if !ok {
+		return nil
+	}
+	return &SevFamilyID{VMType: vmType, TemplateName: templateName, Vcpus: vcpus}
+}
+
+// gctxUpdate performs the core GCTX page-update: SHA-384 of the 0x70-byte PAGE_INFO struct.
+// See AMD SNP spec Section 8.17.2 Table 67.
+func gctxUpdate(ld []byte, pageType byte, gpa uint64, contents []byte) []byte {
+	var buf [0x70]byte
+	copy(buf[0:48], ld)
+	copy(buf[48:96], contents)
+	binary.LittleEndian.PutUint16(buf[96:98], 0x70) // page_info_len
+	buf[98] = pageType
+	// buf[99..103] = 0 (imi, vmpl perms, reserved) -- already zero
+	binary.LittleEndian.PutUint64(buf[104:112], gpa)
+	h := sha512.Sum384(buf[:])
+	return h[:]
+}
+
+func sha384(data []byte) []byte {
+	h := sha512.Sum384(data)
+	return h[:]
+}
+
+func gctxUpdateNormalPages(ld []byte, startGPA uint64, data []byte) []byte {
+	for offset := 0; offset < len(data); offset += 4096 {
+		end := offset + 4096
+		if end > len(data) {
+			end = len(data)
+		}
+		page := data[offset:end]
+		ld = gctxUpdate(ld, 0x01, startGPA+uint64(offset), sha384(page))
+	}
+	return ld
+}
+
+func gctxUpdateVmsaPage(ld []byte, data []byte) []byte {
+	return gctxUpdate(ld, 0x02, vmsaGPA, sha384(data))
+}
+
+func gctxUpdateZeroPages(ld []byte, gpa uint64, size int) []byte {
+	zeros := make([]byte, ldSize)
+	for offset := 0; offset < size; offset += 4096 {
+		ld = gctxUpdate(ld, 0x03, gpa+uint64(offset), zeros)
+	}
+	return ld
+}
+
+func gctxUpdateSecretsPage(ld []byte, gpa uint64) []byte {
+	zeros := make([]byte, ldSize)
+	return gctxUpdate(ld, 0x05, gpa, zeros)
+}
+
+func gctxUpdateCpuidPage(ld []byte, gpa uint64) []byte {
+	zeros := make([]byte, ldSize)
+	return gctxUpdate(ld, 0x06, gpa, zeros)
+}
+
+// uuidToLE converts a UUID string to little-endian byte encoding per RFC 4122.
+func uuidToLE(guid string) []byte {
+	hexStr := strings.ReplaceAll(guid, "-", "")
+	b, _ := hex.DecodeString(hexStr)
+	le := make([]byte, len(b))
+	copy(le, b)
+	// group1: bytes 0-3 (swap)
+	le[0], le[1], le[2], le[3] = b[3], b[2], b[1], b[0]
+	// group2: bytes 4-5 (swap)
+	le[4], le[5] = b[5], b[4]
+	// group3: bytes 6-7 (swap)
+	le[6], le[7] = b[7], b[6]
+	// groups 4+5 remain big-endian
+	return le
+}
+
+const (
+	sevHashTableHeaderGUID = "9438d606-4f22-4cc9-b479-a793d411fd21"
+	sevKernelEntryGUID     = "4de79437-abd2-427f-b835-d5b172d2045b"
+	sevInitrdEntryGUID     = "44baf731-3a2f-4bd7-9af1-41e29169781d"
+	sevCmdlineEntryGUID    = "97d02dd8-bd20-4c94-aa78-e7714d36ab2a"
+)
+
+// sevHashTableEntry builds a 50-byte SevHashTableEntry: guid(16) + length(u16 LE) + hash(32).
+func sevHashTableEntry(guidStr string, hash []byte) []byte {
+	entry := make([]byte, 50)
+	copy(entry[0:16], uuidToLE(guidStr))
+	binary.LittleEndian.PutUint16(entry[16:18], 50)
+	copy(entry[18:50], hash)
+	return entry
+}
+
+// buildHashesPage constructs the QEMU SEV kernel hashes page.
+func buildHashesPage(kernelHashHex, initrdHashHex, cmdline string, offsetInPage int) []byte {
+	kernelHash, _ := hex.DecodeString(kernelHashHex)
+
+	var initrdHash []byte
+	if initrdHashHex != "" {
+		initrdHash, _ = hex.DecodeString(initrdHashHex)
+	} else {
+		h := sha256.Sum256(nil)
+		initrdHash = h[:]
+	}
+
+	var cmdlineBytes []byte
+	if cmdline != "" {
+		cmdlineBytes = append([]byte(cmdline), 0)
+	} else {
+		cmdlineBytes = []byte{0}
+	}
+	cmdlineHashArr := sha256.Sum256(cmdlineBytes)
+	cmdlineHash := cmdlineHashArr[:]
+
+	// SevHashTable: guid(16) + length(u16) + cmdline(50) + initrd(50) + kernel(50) = 168 bytes
+	ht := make([]byte, 168)
+	copy(ht[0:16], uuidToLE(sevHashTableHeaderGUID))
+	binary.LittleEndian.PutUint16(ht[16:18], 168)
+	copy(ht[18:68], sevHashTableEntry(sevCmdlineEntryGUID, cmdlineHash))
+	copy(ht[68:118], sevHashTableEntry(sevInitrdEntryGUID, initrdHash))
+	copy(ht[118:168], sevHashTableEntry(sevKernelEntryGUID, kernelHash))
+
+	// Pad to 16-byte alignment: 168 % 16 = 8 -> 8 padding bytes -> 176 bytes
+	padded := make([]byte, 176)
+	copy(padded, ht)
+
+	page := make([]byte, 4096)
+	copy(page[offsetInPage:], padded)
+	return page
+}
+
+// buildVmsaPage constructs a VMSA page for QEMU SEV-SNP mode.
+func buildVmsaPage(eip uint32, vcpuSig uint32, guestFeat uint64) []byte {
+	page := make([]byte, 4096)
+
+	vmcbSeg := func(off int, sel uint16, attr uint16, lim uint32, base uint64) {
+		binary.LittleEndian.PutUint16(page[off:], sel)
+		binary.LittleEndian.PutUint16(page[off+2:], attr)
+		binary.LittleEndian.PutUint32(page[off+4:], lim)
+		binary.LittleEndian.PutUint64(page[off+8:], base)
+	}
+
+	csBase := uint64(eip & 0xffff0000)
+	rip := uint64(eip & 0x0000ffff)
+
+	vmcbSeg(0x000, 0, 0x0093, 0xffff, 0)       // es
+	vmcbSeg(0x010, 0xf000, 0x009b, 0xffff, csBase) // cs
+	vmcbSeg(0x020, 0, 0x0093, 0xffff, 0)       // ss
+	vmcbSeg(0x030, 0, 0x0093, 0xffff, 0)       // ds
+	vmcbSeg(0x040, 0, 0x0093, 0xffff, 0)       // fs
+	vmcbSeg(0x050, 0, 0x0093, 0xffff, 0)       // gs
+	vmcbSeg(0x060, 0, 0x0000, 0xffff, 0)       // gdtr
+	vmcbSeg(0x070, 0, 0x0082, 0xffff, 0)       // ldtr
+	vmcbSeg(0x080, 0, 0x0000, 0xffff, 0)       // idtr
+	vmcbSeg(0x090, 0, 0x008b, 0xffff, 0)       // tr
+
+	binary.LittleEndian.PutUint64(page[0x0d0:], 0x1000)         // efer (SVME)
+	binary.LittleEndian.PutUint64(page[0x148:], 0x40)           // cr4 (MCE)
+	binary.LittleEndian.PutUint64(page[0x158:], 0x10)           // cr0 (PE)
+	binary.LittleEndian.PutUint64(page[0x160:], 0x400)          // dr7
+	binary.LittleEndian.PutUint64(page[0x168:], 0xffff0ff0)     // dr6
+	binary.LittleEndian.PutUint64(page[0x170:], 0x2)            // rflags
+	binary.LittleEndian.PutUint64(page[0x178:], rip)            // rip
+	binary.LittleEndian.PutUint64(page[0x268:], 0x0007040600070406) // g_pat
+	binary.LittleEndian.PutUint64(page[0x310:], uint64(vcpuSig)) // rdx (CPUID sig)
+	binary.LittleEndian.PutUint64(page[0x3b0:], guestFeat)      // sev_features
+	binary.LittleEndian.PutUint64(page[0x3e8:], 0x1)            // xcr0
+	binary.LittleEndian.PutUint32(page[0x408:], 0x1f80)         // mxcsr
+	binary.LittleEndian.PutUint16(page[0x410:], 0x037f)         // x87_fcw
+
+	return page
+}
+
+// CalcSevMeasurement computes the expected SEV-SNP launch digest for a given
+// registry entry, vcpu count, and kernel cmdline.
+func CalcSevMeasurement(entry *SevArtifactEntry, vcpus int, cmdline string) string {
+	ld, _ := hex.DecodeString(entry.OvmfHash)
+
+	offsetInPage := int(entry.SevHashesTableGPA & 0xfff)
+	hashesPage := buildHashesPage(entry.KernelHash, entry.InitrdHash, cmdline, offsetInPage)
+
+	for _, sec := range entry.OvmfSections {
+		gpa := sec.GPA
+		switch sec.SectionType {
+		case 1: // SNP_SEC_MEM
+			ld = gctxUpdateZeroPages(ld, gpa, sec.Size)
+		case 2: // SNP_SECRETS
+			ld = gctxUpdateSecretsPage(ld, gpa)
+		case 3: // CPUID
+			ld = gctxUpdateCpuidPage(ld, gpa)
+		case 4: // SVSM_CAA
+			ld = gctxUpdateZeroPages(ld, gpa, sec.Size)
+		case 0x10: // SNP_KERNEL_HASHES
+			ld = gctxUpdateNormalPages(ld, gpa, hashesPage)
+		}
+	}
+
+	apEIP := entry.SevEsResetEIP
+	for i := 0; i < vcpus; i++ {
+		eip := uint32(bspEIP)
+		if i != 0 {
+			eip = apEIP
+		}
+		vmsa := buildVmsaPage(eip, vcpuSigEPYC, guestFeatures)
+		ld = gctxUpdateVmsaPage(ld, vmsa)
+	}
+
+	return hex.EncodeToString(ld)
+}

--- a/proxy-router/internal/attestation/sev_gctx_test.go
+++ b/proxy-router/internal/attestation/sev_gctx_test.go
@@ -1,0 +1,168 @@
+package attestation
+
+import (
+	"testing"
+)
+
+func TestParseSevFamilyID_Valid(t *testing.T) {
+	// "prod-small-sev" padded to 16 bytes with nulls
+	input := make([]byte, 16)
+	copy(input, "prod-small-sev")
+
+	result := ParseSevFamilyID(input)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.VMType != "prod" {
+		t.Fatalf("expected VMType=prod, got %s", result.VMType)
+	}
+	if result.TemplateName != "small" {
+		t.Fatalf("expected TemplateName=small, got %s", result.TemplateName)
+	}
+	if result.Vcpus != 1 {
+		t.Fatalf("expected Vcpus=1, got %d", result.Vcpus)
+	}
+}
+
+func TestParseSevFamilyID_Large(t *testing.T) {
+	input := make([]byte, 16)
+	copy(input, "dev-large-sev")
+
+	result := ParseSevFamilyID(input)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.VMType != "dev" {
+		t.Fatalf("expected VMType=dev, got %s", result.VMType)
+	}
+	if result.TemplateName != "large" {
+		t.Fatalf("expected TemplateName=large, got %s", result.TemplateName)
+	}
+	if result.Vcpus != 4 {
+		t.Fatalf("expected Vcpus=4, got %d", result.Vcpus)
+	}
+}
+
+func TestParseSevFamilyID_NoSevSuffix(t *testing.T) {
+	input := make([]byte, 16)
+	copy(input, "prod-small")
+
+	result := ParseSevFamilyID(input)
+	if result != nil {
+		t.Fatal("expected nil for missing -sev suffix")
+	}
+}
+
+func TestParseSevFamilyID_NoDash(t *testing.T) {
+	input := make([]byte, 16)
+	copy(input, "prodsmall-sev")
+
+	result := ParseSevFamilyID(input)
+	if result != nil {
+		t.Fatal("expected nil for missing dash in core")
+	}
+}
+
+func TestParseSevFamilyID_UnknownTemplate(t *testing.T) {
+	input := make([]byte, 16)
+	copy(input, "prod-huge-sev")
+
+	result := ParseSevFamilyID(input)
+	if result != nil {
+		t.Fatal("expected nil for unknown template name")
+	}
+}
+
+func TestParseSevFamilyID_AllZeros(t *testing.T) {
+	input := make([]byte, 16)
+	result := ParseSevFamilyID(input)
+	if result != nil {
+		t.Fatal("expected nil for all-zero input")
+	}
+}
+
+func TestCalcSevMeasurement_Deterministic(t *testing.T) {
+	entry := &SevArtifactEntry{
+		KernelHash: "98c41a86a1ba6a9a9d772ae0b028835091b4930f79ea509b595d2080d7df90c2",
+		InitrdHash: "5f99893492640368a4324e51377296e3ebf4989598297fdea36943da3317aa7a",
+		OvmfHash:   "c581d3eaebf2941beb1f757de97497279b953a6999921cab05f9ed5268f9c0505d741f4021b5a3995c9893851cde190e",
+		SevHashesTableGPA: 8457216,
+		SevEsResetEIP:     8433668,
+		RootfsHash: "fc0a5cc3e9e7e1f72dde8d48a12ae592327ef0e8a9e78991af27b6aea52ac47e",
+		OvmfSections: []SevOvmfSection{
+			{GPA: 8388608, Size: 36864, SectionType: 1},
+			{GPA: 8429568, Size: 12288, SectionType: 1},
+			{GPA: 8441856, Size: 4096, SectionType: 2},
+			{GPA: 8445952, Size: 4096, SectionType: 3},
+			{GPA: 8450048, Size: 4096, SectionType: 4},
+			{GPA: 8458240, Size: 61440, SectionType: 1},
+			{GPA: 8454144, Size: 4096, SectionType: 16},
+		},
+	}
+
+	cmdline := "console=ttyS0 loglevel=7 docker_compose_hash=abcd1234 rootfs_hash=" + entry.RootfsHash
+	result1 := CalcSevMeasurement(entry, 1, cmdline)
+	result2 := CalcSevMeasurement(entry, 1, cmdline)
+
+	if result1 != result2 {
+		t.Fatalf("expected deterministic results, got %s and %s", result1, result2)
+	}
+	if len(result1) != 96 { // SHA-384 = 48 bytes = 96 hex chars
+		t.Fatalf("expected 96 hex chars, got %d", len(result1))
+	}
+}
+
+func TestCalcSevMeasurement_DifferentVcpus(t *testing.T) {
+	entry := &SevArtifactEntry{
+		KernelHash: "98c41a86a1ba6a9a9d772ae0b028835091b4930f79ea509b595d2080d7df90c2",
+		InitrdHash: "5f99893492640368a4324e51377296e3ebf4989598297fdea36943da3317aa7a",
+		OvmfHash:   "c581d3eaebf2941beb1f757de97497279b953a6999921cab05f9ed5268f9c0505d741f4021b5a3995c9893851cde190e",
+		SevHashesTableGPA: 8457216,
+		SevEsResetEIP:     8433668,
+		RootfsHash: "fc0a5cc3e9e7e1f72dde8d48a12ae592327ef0e8a9e78991af27b6aea52ac47e",
+		OvmfSections: []SevOvmfSection{
+			{GPA: 8388608, Size: 36864, SectionType: 1},
+			{GPA: 8429568, Size: 12288, SectionType: 1},
+			{GPA: 8441856, Size: 4096, SectionType: 2},
+			{GPA: 8445952, Size: 4096, SectionType: 3},
+			{GPA: 8450048, Size: 4096, SectionType: 4},
+			{GPA: 8458240, Size: 61440, SectionType: 1},
+			{GPA: 8454144, Size: 4096, SectionType: 16},
+		},
+	}
+
+	cmdline := "console=ttyS0 loglevel=7 docker_compose_hash=test rootfs_hash=" + entry.RootfsHash
+	result1 := CalcSevMeasurement(entry, 1, cmdline)
+	result2 := CalcSevMeasurement(entry, 2, cmdline)
+
+	if result1 == result2 {
+		t.Fatal("expected different measurements for different vcpu counts")
+	}
+}
+
+func TestCalcSevMeasurement_DifferentCmdline(t *testing.T) {
+	entry := &SevArtifactEntry{
+		KernelHash: "98c41a86a1ba6a9a9d772ae0b028835091b4930f79ea509b595d2080d7df90c2",
+		InitrdHash: "5f99893492640368a4324e51377296e3ebf4989598297fdea36943da3317aa7a",
+		OvmfHash:   "c581d3eaebf2941beb1f757de97497279b953a6999921cab05f9ed5268f9c0505d741f4021b5a3995c9893851cde190e",
+		SevHashesTableGPA: 8457216,
+		SevEsResetEIP:     8433668,
+		RootfsHash: "fc0a5cc3e9e7e1f72dde8d48a12ae592327ef0e8a9e78991af27b6aea52ac47e",
+		OvmfSections: []SevOvmfSection{
+			{GPA: 8388608, Size: 36864, SectionType: 1},
+			{GPA: 8429568, Size: 12288, SectionType: 1},
+			{GPA: 8441856, Size: 4096, SectionType: 2},
+			{GPA: 8445952, Size: 4096, SectionType: 3},
+			{GPA: 8450048, Size: 4096, SectionType: 4},
+			{GPA: 8458240, Size: 61440, SectionType: 1},
+			{GPA: 8454144, Size: 4096, SectionType: 16},
+		},
+	}
+
+	result1 := CalcSevMeasurement(entry, 1, "console=ttyS0 loglevel=7 docker_compose_hash=aaaa rootfs_hash="+entry.RootfsHash)
+	result2 := CalcSevMeasurement(entry, 1, "console=ttyS0 loglevel=7 docker_compose_hash=bbbb rootfs_hash="+entry.RootfsHash)
+
+	if result1 == result2 {
+		t.Fatal("expected different measurements for different cmdlines")
+	}
+}

--- a/proxy-router/internal/attestation/sev_registry.go
+++ b/proxy-router/internal/attestation/sev_registry.go
@@ -1,0 +1,126 @@
+package attestation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+)
+
+const (
+	DefaultSevRegistryURL = "https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/sev.json"
+)
+
+type SevArtifactRegistry struct {
+	registryURL     string
+	refreshInterval time.Duration
+	client          *http.Client
+	log             lib.ILogger
+
+	mu          sync.RWMutex
+	entries     []SevArtifactEntry
+	lastFetched time.Time
+}
+
+func NewSevArtifactRegistry(registryURL string, refreshInterval time.Duration, log lib.ILogger) *SevArtifactRegistry {
+	if registryURL == "" {
+		registryURL = DefaultSevRegistryURL
+	}
+	if refreshInterval == 0 {
+		refreshInterval = DefaultRegistryRefreshInterval
+	}
+	return &SevArtifactRegistry{
+		registryURL:     registryURL,
+		refreshInterval: refreshInterval,
+		client:          &http.Client{Timeout: 30 * time.Second},
+		log:             log,
+	}
+}
+
+func (r *SevArtifactRegistry) Start(ctx context.Context) {
+	if err := r.fetch(ctx); err != nil {
+		r.log.Warnf("initial SEV artifact registry fetch failed: %v", err)
+	}
+
+	go func() {
+		ticker := time.NewTicker(r.refreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := r.fetch(ctx); err != nil {
+					r.log.Warnf("SEV artifact registry refresh failed, keeping stale cache: %v", err)
+				}
+			}
+		}
+	}()
+}
+
+func (r *SevArtifactRegistry) fetch(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.registryURL, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("fetch SEV registry: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("SEV registry returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
+
+	var entries []SevArtifactEntry
+	if err := json.Unmarshal(body, &entries); err != nil {
+		return fmt.Errorf("parse SEV registry JSON: %w", err)
+	}
+
+	r.mu.Lock()
+	r.entries = entries
+	r.lastFetched = time.Now()
+	r.mu.Unlock()
+
+	r.log.Infof("SEV artifact registry loaded %d entries", len(entries))
+	return nil
+}
+
+func (r *SevArtifactRegistry) FindByVMType(vmType string) []SevArtifactEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var matched []SevArtifactEntry
+	for _, e := range r.entries {
+		if e.VMType == vmType {
+			matched = append(matched, e)
+		}
+	}
+	return matched
+}
+
+func (r *SevArtifactRegistry) AllEntries() []SevArtifactEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]SevArtifactEntry, len(r.entries))
+	copy(out, r.entries)
+	return out
+}
+
+func (r *SevArtifactRegistry) IsLoaded() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return !r.lastFetched.IsZero()
+}

--- a/proxy-router/internal/attestation/sev_workload.go
+++ b/proxy-router/internal/attestation/sev_workload.go
@@ -1,0 +1,151 @@
+package attestation
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+)
+
+// VerifySevWorkload verifies that an AMD SEV-SNP attestation quote was produced
+// by a known SecretVM running the given docker-compose YAML.
+//
+// Port of verifySevWorkload from secretvm-verify/workload.ts.
+func VerifySevWorkload(registry *SevArtifactRegistry, cpuQuoteBase64 string, dockerComposeYaml string, log lib.ILogger) WorkloadResult {
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(cpuQuoteBase64))
+	if err != nil {
+		if log != nil {
+			log.Warnf("sev workload: failed to base64-decode quote: %s", err)
+		}
+		return WorkloadResult{Status: WorkloadNotAuthentic}
+	}
+
+	// Need at least 0x090 + 48 = 192 bytes for the measurement field
+	if len(raw) < 0x090+48 {
+		if log != nil {
+			log.Warnf("sev workload: quote too short (%d bytes)", len(raw))
+		}
+		return WorkloadResult{Status: WorkloadNotAuthentic}
+	}
+
+	quoteMeasurement := hex.EncodeToString(raw[0x090 : 0x090+48])
+
+	// Parse family_id (0x010..0x020) and image_id (0x020..0x030)
+	var familyIDBytes []byte
+	var imageID string
+	if len(raw) >= 0x030 {
+		familyIDBytes = raw[0x010:0x020]
+		imageID = strings.TrimRight(string(raw[0x020:0x030]), "\x00#")
+	}
+
+	composeHashArr := sha256.Sum256([]byte(dockerComposeYaml))
+	composeHash := hex.EncodeToString(composeHashArr[:])
+
+	family := ParseSevFamilyID(familyIDBytes)
+
+	if log != nil {
+		familyStr := "<nil>"
+		if family != nil {
+			familyStr = fmt.Sprintf("%s/%s/%d", family.VMType, family.TemplateName, family.Vcpus)
+		}
+		log.Infof("sev workload: measurement=%s..., family=%s, imageId=%s, composeHash=%s...",
+			quoteMeasurement[:16], familyStr, imageID, composeHash[:16])
+	}
+
+	buildCmdline := func(entry *SevArtifactEntry) string {
+		prefix := "console=ttyS0 loglevel=7"
+		if entry.CmdlineExtra != "" {
+			prefix += " " + entry.CmdlineExtra
+		}
+		return fmt.Sprintf("%s docker_compose_hash=%s rootfs_hash=%s", prefix, composeHash, entry.RootfsHash)
+	}
+
+	tryEntry := func(entry *SevArtifactEntry, vcpus int) bool {
+		cmdline := buildCmdline(entry)
+		computed := CalcSevMeasurement(entry, vcpus, cmdline)
+		return computed == quoteMeasurement
+	}
+
+	if family == nil {
+		// family_id not set -- brute-force all registry entries and vcpu counts
+		if log != nil {
+			log.Infof("sev workload: family_id not set, brute-forcing all entries x vcpu counts")
+		}
+		allEntries := registry.AllEntries()
+		for _, entry := range allEntries {
+			for templateName, vcpus := range VcpuMap {
+				if tryEntry(&entry, vcpus) {
+					return WorkloadResult{
+						Status:       WorkloadAuthentic,
+						TemplateName: templateName,
+						VMType:       entry.VMType,
+						ArtifactsVer: entry.ArtifactsVer,
+						Env:          entry.VMType,
+					}
+				}
+			}
+		}
+		return WorkloadResult{Status: WorkloadNotAuthentic}
+	}
+
+	// family_id is valid -- filter by vmType
+	candidates := registry.FindByVMType(family.VMType)
+	if log != nil {
+		log.Infof("sev workload: found %d candidates for vm_type=%s", len(candidates), family.VMType)
+	}
+
+	// Try version-specific entries first
+	var versionEntries []SevArtifactEntry
+	if imageID != "" {
+		for _, e := range candidates {
+			if e.ArtifactsVer == imageID {
+				versionEntries = append(versionEntries, e)
+			}
+		}
+	}
+
+	for i := range versionEntries {
+		if tryEntry(&versionEntries[i], family.Vcpus) {
+			return WorkloadResult{
+				Status:       WorkloadAuthentic,
+				TemplateName: family.TemplateName,
+				VMType:       family.TemplateName,
+				ArtifactsVer: versionEntries[i].ArtifactsVer,
+				Env:          family.VMType,
+			}
+		}
+	}
+
+	// Fallback: try other entries for this vmType
+	for i := range candidates {
+		if imageID != "" && candidates[i].ArtifactsVer == imageID {
+			continue // already tried above
+		}
+		if tryEntry(&candidates[i], family.Vcpus) {
+			return WorkloadResult{
+				Status:       WorkloadAuthentic,
+				TemplateName: family.TemplateName,
+				VMType:       family.TemplateName,
+				ArtifactsVer: candidates[i].ArtifactsVer,
+				Env:          family.VMType,
+			}
+		}
+	}
+
+	// No compose match. If version entries exist, the VM is authentic but
+	// the provided compose doesn't match the measurement.
+	if len(versionEntries) > 0 {
+		return WorkloadResult{
+			Status:       WorkloadAuthenticMismatch,
+			TemplateName: family.TemplateName,
+			VMType:       family.TemplateName,
+			ArtifactsVer: imageID,
+			Env:          family.VMType,
+		}
+	}
+
+	return WorkloadResult{Status: WorkloadNotAuthentic}
+}

--- a/proxy-router/internal/attestation/verifier.go
+++ b/proxy-router/internal/attestation/verifier.go
@@ -44,10 +44,17 @@ func (c *collateralField) UnmarshalJSON(data []byte) error {
 }
 
 const (
-	AttestationPort  = "29343"
-	DefaultPortalURL = "https://secretai.scrtlabs.com/api/quote-parse"
-	VerifyTimeout    = 30 * time.Second
+	AttestationPort     = "29343"
+	DefaultPortalURL    = "https://secretai.scrtlabs.com/api/quote-parse"
+	DefaultPortalURLSEV = "https://secretai.scrtlabs.com/api/quote-parse-sev"
+	VerifyTimeout       = 30 * time.Second
 )
+
+// deriveSEVPortalURL returns the SEV-specific portal URL by appending "-sev"
+// to the base portal URL path (e.g. ".../quote-parse" -> ".../quote-parse-sev").
+func deriveSEVPortalURL(portalURL string) string {
+	return strings.TrimSuffix(portalURL, "/") + "-sev"
+}
 
 // ParseQuoteRequest is the POST body for the SecretAI Portal quote-parse API.
 type ParseQuoteRequest struct {
@@ -188,14 +195,14 @@ func (v *Verifier) VerifyProvider(ctx context.Context, providerEndpoint string, 
 
 	v.log.Infof("verifying TEE attestation for provider %s (version %s)", providerEndpoint, version)
 
-	hexQuote, tlsFingerprint, err := v.loadAttestationQuote(ctx, attestationURL)
+	cpuQuote, tlsFingerprint, err := v.loadAttestationQuote(ctx, attestationURL)
 	if err != nil {
 		return fmt.Errorf("failed to load attestation quote from %s: %w", attestationURL, err)
 	}
 
 	v.log.Infof("captured TLS cert fingerprint: %s", tlsFingerprint)
 
-	result, err := v.verifyQuote(ctx, hexQuote)
+	result, err := v.verifyQuote(ctx, cpuQuote)
 	if err != nil {
 		return fmt.Errorf("attestation quote verification failed: %w", err)
 	}
@@ -228,7 +235,7 @@ func (v *Verifier) VerifyProvider(ctx context.Context, providerEndpoint string, 
 
 	v.log.Infof("all TEE register values match golden values for version %s", version)
 
-	quoteHash := fmt.Sprintf("%x", sha256.Sum256([]byte(hexQuote)))
+	quoteHash := fmt.Sprintf("%x", sha256.Sum256([]byte(cpuQuote)))
 	v.mu.Lock()
 	v.quoteCache[attestationURL] = &verifiedQuoteEntry{
 		quoteHash:      quoteHash,
@@ -256,7 +263,7 @@ func VerifyTLSBinding(tlsFingerprint string, reportData string) error {
 		return fmt.Errorf("no report_data in attestation quote")
 	}
 
-	reportData = strings.ToLower(strings.TrimSpace(reportData))
+	reportData = strings.ToLower(strings.ReplaceAll(strings.TrimSpace(reportData), " ", ""))
 	tlsFingerprint = strings.ToLower(strings.TrimSpace(tlsFingerprint))
 
 	if len(reportData) < len(tlsFingerprint) {
@@ -309,14 +316,14 @@ func (v *Verifier) VerifyProviderQuick(ctx context.Context, providerEndpoint str
 
 	v.log.Infof("quick attestation: cache hit for %s, fetching live quote", attestationURL)
 
-	hexQuote, tlsFingerprint, err := v.loadAttestationQuote(ctx, attestationURL)
+	cpuQuote, tlsFingerprint, err := v.loadAttestationQuote(ctx, attestationURL)
 	if err != nil {
 		return fmt.Errorf("quick attestation check failed: %w", err)
 	}
 
 	v.log.Infof("quick attestation: fetched live quote from %s, TLS fingerprint: %s", attestationURL, tlsFingerprint)
 
-	currentHash := fmt.Sprintf("%x", sha256.Sum256([]byte(hexQuote)))
+	currentHash := fmt.Sprintf("%x", sha256.Sum256([]byte(cpuQuote)))
 
 	if currentHash != cached.quoteHash {
 		v.log.Warnf("quick attestation: quote hash MISMATCH for %s (cached=%s, live=%s)", providerEndpoint, cached.quoteHash, currentHash)
@@ -411,9 +418,9 @@ func CompareRegisters(result *AttestationResult, golden *GoldenValues, log lib.I
 	return nil
 }
 
-// LoadAttestationQuote fetches a raw hex-encoded attestation quote from the
-// given URL path and returns the SHA-256 fingerprint of the peer's TLS certificate.
-func LoadAttestationQuote(ctx context.Context, client *http.Client, quoteURL string) (hexQuote string, tlsFingerprint string, err error) {
+// LoadAttestationQuote fetches a raw attestation quote (hex for TDX, base64 for SEV)
+// from the given URL path and returns the SHA-256 fingerprint of the peer's TLS certificate.
+func LoadAttestationQuote(ctx context.Context, client *http.Client, quoteURL string) (quote string, tlsFingerprint string, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, quoteURL, nil)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create request: %w", err)
@@ -439,20 +446,20 @@ func LoadAttestationQuote(ctx context.Context, client *http.Client, quoteURL str
 		return "", "", fmt.Errorf("failed to read attestation quote: %w", err)
 	}
 
-	hexQuote = strings.TrimSpace(string(body))
-	if hexQuote == "" {
+	quote = strings.TrimSpace(string(body))
+	if quote == "" {
 		return "", "", fmt.Errorf("empty attestation quote")
 	}
 
-	return hexQuote, tlsFingerprint, nil
+	return quote, tlsFingerprint, nil
 }
 
 // loadAttestationQuote is the instance method that delegates to the package-level function.
-func (v *Verifier) loadAttestationQuote(ctx context.Context, attestationBaseURL string) (hexQuote string, tlsFingerprint string, err error) {
+func (v *Verifier) loadAttestationQuote(ctx context.Context, attestationBaseURL string) (quote string, tlsFingerprint string, err error) {
 	cpuURL := attestationBaseURL + "/cpu"
 	v.log.Infof("fetching attestation quote from %s", cpuURL)
 
-	hexQuote, tlsFingerprint, err = LoadAttestationQuote(ctx, v.attestationClient, cpuURL)
+	quote, tlsFingerprint, err = LoadAttestationQuote(ctx, v.attestationClient, cpuURL)
 	if err != nil {
 		return "", "", err
 	}
@@ -461,20 +468,26 @@ func (v *Verifier) loadAttestationQuote(ctx context.Context, attestationBaseURL 
 		v.log.Warnf("no TLS peer certificate received from %s", cpuURL)
 	}
 
-	v.log.Infof("received attestation quote from %s (%d bytes)", cpuURL, len(hexQuote))
-	return hexQuote, tlsFingerprint, nil
+	v.log.Infof("received attestation quote from %s (%d bytes)", cpuURL, len(quote))
+	return quote, tlsFingerprint, nil
 }
 
-// VerifyQuote sends the hex attestation quote to the SecretAI Portal parse-quote API
-// for cryptographic verification and field extraction.
-func VerifyQuote(ctx context.Context, portalClient *http.Client, portalURL string, hexQuote string) (*AttestationResult, error) {
-	reqBody := ParseQuoteRequest{Quote: hexQuote}
+// VerifyQuote sends the attestation quote to the SecretAI Portal for cryptographic
+// verification and field extraction. TDX (hex-encoded) quotes go to portalURL;
+// SEV (base64-encoded) quotes are routed to the derived SEV endpoint automatically.
+func VerifyQuote(ctx context.Context, portalClient *http.Client, portalURL string, quote string) (*AttestationResult, error) {
+	targetURL := portalURL
+	if !IsTdxQuote(quote) {
+		targetURL = deriveSEVPortalURL(portalURL)
+	}
+
+	reqBody := ParseQuoteRequest{Quote: quote}
 	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, portalURL, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -551,9 +564,13 @@ func VerifyQuote(ctx context.Context, portalClient *http.Client, portalURL strin
 }
 
 // verifyQuote is the instance method that delegates to the package-level function.
-func (v *Verifier) verifyQuote(ctx context.Context, hexQuote string) (*AttestationResult, error) {
-	v.log.Infof("sending quote to SecretAI portal for cryptographic verification (%s)", v.portalURL)
-	result, err := VerifyQuote(ctx, v.portalClient, v.portalURL, hexQuote)
+func (v *Verifier) verifyQuote(ctx context.Context, quote string) (*AttestationResult, error) {
+	portalTarget := v.portalURL
+	if !IsTdxQuote(quote) {
+		portalTarget = deriveSEVPortalURL(v.portalURL)
+	}
+	v.log.Infof("sending quote to SecretAI portal for cryptographic verification (%s)", portalTarget)
+	result, err := VerifyQuote(ctx, v.portalClient, v.portalURL, quote)
 	if err != nil {
 		return nil, err
 	}

--- a/proxy-router/internal/attestation/workload_rytn_test.go
+++ b/proxy-router/internal/attestation/workload_rytn_test.go
@@ -109,7 +109,7 @@ func TestIntegration_RytnLive(t *testing.T) {
 	}
 
 	// 6. Run full VerifyWorkload
-	result := VerifyWorkload(registry, cpuQuoteHex, string(composeBody), &lib.LoggerMock{})
+	result := VerifyWorkload(registry, nil, cpuQuoteHex, string(composeBody), &lib.LoggerMock{})
 	t.Logf("VerifyWorkload result: status=%s template=%s ver=%s env=%s", result.Status, result.TemplateName, result.ArtifactsVer, result.Env)
 
 	if result.Status != WorkloadAuthentic {
@@ -121,7 +121,7 @@ func TestIntegration_RytnLive(t *testing.T) {
 		if localErr == nil {
 			localHash := sha256.Sum256(localCompose)
 			t.Logf("Local rytn-docker-compose.yaml: %d bytes, sha256=%s", len(localCompose), hex.EncodeToString(localHash[:]))
-			localResult := VerifyWorkload(registry, cpuQuoteHex, string(localCompose), &lib.LoggerMock{})
+			localResult := VerifyWorkload(registry, nil, cpuQuoteHex, string(localCompose), &lib.LoggerMock{})
 			t.Logf("VerifyWorkload with local file: status=%s", localResult.Status)
 
 			if len(composeBody) != len(localCompose) {
@@ -182,7 +182,7 @@ func TestIntegration_RytnLocalFiles(t *testing.T) {
 		t.Logf("    calculated=%s quote=%s match=%v", calculated, fields.RTMR3, calculated == fields.RTMR3)
 	}
 
-	result := VerifyWorkload(registry, cpuQuoteHex, string(composeBytes), &lib.LoggerMock{})
+	result := VerifyWorkload(registry, nil, cpuQuoteHex, string(composeBytes), &lib.LoggerMock{})
 	t.Logf("Result: status=%s template=%s ver=%s env=%s", result.Status, result.TemplateName, result.ArtifactsVer, result.Env)
 
 	if result.Status != WorkloadAuthentic {
@@ -209,6 +209,7 @@ func TestIntegration_RytnBackendVerifier(t *testing.T) {
 		DefaultPortalURL,
 		&NoopGoldenSource{},
 		registry,
+		nil,
 		&lib.LoggerMock{},
 	)
 

--- a/proxy-router/internal/attestation/workload_verifier.go
+++ b/proxy-router/internal/attestation/workload_verifier.go
@@ -13,6 +13,7 @@ const (
 	WorkloadAuthentic         WorkloadStatus = "authentic_match"
 	WorkloadAuthenticMismatch WorkloadStatus = "authentic_mismatch"
 	WorkloadNotAuthentic      WorkloadStatus = "not_authentic"
+	WorkloadSkipped           WorkloadStatus = "skipped"
 )
 
 type WorkloadResult struct {
@@ -75,9 +76,15 @@ func VerifyTdxWorkload(registry *ArtifactRegistry, cpuQuoteHex string, dockerCom
 	}
 }
 
-func VerifyWorkload(registry *ArtifactRegistry, cpuQuoteData string, dockerComposeYaml string, log lib.ILogger) WorkloadResult {
+func VerifyWorkload(registry *ArtifactRegistry, sevRegistry *SevArtifactRegistry, cpuQuoteData string, dockerComposeYaml string, log lib.ILogger) WorkloadResult {
 	if IsTdxQuote(cpuQuoteData) {
 		return VerifyTdxWorkload(registry, cpuQuoteData, dockerComposeYaml, log)
 	}
-	return WorkloadResult{Status: WorkloadNotAuthentic}
+	if sevRegistry != nil && sevRegistry.IsLoaded() {
+		return VerifySevWorkload(sevRegistry, cpuQuoteData, dockerComposeYaml, log)
+	}
+	if log != nil {
+		log.Infof("workload: SEV quote detected but SEV registry not available, skipping")
+	}
+	return WorkloadResult{Status: WorkloadSkipped}
 }

--- a/proxy-router/internal/attestation/workload_verifier_test.go
+++ b/proxy-router/internal/attestation/workload_verifier_test.go
@@ -158,7 +158,7 @@ func TestVerifyWorkload_TdxQuote(t *testing.T) {
 	quoteHex := readTestFixture(t, "tdx_cpu_docker_check_quote.txt")
 	composeYaml := readTestFixture(t, "tdx_cpu_docker_check_compose.yaml")
 
-	result := VerifyWorkload(reg, quoteHex, composeYaml, nil)
+	result := VerifyWorkload(reg, nil, quoteHex, composeYaml, nil)
 	if result.Status != WorkloadAuthentic {
 		t.Fatalf("status = %s, want %s", result.Status, WorkloadAuthentic)
 	}
@@ -166,8 +166,8 @@ func TestVerifyWorkload_TdxQuote(t *testing.T) {
 
 func TestVerifyWorkload_NonTdxQuote(t *testing.T) {
 	reg := testRegistry(t)
-	result := VerifyWorkload(reg, "SGVsbG8gV29ybGQ=", "anything", nil)
-	if result.Status != WorkloadNotAuthentic {
-		t.Fatalf("status = %s, want %s", result.Status, WorkloadNotAuthentic)
+	result := VerifyWorkload(reg, nil, "SGVsbG8gV29ybGQ=", "anything", nil)
+	if result.Status != WorkloadSkipped {
+		t.Fatalf("status = %s, want %s", result.Status, WorkloadSkipped)
 	}
 }

--- a/proxy-router/internal/config/config.go
+++ b/proxy-router/internal/config/config.go
@@ -88,6 +88,7 @@ type Config struct {
 		PortalURL                  string        `env:"TEE_PORTAL_URL"  flag:"tee-portal-url"  validate:"omitempty,url" desc:"SecretAI Portal API URL for TEE attestation quote parsing"`
 		ImageRepo                  string        `env:"TEE_IMAGE_REPO"  flag:"tee-image-repo"  validate:"omitempty"     desc:"GHCR image repo for cosign attestation verification (e.g. ghcr.io/morpheusais/morpheus-lumerin-node-tee)"`
 		ArtifactRegistryURL             string        `env:"ARTIFACT_REGISTRY_URL" flag:"artifact-registry-url" validate:"omitempty,url" desc:"URL for SecretVM TDX artifact registry CSV"`
+		SevArtifactRegistryURL          string        `env:"SEV_ARTIFACT_REGISTRY_URL" flag:"sev-artifact-registry-url" validate:"omitempty,url" desc:"URL for SecretVM SEV-SNP artifact registry JSON"`
 		ArtifactRegistryRefreshInterval time.Duration `env:"ARTIFACT_REGISTRY_REFRESH_INTERVAL" flag:"artifact-registry-refresh-interval" validate:"omitempty" desc:"how often to refresh the artifact registry"`
 	}
 	Web struct {


### PR DESCRIPTION
Route SEV quotes to the dedicated portal endpoint, normalize space-separated report_data from the SEV portal, and implement full SEV-SNP workload verification (GCTX launch digest computation against the SecretVM SEV artifact registry).