### PR TITLE
promote: dev -> test (TEE pipeline v0.0.27-alpha.1 + SEV-SNP per-template + baked LOG_LEVEL_*)

### DIFF
--- a/.ai-docs/TEE_Attestation_Architecture.md
+++ b/.ai-docs/TEE_Attestation_Architecture.md
@@ -1,16 +1,17 @@
 # TEE Attestation Architecture — Verifiable Provider Compute
 
-**Status:** v2.0 — Full two-hop trust chain shipped. Phase 1 (consumer → P-Node) in v6.0.0+; Phase 2 (P-Node → backend LLM) in v7.0.0+.
-**Last updated:** 2026-04-22
+**Status:** v2.1 — Full two-hop trust chain shipped, AMD SEV-SNP added. Phase 1 (consumer → P-Node) in v6.0.0+; Phase 2 (P-Node → backend LLM) in v7.0.0+; SEV-SNP support in v7.x (PR #718, #720).
+**Last updated:** 2026-04-29
 
-> **Shipping summary (as of v7.0.0):**
+> **Shipping summary (as of v7.x with SEV-SNP):**
 > - **Phase 1a (CI/CD supply-chain hardening)** — DONE (v6.0.0)
-> - **Phase 1b (RTMR3 computation + automated deployment + post-deploy attestation)** — DONE (v6.0.0)
-> - **Phase 1c (proxy-router code: consumer verifies P-Node)** — DONE (v6.0.0, refined through v6.2.x)
-> - **Phase 2a (P-Node verifies backend LLM: CPU quote, TLS pinning, RTMR3 replay, CPU-GPU binding, NRAS)** — DONE (v7.0.0, PR #699 and follow-ups #700, #703/#704, #705, #708/#709)
+> - **Phase 1b (RTMR3 computation + automated deployment + post-deploy attestation)** — DONE (v6.0.0); **SecretVM release pin updated to `v0.0.27-alpha.1`** (the only release the SecretVM portal currently accepts for *new* VM provisioning, 2026-04-29)
+> - **Phase 1c (proxy-router code: consumer verifies P-Node)** — DONE (v6.0.0, refined through v6.2.x); SEV-SNP path verifies via the dedicated `quote-parse-sev` portal endpoint and a per-template golden table (PR #718)
+> - **Phase 2a (P-Node verifies backend LLM: CPU quote, TLS pinning, RTMR3 replay for TDX *and* GCTX launch-digest replay for SEV, CPU-GPU binding, NRAS)** — DONE (v7.0.0; SEV branch added by PR #718, VMType fix in PR #720)
+> - **CI/CD SEV measurement signing** — DONE (this PR — SEV launch digest computed for all 5 portal templates and attached to the cosign-signed manifest, alongside baked log-level fields in `baked_env`)
 > - **Phase 2b (verifiable per-message signing, local quote verification, co-located CPU+GPU TDX VM)** — still future work
 >
-> The `tee` on-chain model tag is the single switch that turns on **both** hops: consumer-side P-Node verification (Phase 1) and P-Node-side backend verification (Phase 2). A v6.0.0+ consumer paired with a v7.0.0+ provider gets the full chain transparently with no client-side upgrade.
+> The `tee` on-chain model tag is the single switch that turns on **both** hops: consumer-side P-Node verification (Phase 1) and P-Node-side backend verification (Phase 2). A v6.0.0+ consumer paired with a v7.x+ provider gets the full chain transparently with no client-side upgrade. The new SEV branch is platform-transparent — the consumer auto-routes the quote to the TDX or SEV portal endpoint based on whether the bytes parse as a TDX hex quote or a SEV base64 quote.
 
 ---
 
@@ -35,8 +36,9 @@ A consumer node should be able to **cryptographically verify**, before sending a
 - SBOM generation and attachment (syft) — **DONE**
 - Signed TEE attestation manifest (Option 5B — stored in GHCR as OCI artifact) — **DONE**
 - Intel TDX RTMR3 computed in CI and published in the signed manifest — **DONE**
-- Auto-deploy to SecretVM test instance + post-deploy RTMR3 verification gate — **DONE**
-- AMD SEV-SNP measurement path — still TODO (blocked on upstream tooling)
+- Auto-deploy to SecretVM test instance + post-deploy RTMR3 verification gate — **DONE** (TDX-only; SEV auto-deploy is a follow-up — see §6.5)
+- AMD SEV-SNP measurement path — **DONE** (this PR; pre-computed for all 5 portal templates: small/medium/large/2xlarge/4xlarge — see §6.3)
+- Baked log-level pin in attestation manifest (`baked_env.LOG_LEVEL_*`) so consumers can verify privacy-sensitive log levels are not at debug — **DONE** (this PR)
 
 **Proxy-router code (consumer verifies P-Node):**
 - `IsTeeModel()` helper for on-chain tag detection — **DONE** (`blockchainapi/model_tags.go`)
@@ -67,8 +69,9 @@ A consumer node should be able to **cryptographically verify**, before sending a
 
 - On-chain oracle / DAO governance for golden-measurement updates (cosign keyless via GHA OIDC remains the signer)
 - Verifiable per-message signing using a TEE-bound key (§7.6) — slipped to Phase 2b
-- Local quote verification in Go (today we still call SCRT Labs `quote-parse`)
+- Local quote verification in Go (today we still call SCRT Labs `quote-parse` / `quote-parse-sev`)
 - Co-located proxy-router + LLM in a single TDX VM (would collapse both hops into one RTMR3)
+- Auto-deploy + RTMR3-style verification for an SEV test VM (TDX-only today; needs SEV-flavoured offsets and a separate `SECRETVM_TEST_SEV_VM_UUID`)
 - Rating system integration
 - CVE scanning gate
 
@@ -78,7 +81,7 @@ A consumer node should be able to **cryptographically verify**, before sending a
 |---|---|---|
 | 1 | Oracle governance | **Automated by CI/CD** — cosign keyless signing via GitHub Actions OIDC. No multi-sig/DAO for now. |
 | 2 | SCRT Labs coupling | **Yes, couple** — use their quote-parse API and `reproduce-mr` tool. They control the VM layer; we need their artifacts. See §3. |
-| 3 | AMD SEV support | **Both platforms from day one** if feasible; if `reproduce-mr` only handles TDX, compute what we can and extend for SEV in a fast follow. |
+| 3 | AMD SEV support | **Shipped (PR #718, #720).** Runtime path verifies SEV-SNP quotes via a dedicated portal endpoint (`quote-parse-sev`) and replays the launch digest in-process via the GCTX page-update chain (`sev_gctx.go::CalcSevMeasurement`) using the SCRT Labs SEV artifact registry. Pipeline pre-computes the launch digest for every SecretVM portal template (small/medium/large/2xlarge/4xlarge) and stores them in `measurements.amd_sev_snp.per_template` of the cosign-signed manifest — the per-template scheme is needed because the SEV measurement includes per-vCPU VMSA pages (TDX RTMR3 is template-independent). |
 | 4 | Model backend trust | **Closed in Phase 2 (v7.0.0).** Instead of co-locating, the P-Node actively verifies the backend LLM over the network: CPU quote + TLS pinning + RTMR3 replay of the backend's `docker-compose.yaml` + CPU-GPU nonce binding + NVIDIA NRAS. See §7.7. Co-location (single TDX VM for proxy-router + LLM) remains a future simplification that would collapse both hops into one measurement chain. |
 | 5 | RTMR computation in CI/CD | **Attempt to integrate** `reproduce-mr` using SCRT Labs release artifacts from GitHub. If not available in CI, publish all inputs so it can be run independently. |
 | 6 | Attestation freshness | **Version-based, not clock-based.** Support current version and N-2 prior versions. When a new version publishes, the oldest attestation manifest becomes stale. This is a release-cadence policy. |
@@ -95,11 +98,14 @@ We intentionally couple to SCRT Labs' infrastructure because they control the TE
 
 | Asset | Where | Purpose |
 |---|---|---|
-| **Quote parse API** | `POST https://pccs.scrtlabs.com/dcap-tools/quote-parse` | Parse Intel TDX / AMD SEV quotes into human-readable fields. Used by consumers for verification. |
+| **Quote parse API (TDX)** | `POST https://secretai.scrtlabs.com/api/quote-parse` | Parse Intel TDX quotes (hex) into human-readable fields. Default `TEE_PORTAL_URL`. |
+| **Quote parse API (SEV)** | `POST https://secretai.scrtlabs.com/api/quote-parse-sev` | Parse AMD SEV-SNP quotes (base64). Auto-derived from the TDX URL by `attestation/verifier.go::deriveSEVPortalURL` when the quote is detected as non-TDX. |
 | **Attestation portal** | `https://secretai.scrtlabs.com/attestation` | Web-based quick verification (paste compose + quote). Useful for manual spot-checks. |
-| **`reproduce-mr` tool** | [github.com/scrtlabs/reproduce-mr](https://github.com/scrtlabs/reproduce-mr) | Compute expected RTMR values (Intel TDX) from VM artifacts + docker-compose. Run in CI/CD. |
-| **`sev-snp-measure` tool** | [github.com/virtee/sev-snp-measure](https://github.com/virtee/sev-snp-measure) | Compute expected AMD SEV measurement. Run in CI/CD. |
-| **SecretVM build artifacts** | [github.com/scrtlabs/secret-vm-build/releases](https://github.com/scrtlabs/secret-vm-build/releases) | Firmware (ovmf.fd), kernel (bzImage), initramfs, rootfs — needed by `reproduce-mr`. |
+| **`reproduce-mr` tool** | [github.com/scrtlabs/reproduce-mr](https://github.com/scrtlabs/reproduce-mr) | Compute expected RTMR values (Intel TDX) from VM artifacts + docker-compose. CI uses our standalone Python port (`compute-rtmr3.py`) for the RTMR3-only subset. |
+| **SecretVM SEV verifier** | [github.com/scrtlabs/secretvm-verify](https://github.com/scrtlabs/secretvm-verify) | TypeScript reference verifier; the Go port lives at `proxy-router/internal/attestation/sev_*.go` (PR #718). The pipeline ports the GCTX algorithm to Python in `compute-sev-measurement.go`+`compute-sev-measurement.py` (kept in lockstep with the runtime Go via `sev_python_parity_test.go`). |
+| **SecretVM SEV artifact registry** | `https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/sev.json` | Per-release JSON listing kernel/initrd/ovmf hashes + OVMF section table for SEV measurement compute. The pipeline pulls the entry whose `(vm_type, artifacts_ver)` matches our `secretvm.env`. |
+| **SecretVM TDX artifact registry** | `https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/tdx.csv` | Per-release CSV used by the runtime BackendVerifier to look up MRTD + RTMR0-2 (which we don't recompute). |
+| **SecretVM build artifacts** | [github.com/scrtlabs/secret-vm-build/releases](https://github.com/scrtlabs/secret-vm-build/releases) | Firmware (ovmf.fd), kernel (bzImage), initramfs, rootfs — needed by `reproduce-mr` and SEV measurement compute. |
 | **Host attestation service** | `https://<vm-domain>:29343/cpu.html` | Returns the live attestation quote from a running SecretVM instance. Queried directly by the consumer — served by the TEE host, outside the application container. |
 | **Verifiable signing service** | `http://172.17.0.1:49153/sign` (internal only) | Signs messages with a TEE-bound key whose public key is embedded in attestation `reportdata`. Phase 2 feature. |
 | **SecretVM CLI** | `npm install --global secretvm-cli` / [CLI docs](https://docs.scrt.network/secret-network-documentation/secretvm-confidential-virtual-machines/secretvm-cli) | CLI tool for provisioning, managing, and monitoring SecretVM instances. Alternative to the web portal. |
@@ -154,7 +160,19 @@ The CLI is useful for automation and scripting — could be integrated into depl
 
 ### AMD SEV-SNP Difference
 
-AMD SEV-SNP produces a **single cumulative `measurement`** hash over the entire initial guest state. Both platforms are x86_64 — the same Docker image works on both, but the measurement format and computation tool differ.
+AMD SEV-SNP produces a **single cumulative `measurement`** hash (SHA-384) over the entire initial guest state — OVMF firmware, the SEV kernel-hashes table (which itself binds kernel + initrd + cmdline), and one VMSA page per vCPU. Both platforms are x86_64 — the same Docker image works on both, but the measurement format and computation tool differ.
+
+**TDX vs SEV measurement asymmetry that matters for the manifest:**
+
+| Aspect | Intel TDX | AMD SEV-SNP |
+|---|---|---|
+| Software-controlled register | RTMR3 only (RTMR0-2 + MRTD owned by SCRT Labs) | The single `measurement` field |
+| Inputs we control | `sha256(compose) + sha256(rootfs)` | Same compose + rootfs hashes appear inside the kernel cmdline (`docker_compose_hash=… rootfs_hash=…`), which is hashed into the SEV kernel-hashes table |
+| Template (vCPU count) sensitivity | **No** — RTMR3 is identical for small/medium/large | **Yes** — VMSA pages depend on vCPU count, so each portal size produces a different launch digest |
+| What we publish in the manifest | one `intel_tdx.rtmr3` value | a `amd_sev_snp.per_template` map: `{small, medium, large, 2xlarge, 4xlarge}` plus the inputs (kernel/initrd/ovmf/rootfs hashes, exact cmdline, registry URL+sha256) |
+| What the consumer compares against the live quote | RTMR3 byte-for-byte | the entry whose template matches the quote's `family_id` (encoded as `<vmType>-<template>-sev`); helper `attestation.GoldenValues.MatchSEVMeasurement` does this lookup |
+
+The runtime BackendVerifier (Phase 2) does NOT need the manifest to verify the backend's workload — it brute-forces the public SEV registry just like for TDX. The per-template manifest values exist for **Phase 1** (the consumer's pre-session check), where the consumer wants a CI/CD-signed golden to compare the freshly-attested provider against.
 
 ---
 
@@ -340,11 +358,11 @@ This is a **release cadence** concern, not a clock-based TTL. A version doesn't 
    - Can be run locally by providers/consumers for independent verification
 
 2. **SecretVM artifact config:** `.github/tee/secretvm.env`
-   - Pins SecretVM release version (`v0.0.25`) and rootfs variant (`rootfs-prod-tdx`)
-   - Pins rootfs URL and expected SHA-256 hash
-   - All pipeline references to rootfs filenames are derived from `SECRETVM_ROOTFS_VARIANT` — no hardcoded filenames in `build.yml`
-   - Separate entries for TDX / SEV / GPU variants (SEV/GPU commented out for now)
-   - **Important:** Always use the `prod` rootfs variant — SecretVM runs "environment prod" even for developer portal deployments
+   - Pins SecretVM release version (currently **`v0.0.27-alpha.1`** — the only release the SecretVM portal accepts for *new* VM provisioning as of 2026-04-29) and rootfs variant base (`rootfs-prod`)
+   - Pins TDX **and** SEV rootfs URLs + their expected SHA-256 hashes
+   - Pins the SEV artifact registry URL (`SECRETVM_SEV_REGISTRY_URL`) and the registry vm_type (`SECRETVM_SEV_REGISTRY_VM_TYPE=prod`) — used by `compute-sev-measurement.py` to find the right entry
+   - All pipeline references to rootfs filenames are derived from `SECRETVM_ROOTFS_VARIANT` (no hardcoded filenames in `build.yml`); the platform suffix (`-tdx` / `-sev`) is appended at use site
+   - **Important:** Always use the `prod` rootfs variant — SecretVM runs "environment prod" even for developer portal deployments. Using `dev` produces a different rootfs hash → wrong measurement → verification fails.
 
 3. **Compose generation with immutable digest reference:**
    - The repo's `docker-compose.tee.yml` is a **template** (tag-based, for reference)
@@ -356,20 +374,23 @@ This is a **release cadence** concern, not a clock-based TTL. A version doesn't 
    ```
    Load network config (main.env or test.env based on branch)
      → Build TEE image with network-specific build args → capture digest → sign image
-     → load secretvm.env → download rootfs (cached)
+     → load secretvm.env → download TDX rootfs + SEV rootfs (both cached, both SHA-verified)
      → generate compose with @sha256:DIGEST
-     → compute RTMR3 from compose + rootfs
-     → generate attestation manifest (with RTMR3 + network-specific baked_env)
+     → compute RTMR3 from compose + TDX rootfs (compute-rtmr3.py)
+     → fetch SecretVM SEV artifact registry → compute SEV launch digest for all 5 templates (compute-sev-measurement.py)
+     → extract baked LOG_LEVEL_* fields from Dockerfile.tee (privacy gate: hard-fails if LOG_LEVEL_APP=debug)
+     → generate attestation manifest (with TDX RTMR3 + SEV per-template + baked_env including baked log levels)
      → sign and attach manifest → upload deployed compose
    ```
 
-5. **Enhanced attestation manifest structure:**
+5. **Enhanced attestation manifest structure (current schema, v0.0.27-alpha.1 era):**
    ```json
    {
      "tee_image": "ghcr.io/.../morpheus-lumerin-node-tee@sha256:DIGEST",
      "tee_image_tag": "ghcr.io/.../morpheus-lumerin-node-tee:vX.Y.Z-branch",
      "compose_sha256": "sha256:...",
      "compose_image_reference": "ghcr.io/.../morpheus-lumerin-node-tee@sha256:DIGEST",
+     "tee_platforms": ["intel-tdx", "amd-sev-snp"],
      "baked_env": {
        "network": "mainnet | testnet",
        "DIAMOND_CONTRACT_ADDRESS": "...",
@@ -377,18 +398,49 @@ This is a **release cadence** concern, not a clock-based TTL. A version doesn't 
        "BLOCKSCOUT_API_URL": "...",
        "ETH_NODE_CHAIN_ID": "8453 | 84532",
        "PROXY_STORE_CHAT_CONTEXT": "false",
-       "ENVIRONMENT": "production"
+       "ENVIRONMENT": "production",
+       "LOG_COLOR": "false",
+       "LOG_JSON": "true",
+       "LOG_IS_PROD": "true",
+       "LOG_LEVEL_APP": "info",
+       "LOG_LEVEL_TCP": "warn",
+       "LOG_LEVEL_ETH_RPC": "warn",
+       "LOG_LEVEL_STORAGE": "warn"
      },
      "measurements": {
        "intel_tdx": {
          "rtmr3": "96-char-hex-value",
-         "secretvm_release": "v0.0.25",
-         "rootfs_variant": "rootfs-prod-tdx",
-         "rootfs_sha256": "<sha256-of-rootfs-prod-v0.0.25-tdx.iso>"
+         "secretvm_release": "v0.0.27-alpha.1",
+         "rootfs_variant": "rootfs-prod",
+         "rootfs_sha256": "<sha256-of-rootfs-prod-v0.0.27-alpha.1-tdx.iso>",
+         "note": "RTMR3 measures (compose + rootfs); template-independent. RTMR0-2 verified at runtime via SecretVM TDX artifact registry lookup."
+       },
+       "amd_sev_snp": {
+         "vcpu_type": "EPYC",
+         "vm_type": "prod",
+         "secretvm_release": "v0.0.27-alpha.1",
+         "rootfs_sha256": "<sha256-of-rootfs-prod-v0.0.27-alpha.1-sev.iso>",
+         "kernel_hash":   "<sha256 of bzImage-...-sev>",
+         "initrd_hash":   "<sha256 of initramfs-...-sev.cpio.gz>",
+         "ovmf_hash":     "<sha384 of ovmf-...-sev.fd, registry value>",
+         "kernel_cmdline": "console=ttyS0 loglevel=7 docker_compose_hash=<...> rootfs_hash=<...>",
+         "artifact_registry": {
+           "url": "https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/sev.json",
+           "sha256": "<sha256 of the registry file at build time>"
+         },
+         "per_template": {
+           "small":   "<96-char-hex SEV launch digest, vCPU=1>",
+           "medium":  "<96-char-hex SEV launch digest, vCPU=2>",
+           "large":   "<96-char-hex SEV launch digest, vCPU=4>",
+           "2xlarge": "<96-char-hex SEV launch digest, vCPU=8>",
+           "4xlarge": "<96-char-hex SEV launch digest, vCPU=16>"
+         }
        }
      }
    }
    ```
+
+   The `baked_env.LOG_LEVEL_*` fields are extracted from `proxy-router/Dockerfile.tee` at manifest-generation time. The pipeline hard-fails the build if any of `LOG_LEVEL_APP`/`LOG_LEVEL_TCP`/`LOG_LEVEL_ETH_RPC`/`LOG_LEVEL_STORAGE` is missing or if `LOG_LEVEL_APP=debug` (privacy gate — prevents debug-level prompt/request payload logging in a TEE-published image). Consumers verifying the cosign-signed manifest can compare these against the proxy-router runtime config to confirm the running TEE image is not silently elevating verbosity.
 
 **Why RTMR3 only (not RTMR0-3):**
 - RTMR3 measures rootfs + docker-compose.yaml — the only registers **our software** controls
@@ -411,22 +463,44 @@ This is a **release cadence** concern, not a clock-based TTL. A version doesn't 
 **Effort:** M  
 **Blocked by:** Obtaining ACPI templates from SCRT Labs
 
-### 6.3 Integrate `sev-snp-measure` for AMD SEV
+### 6.3 SEV-SNP measurement in CI — DONE
 
-**Goal:** Compute expected AMD SEV-SNP `measurement` hash.
+**Goal:** Compute expected AMD SEV-SNP launch-digest (`measurement`) values in CI/CD and publish them in the cosign-signed manifest.
 
-**Approach:** Same rootfs, different computation tool: [virtee/sev-snp-measure](https://github.com/virtee/sev-snp-measure) (Python).
+**Implementation:**
 
-**Effort:** M  
-**Blocked by:** Same template/config dependency as 6.2
+1. **Standalone Python script:** `proxy-router/scripts/compute-sev-measurement.py`
+   - Byte-for-byte port of `proxy-router/internal/attestation/sev_gctx.go::CalcSevMeasurement` (the runtime source-of-truth introduced in PR #718).
+   - Mirrors the GCTX page-update chain (AMD SNP spec §8.17.2 Table 67): `PAGE_INFO = ld(48) || contents(48) || u16_LE(0x70) || page_type(1) || zeros(5) || gpa_LE(8); ld_next = SHA-384(PAGE_INFO)`.
+   - Inputs: SEV registry JSON entry (kernel/initrd/ovmf hashes, OVMF section table, sev_hashes_table_gpa, sev_es_reset_eip), the deployed `docker-compose.tee.yml`, and a vCPU template.
+   - Emits one `measurement` per template (small=1, medium=2, large=4, 2xlarge=8, 4xlarge=16).
+   - Parity-tested against the Go runtime via `internal/attestation/sev_python_parity_test.go` (uses `t.TempDir()` + the v0.0.27-alpha.1 fixture; the test runs the Python script as a subprocess and asserts identical hex output for all 5 templates).
 
-### 6.4 SecretVM release version tracking — DONE
+2. **Pipeline integration (`GHCR-Build-and-Push-TEE`):**
+   - Downloads SEV rootfs (URL + SHA from `secretvm.env`) into the same cache as the TDX rootfs.
+   - `Fetch SecretVM SEV artifact registry` step pulls `sev.json` from `scrtlabs/secretvm-verify` and records its SHA-256 in the manifest.
+   - `Compute SEV-SNP measurement (per template)` step invokes `compute-sev-measurement.py --all-templates --json` and exposes one job-output per template (`sev_measurement_small`, `sev_measurement_medium`, …).
+   - `Generate TEE attestation manifest` writes the full `amd_sev_snp` block (per-template values + kernel/initrd/ovmf/rootfs hashes + exact cmdline + registry URL/SHA) into the cosign-attested predicate.
 
-**Implementation:** `.github/tee/secretvm.env` pins the release version and rootfs variant. The pipeline derives all rootfs filenames, cache keys, and download paths from `SECRETVM_RELEASE` and `SECRETVM_ROOTFS_VARIANT` — no hardcoded filenames in `build.yml`. The attestation manifest includes `measurements.intel_tdx.secretvm_release`, `rootfs_variant`, and `rootfs_sha256`.
+3. **Why per-template instead of a single value:** the SEV launch digest folds in one VMSA page per vCPU, so a small VM (1 vCPU) and a large VM (4 vCPU) running the same image produce different launch digests. The TDX RTMR3 chain does not have this property — RTMR3 only covers `(rootfs, compose)` and is template-independent — so the manifest's `intel_tdx` block stays single-valued.
 
-**Upgrade procedure:** When SCRT Labs publishes a new release, edit `secretvm.env` (version, URL, clear SHA256), push, let CI capture the new rootfs hash from the step summary, then pin it back. Full instructions in `docs/02.3-proxy-router-tee.md` § "Upgrading SecretVM Artifacts".
+**Effort:** M — **DONE** (this PR)
 
-**Version detection:** There is no SCRT Labs push notification or dedicated API for new releases. The GitHub Releases API (`https://api.github.com/repos/scrtlabs/secret-vm-build/releases`) can be polled, but newer versions are often marked as **pre-release** on GitHub while already deployed to the SecretVM portal (e.g., `v0.0.25` is a pre-release on GitHub but portal runs "artifacts v0.0.25, environment prod"). The `/releases/latest` endpoint only returns non-prerelease versions and should NOT be relied on. Future consideration: a scheduled GitHub Action that polls for new releases and opens an issue or PR.
+### 6.4 SecretVM release version tracking — DONE (current pin: v0.0.27-alpha.1)
+
+**Implementation:** `.github/tee/secretvm.env` pins the release version, rootfs variant, and BOTH the TDX and SEV rootfs URLs + SHA-256s. The pipeline derives all artifact filenames, cache keys, and download paths from `SECRETVM_RELEASE` and `SECRETVM_ROOTFS_VARIANT` (with the platform suffix `-tdx`/`-sev` appended). The attestation manifest includes `measurements.intel_tdx.{secretvm_release, rootfs_variant, rootfs_sha256}` and `measurements.amd_sev_snp.{secretvm_release, rootfs_sha256, kernel_hash, initrd_hash, ovmf_hash, …}`.
+
+**Current pin (2026-04-29):** `v0.0.27-alpha.1`. SCRT Labs flipped the SecretVM portal so that *new* VM provisioning is only allowed against this release (older releases like `v0.0.25` continue to run already-provisioned VMs but cannot be selected for fresh `vm create`). Both the TDX rootfs (`rootfs-prod-v0.0.27-alpha.1-tdx.iso`, sha256 `1d638b06…`) and the SEV rootfs (`rootfs-prod-v0.0.27-alpha.1-sev.iso`, sha256 `f44141c9…`) are pinned.
+
+**Upgrade procedure:** When SCRT Labs publishes a new release:
+
+1. Update `SECRETVM_RELEASE` in `.github/tee/secretvm.env`.
+2. Update both `SECRETVM_ROOTFS_TDX_URL` and `SECRETVM_ROOTFS_SEV_URL`. Clear the corresponding `*_SHA256` lines.
+3. Push to a `cicd/*` branch — CI downloads the new artifacts and prints their SHA-256s in the step summary.
+4. Pin those SHA-256s back into `secretvm.env` and re-push.
+5. Confirm the SEV registry (`scrtlabs/secretvm-verify/artifacts_registry/sev.json`) has been updated with the new release's `(vm_type, artifacts_ver)` entry — without it the SEV measurement compute will fail with `no SEV registry entry found`. SCRT Labs typically publishes the registry alongside the build artifacts; check by `curl ${SECRETVM_SEV_REGISTRY_URL} | jq '.[] | select(.artifacts_ver == "${SECRETVM_RELEASE}")'`.
+
+**Version detection:** There is no SCRT Labs push notification or dedicated API for new releases. The GitHub Releases API (`https://api.github.com/repos/scrtlabs/secret-vm-build/releases`) can be polled, but newer versions are often marked as **pre-release** on GitHub while already required by the portal (e.g., `v0.0.27-alpha.1` is a pre-release on GitHub but is the *only* version the portal accepts for new VMs). The `/releases/latest` endpoint only returns non-prerelease versions and should NOT be relied on. Future consideration: a scheduled GitHub Action that polls for new releases AND new SEV-registry entries, opens an issue or PR.
 
 ### 6.5 Auto-deploy to SecretVM test instance — DONE
 
@@ -753,10 +827,13 @@ See also: [`proxy-router/docs/tee-backend-verification.md`](../proxy-router/docs
 | 1.13c | Variablize rootfs config — no hardcoded filenames in pipeline | S | **DONE** | `SECRETVM_ROOTFS_VARIANT` flows to cache key, download, RTMR3 compute, attestation manifest |
 | 1.13d | Switch rootfs from `dev` to `prod` variant (v0.0.25) | S | **DONE** | SecretVM runs "environment prod"; `dev` rootfs produces wrong RTMR3 |
 | 1.13e | Document upgrade procedure for SecretVM releases | S | **DONE** | `docs/02.3-proxy-router-tee.md` § "Upgrading SecretVM Artifacts" |
-| 1.14 | Full `reproduce-mr` for RTMR0-2 (Intel TDX) | M | TODO | Blocked: ACPI templates from SCRT Labs |
-| 1.15 | `sev-snp-measure` for AMD SEV measurement | M | TODO | Blocked: same as 1.14 |
+| 1.13f | Pin SecretVM release `v0.0.27-alpha.1` (TDX + SEV rootfs) | S | **DONE** | Portal-required release; this PR. SHA-256s pinned in `secretvm.env` |
+| 1.13g | SEV-SNP measurement in CI: `compute-sev-measurement.py` + per-template publish | M | **DONE** | This PR; parity-tested against Go `sev_gctx.go`. See §6.3 |
+| 1.13h | Bake `LOG_LEVEL_*` into `Dockerfile.tee` and surface them in `baked_env` | S | **DONE** | This PR; pipeline hard-fails if `LOG_LEVEL_APP=debug` |
+| 1.14 | Full `reproduce-mr` for RTMR0-2 (Intel TDX) | M | TODO | Blocked: ACPI templates from SCRT Labs (not on critical path — RTMR0-2 verified at runtime via artifact registry lookup) |
+| 1.15 | Auto-deploy + RTMR3-verify for an SEV test VM | S | TODO | TDX-only today; needs SEV-flavoured offsets, `SECRETVM_TEST_SEV_VM_UUID`, parallel `Deploy-SecretVM-Test-SEV` job |
 | 1.16 | CVE scanning (Trivy/Grype) — advisory, then gate | S | TODO | — |
-| 1.17 | Automated SecretVM release monitoring (scheduled GHA) | S | TODO | GitHub API pre-release caveat; see §6.4 |
+| 1.17 | Automated SecretVM release monitoring (scheduled GHA) | S | TODO | GitHub API pre-release caveat; see §6.4. Should also poll secretvm-verify SEV registry for matching `artifacts_ver` entries. |
 | 1.18 | Auto-deploy to SecretVM test instance via CLI | S | **DONE** | Separate `Deploy-SecretVM-Test` job; `environment: test`; `test` + `cicd/*` branches |
 | 1.19 | Post-deploy attestation verification | S | **DONE** | Extracts RTMR3 from raw TDX quote at byte offset 520; polls 12×30s; fails job on mismatch |
 | 1.20 | Temporarily disable service/UI builds on cicd/* branches | S | **DONE** | `Build-Service-Executables` set to `if: false`; cascades to all UI jobs. Re-enable before merge to main |
@@ -790,17 +867,31 @@ See also: [`proxy-router/docs/tee-backend-verification.md`](../proxy-router/docs
 | 2a.9 | Consolidate `tee` on-chain tag as sole TEE switch (remove `isTee` field from models config schema) | S | **DONE** | PR #708 / #709 |
 | 2a.10 | Test coverage: `backend_verifier_test.go`, `golden_test.go`, `workload_verifier_test.go`, `workload_rytn_test.go`, `nras_verifier_test.go` | M | **DONE** | PR #699 |
 
+### Phase 2 SEV-SNP add-on — DONE (this PR + PR #718, #720)
+
+| # | Task | Effort | Status | Reference |
+|---|---|---|---|---|
+| 2c.1 | Route SEV quotes to dedicated `quote-parse-sev` portal endpoint | S | **DONE** — PR #718 | `attestation/verifier.go::deriveSEVPortalURL` |
+| 2c.2 | Normalize space-separated `report_data` from SEV portal response | S | **DONE** — PR #718 | `attestation/verifier.go::VerifyTLSBinding` |
+| 2c.3 | Implement SEV-SNP launch-digest replay (GCTX page-update chain) | L | **DONE** — PR #718 | `attestation/sev_gctx.go::CalcSevMeasurement` |
+| 2c.4 | SEV artifact registry loader (auto-refresh from `secretvm-verify`) | S | **DONE** — PR #718 | `attestation/sev_registry.go::SevArtifactRegistry` |
+| 2c.5 | SEV workload verifier with family_id + brute-force fallback | M | **DONE** — PR #718 | `attestation/sev_workload.go::VerifySevWorkload` |
+| 2c.6 | Pass correct VMType for SEV in workload result | XS | **DONE** — PR #720 | `attestation/sev_workload.go` |
+| 2c.7 | Wire `SevArtifactRegistry` into `BackendVerifier` constructor + `cmd/main.go` | S | **DONE** — PR #718 | `cmd/main.go` (~line 328); new env var `SEV_ARTIFACT_REGISTRY_URL` in `config/config.go` |
+| 2c.8 | Pre-compute SEV `measurement` per template in CI and ship in cosign manifest | M | **DONE** | This PR — §6.3 above |
+
 ### Phase 2b — Deeper Guarantees (future, post-v7)
 
 | # | Task | Effort | Status | Notes |
 |---|---|---|---|---|
 | 2b.1 | Co-locate proxy-router + LLM in same TEE VM (single RTMR3 covers both hops) | L | TODO | Collapses Phase 1 + Phase 2 into one measurement chain |
 | 2b.2 | Verifiable per-message signing (TEE-bound key via SecretVM internal signer) | L | TODO | §7.6; deferred because Phase 2a fast-verify narrows the attack window significantly |
-| 2b.3 | AMD SEV-SNP measurement path in CI/CD | M | TODO | Blocked on upstream tooling; TDX-only today |
-| 2b.4 | Local quote verification in-process (remove SCRT Labs `quote-parse` dependency) | L | TODO | Requires PCK cert chain handling + Intel quote-verification library in Go |
+| ~~2b.3~~ | ~~AMD SEV-SNP measurement path in CI/CD~~ | ~~M~~ | **DONE** | Closed by §6.3 + Phase 2c |
+| 2b.4 | Local quote verification in-process (remove SCRT Labs `quote-parse` / `quote-parse-sev` dependency) | L | TODO | Requires PCK cert chain handling + Intel/AMD quote-verification libraries in Go |
 | 2b.5 | On-chain measurement registry (if ever needed beyond cosign signatures) | L | TODO | Cosign keyless via GHA OIDC is sufficient today |
 | 2b.6 | NRAS alternatives for non-NVIDIA GPU vendors | M | TODO | NVIDIA-only today |
 | 2b.7 | CVE scanning gate in CI/CD (Trivy/Grype) | S | TODO | §6.6 |
+| 2b.8 | Auto-deploy + post-deploy verify for an SEV test VM | S | TODO | TDX-only today; see §1.15 above |
 
 ---
 
@@ -827,15 +918,20 @@ See also: [`proxy-router/docs/tee-backend-verification.md`](../proxy-router/docs
 | PR #703 / #704 — correct error wrapping on P-Node TEE attestation fail | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/704 |
 | PR #705 — request_id propagation in TEE logs | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/705 |
 | PR #708 / #709 — `tee` on-chain tag as sole TEE switch (removed `isTee` from models-config schema) | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/709 |
+| **PR #718 — AMD SEV-SNP attestation support for TEE providers** | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/718 |
+| PR #719 — SEV merge dev → stg | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/719 |
+| PR #720 — fix: pass correct VMType for SEV | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/720 |
 | First verified pipeline run (build + sign) | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22920492249 |
 | First end-to-end run (build → sign → deploy → verify attestation) | https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22969993910 |
 | **SCRT Labs / TEE platform** | |
 | SecretVM Attestation Docs | https://docs.scrt.network/secret-network-documentation/secretvm-confidential-virtual-machines/attestation |
 | SecretVM CLI Docs | https://docs.scrt.network/secret-network-documentation/secretvm-confidential-virtual-machines/secretvm-cli |
 | SCRT Labs reproduce-mr | https://github.com/scrtlabs/reproduce-mr |
-| SCRT Labs secret-vm-build | https://github.com/scrtlabs/secret-vm-build |
-| SCRT Labs quote parser API | `POST https://pccs.scrtlabs.com/dcap-tools/quote-parse` |
-| AMD sev-snp-measure | https://github.com/virtee/sev-snp-measure |
+| SCRT Labs secret-vm-build (rootfs/bzImage/ovmf/initramfs releases) | https://github.com/scrtlabs/secret-vm-build |
+| **SCRT Labs secretvm-verify (TS reference verifier + TDX/SEV registries)** | https://github.com/scrtlabs/secretvm-verify |
+| Current SecretVM release pin | https://github.com/scrtlabs/secret-vm-build/releases/tag/v0.0.27-alpha.1 |
+| SCRT Labs TDX quote parser API | `POST https://secretai.scrtlabs.com/api/quote-parse` |
+| SCRT Labs SEV-SNP quote parser API | `POST https://secretai.scrtlabs.com/api/quote-parse-sev` |
 | **Sigstore / supply-chain tools** | |
 | Sigstore cosign | https://github.com/sigstore/cosign |
 | Cosign keyless signing docs | https://docs.sigstore.dev/cosign/signing/signing_with_containers/ |
@@ -850,12 +946,18 @@ See also: [`proxy-router/docs/tee-backend-verification.md`](../proxy-router/docs
 | InitiateSession handshake + `VerifyProviderQuick` callsites | `proxy-router/internal/proxyapi/proxy_sender.go`, `proxy_receiver.go` |
 | **Phase 1 consumer verifier** | `proxy-router/internal/attestation/verifier.go` (`Verifier`, `VerifyProvider`, `VerifyProviderQuick`) |
 | **Phase 2 backend verifier** | `proxy-router/internal/attestation/backend_verifier.go` (`BackendVerifier.AttestBackend`, `FastVerifyBackend`) |
-| **Phase 2 workload verifier + RTMR3 replay** | `proxy-router/internal/attestation/workload_verifier.go`, `rtmr.go`, `tdx_quote.go` |
-| **Phase 2 artifact registry** | `proxy-router/internal/attestation/artifacts_registry.go` |
+| **Phase 2 workload verifier (TDX RTMR3 replay)** | `proxy-router/internal/attestation/workload_verifier.go`, `rtmr.go`, `tdx_quote.go` |
+| **Phase 2 SEV launch-digest replay (PR #718)** | `proxy-router/internal/attestation/sev_gctx.go`, `sev_workload.go`, `sev_registry.go` |
+| **Phase 2 TDX artifact registry** | `proxy-router/internal/attestation/artifacts_registry.go` |
+| **Phase 2 SEV artifact registry** | `proxy-router/internal/attestation/sev_registry.go` (default URL `https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/sev.json`) |
 | **Phase 2 NVIDIA NRAS client** | `proxy-router/internal/attestation/nras_verifier.go` |
 | **Phase 2 pinned TLS client** | `proxy-router/internal/aiengine/ai_engine.go` (returns `PinnedHTTPClient` for TEE models) |
 | **Phase 2 health endpoint** | `proxy-router/internal/proxyapi/controller_http.go` (`GET /v1/models/attestation`) |
-| TEE config struct | `proxy-router/internal/config/config.go` — `TEE` section (lines ~87-92) |
+| **Phase 1 cosign manifest parser (TDX + SEV per-template)** | `proxy-router/internal/attestation/golden.go` — `TEEMeasurements`, `SEVMeasurements`, `GoldenValues.MatchSEVMeasurement` |
+| **Pipeline SEV measurement compute** | `proxy-router/scripts/compute-sev-measurement.py` (parity-tested in `internal/attestation/sev_python_parity_test.go`) |
+| **Pipeline TDX RTMR3 compute** | `proxy-router/scripts/compute-rtmr3.py` |
+| **SecretVM artifact pin** | `.github/tee/secretvm.env` |
+| TEE config struct | `proxy-router/internal/config/config.go` — `TEE` section (`PortalURL`, `ImageRepo`, `ArtifactRegistryURL`, **`SevArtifactRegistryURL`** added by PR #718, `ArtifactRegistryRefreshInterval`) |
 | Session repository (tracks `IsTee`) | `proxy-router/internal/repositories/session/session_model.go`, `session_repo.go` |
 | ModelRegistry contract | `smart-contracts/contracts/diamond/facets/ModelRegistry.sol` |
 | Model struct (with tags) | `smart-contracts/contracts/interfaces/storage/IModelStorage.sol` |

--- a/.ai-docs/TEE_CICD_Supply_Chain_Hardening.md
+++ b/.ai-docs/TEE_CICD_Supply_Chain_Hardening.md
@@ -1,10 +1,10 @@
 # CI/CD Supply-Chain Hardening for Morpheus Docker Images
 
-**Last updated:** 2026-04-22
+**Last updated:** 2026-04-29
 **First successful run (Phase 1a — signing):** [#22920492249](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22920492249)
 **First end-to-end run (Phase 1b — deploy + verify):** [#22969993910](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22969993910)
 
-> **v7.0.0 release status.** The CI/CD hardening described here is the foundation that every downstream trust check depends on. Both **Phase 1c** (consumer-side proxy-router verification of the P-Node) and **Phase 2** (P-Node verifies its own backend LLM) have shipped on top of it — see [`TEE_Attestation_Architecture.md`](TEE_Attestation_Architecture.md) §7.4 and §7.7 for the code-level flow. The CI/CD pipeline itself remains unchanged from Phase 1b in this release; v7 is the *consumer* of the artifacts this pipeline produces.
+> **v7.x release status (with AMD SEV-SNP).** The CI/CD hardening described here is the foundation that every downstream trust check depends on. Both **Phase 1c** (consumer-side proxy-router verification of the P-Node) and **Phase 2** (P-Node verifies its own backend LLM) have shipped on top of it — see [`TEE_Attestation_Architecture.md`](TEE_Attestation_Architecture.md) §7.4 and §7.7. **As of this release the pipeline now also publishes AMD SEV-SNP launch-digest goldens (one per portal template), pins SecretVM `v0.0.27-alpha.1` for both TDX and SEV rootfs, and bakes the proxy-router's privacy-sensitive `LOG_LEVEL_*` fields into the cosign-signed manifest's `baked_env` block.** The new SEV path mirrors the TDX one — Python compute script in CI (`compute-sev-measurement.py`) backed by the runtime Go source-of-truth (`sev_gctx.go`) with a parity test gating drift between the two.
 
 ---
 
@@ -90,24 +90,25 @@ The SBOM is attached to the image in GHCR as an OCI artifact and travels with th
 
 ### 4. TEE Attestation Manifest
 
-This is the most important new artifact. It's a signed JSON document that records everything needed to verify a TEE deployment:
+This is the most important new artifact. It's a signed JSON document that records everything needed to verify a TEE deployment, on **both** Intel TDX and AMD SEV-SNP platforms:
 
 ```json
 {
-  "tee_image": "ghcr.io/morpheusais/morpheus-lumerin-node-tee:v5.14.7-tee-supply-chain",
+  "tee_image": "ghcr.io/morpheusais/morpheus-lumerin-node-tee@sha256:DIGEST",
+  "tee_image_tag": "ghcr.io/morpheusais/morpheus-lumerin-node-tee:vX.Y.Z-branch",
   "tee_image_digest": "sha256:3bc2f2f9...",
-  "base_image": "ghcr.io/morpheusais/morpheus-lumerin-node:v5.14.7-tee-supply-chain",
+  "base_image": "ghcr.io/morpheusais/morpheus-lumerin-node:vX.Y.Z-branch",
   "base_image_digest": "sha256:67dbc859...",
-  "compose_file": "proxy-router/docker-compose.tee.yml",
   "compose_sha256": "sha256:9b4b4fce...",
+  "compose_image_reference": "ghcr.io/.../morpheus-lumerin-node-tee@sha256:DIGEST",
   "dockerfile_tee_sha256": "sha256:30094e96...",
   "build": {
     "commit": "369e9027dc048b52003ca8abd4fbeb278196cba4",
-    "ref": "refs/heads/cicd/tee-supply-chain",
+    "ref": "refs/heads/cicd/tee-sev-and-secretvm-v0.0.27",
     "workflow": "build.yml",
     "run_id": "22920492249",
     "run_url": "https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22920492249",
-    "timestamp": "2026-03-10T19:46:38Z"
+    "timestamp": "2026-04-29T15:00:00Z"
   },
   "tee_platforms": ["intel-tdx", "amd-sev-snp"],
   "runtime_secrets_only": [
@@ -127,14 +128,40 @@ This is the most important new artifact. It's a signed JSON document that record
     "LOG_COLOR": "false",
     "LOG_JSON": "true",
     "LOG_IS_PROD": "true",
+    "LOG_LEVEL_APP": "info",
+    "LOG_LEVEL_TCP": "warn",
+    "LOG_LEVEL_ETH_RPC": "warn",
+    "LOG_LEVEL_STORAGE": "warn",
     "ENVIRONMENT": "production"
   },
   "measurements": {
     "intel_tdx": {
       "rtmr3": "<96-char-hex — computed from sha256(compose) + sha256(rootfs)>",
-      "secretvm_release": "v0.0.25",
-      "rootfs_variant": "rootfs-prod-tdx",
-      "rootfs_sha256": "<sha256 of rootfs-prod-v0.0.25-tdx.iso>"
+      "secretvm_release": "v0.0.27-alpha.1",
+      "rootfs_variant": "rootfs-prod",
+      "rootfs_sha256": "<sha256 of rootfs-prod-v0.0.27-alpha.1-tdx.iso>",
+      "note": "RTMR3 measures (compose + rootfs); template-independent. RTMR0-2 verified at runtime via SecretVM TDX artifact registry lookup."
+    },
+    "amd_sev_snp": {
+      "vcpu_type": "EPYC",
+      "vm_type": "prod",
+      "secretvm_release": "v0.0.27-alpha.1",
+      "rootfs_sha256": "<sha256 of rootfs-prod-v0.0.27-alpha.1-sev.iso>",
+      "kernel_hash":   "<sha256 of bzImage-v0.0.27-alpha.1-sev>",
+      "initrd_hash":   "<sha256 of initramfs-v0.0.27-alpha.1-sev.cpio.gz>",
+      "ovmf_hash":     "<sha384 of ovmf-v0.0.27-alpha.1-sev.fd, registry value>",
+      "kernel_cmdline": "console=ttyS0 loglevel=7 docker_compose_hash=<...> rootfs_hash=<...>",
+      "artifact_registry": {
+        "url": "https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/sev.json",
+        "sha256": "<sha256 of sev.json at build time>"
+      },
+      "per_template": {
+        "small":   "<96-char-hex SEV launch digest, vCPU=1>",
+        "medium":  "<96-char-hex SEV launch digest, vCPU=2>",
+        "large":   "<96-char-hex SEV launch digest, vCPU=4>",
+        "2xlarge": "<96-char-hex SEV launch digest, vCPU=8>",
+        "4xlarge": "<96-char-hex SEV launch digest, vCPU=16>"
+      }
     }
   }
 }
@@ -147,9 +174,14 @@ This manifest is signed with cosign and attached to the image using `cosign atte
 - **Image provenance**: Which commit, branch, workflow run, and timestamp produced this image. You can trace back to the exact source code.
 - **Image chain**: The TEE image's digest AND the base image's digest. You can verify both independently.
 - **Config integrity**: SHA256 hashes of `docker-compose.tee.yml` and `Dockerfile.tee`. If either file was modified between the build and a deployment, the hashes won't match.
-- **Baked configuration**: The exact environment variables frozen into the image. A verifier can confirm that `PROXY_STORE_CHAT_CONTEXT=false` (no chat logging) and `ENVIRONMENT=production` are immutable — not overridable at runtime. The `network` field ("mainnet" or "testnet") and corresponding blockchain values (contract addresses, chain ID, blockscout URL) are set at build time based on the branch: `main` → mainnet (Base Mainnet 8453), `test` → testnet (Base Sepolia 84532). All other hardened settings are identical across networks.
+- **Baked configuration**: The exact environment variables frozen into the image. A verifier can confirm that:
+  - `PROXY_STORE_CHAT_CONTEXT=false` (no chat logging) and `ENVIRONMENT=production` are immutable — not overridable at runtime.
+  - The four `LOG_LEVEL_*` fields (`APP=info`, `TCP=warn`, `ETH_RPC=warn`, `STORAGE=warn`) are explicit, not assumed defaults — this guarantees the running TEE image is not silently elevated to `debug`-level app logging (which could expose request/prompt payloads). The pipeline hard-fails the build if `LOG_LEVEL_APP=debug` is detected in `Dockerfile.tee`.
+  - The `network` field ("mainnet" or "testnet") and corresponding blockchain values (contract addresses, chain ID, blockscout URL) are set at build time based on the branch: `main` → mainnet (Base Mainnet 8453), `test` → testnet (Base Sepolia 84532). All other hardened settings are identical across networks.
 - **Runtime secret boundary**: Explicitly lists the 5 variables that ARE injectable at runtime. Everything else is sealed.
 - **Platform targets**: Confirms the image is built for both Intel TDX and AMD SEV-SNP TEE platforms.
+- **TDX golden**: One `rtmr3` value (template-independent). Consumers compare it byte-for-byte to the live TDX quote.
+- **SEV-SNP golden**: A `per_template` map with one launch digest per portal-selectable VM size (small/medium/large/2xlarge/4xlarge). Consumers parse the live quote's `family_id` (`<vmType>-<template>-sev`) to pick the correct entry — `attestation.GoldenValues.MatchSEVMeasurement` does the lookup. The asymmetry vs. TDX exists because the SEV launch digest folds in one VMSA page per vCPU; TDX RTMR3 does not.
 
 ---
 
@@ -267,12 +299,15 @@ This CI/CD hardening is the **foundation layer** for the full TEE attestation lo
 
 | File | Change |
 |---|---|
-| `.github/workflows/build.yml` | Cosign signing, digest capture, SBOM, attestation manifest, RTMR3 computation, auto-deploy, and post-deploy verification. Also: GitHub Actions upgraded to Node 24-compatible versions, Go version updated to 1.23.x. |
-| `.github/tee/secretvm.env` | Pins SecretVM release version, rootfs variant, URL, and SHA-256. All pipeline rootfs references derive from this file. |
+| `.github/workflows/build.yml` | Cosign signing, digest capture, SBOM, attestation manifest, RTMR3 computation, **SEV-SNP measurement compute (per template) + SEV registry fetch + baked-loglevel extraction with privacy hard-fail**, auto-deploy, and post-deploy verification. Also: GitHub Actions upgraded to Node 24-compatible versions, Go version updated to 1.25.x. |
+| `.github/tee/secretvm.env` | Pins SecretVM release version (currently `v0.0.27-alpha.1`), rootfs variant (`rootfs-prod`), **TDX rootfs URL/SHA-256 AND SEV rootfs URL/SHA-256, plus the SEV artifact registry URL and registry vm_type**. All pipeline rootfs references derive from this file. |
 | `proxy-router/scripts/compute-rtmr3.py` | Standalone RTMR3 computation script matching the `reproduce-mr` algorithm. Can be run locally for independent verification. |
-| `proxy-router/Dockerfile.tee` | Bakes immutable ENV config into the TEE image. Blockchain values (diamond, token, blockscout, chain ID) are parameterized via `ARG` with mainnet defaults; overridden via `--build-arg` for testnet builds. |
-| `proxy-router/docker-compose.tee.yml` | Canonical compose template for TEE deployment with 5 runtime secrets |
-| `docs/02.3-proxy-router-tee.md` | Provider setup and consumer verification guide |
+| `proxy-router/scripts/compute-sev-measurement.py` | **NEW** — Standalone SEV-SNP launch-digest computation script. Byte-for-byte port of `attestation/sev_gctx.go::CalcSevMeasurement`. Computes one measurement per vCPU template (small/medium/large/2xlarge/4xlarge). Parity-tested against the runtime Go via `internal/attestation/sev_python_parity_test.go`. |
+| `proxy-router/internal/attestation/sev_python_parity_test.go` | **NEW** — Hermetic regression guard: runs `compute-sev-measurement.py` as a subprocess against the v0.0.27-alpha.1 prod registry fixture and asserts byte-for-byte match against `CalcSevMeasurement` for all 5 templates. Skips gracefully when `python3` is unavailable. |
+| `proxy-router/internal/attestation/golden.go` | Renamed JSON tag `amd_sev` → `amd_sev_snp` to align with the manifest schema; added `SEVMeasurements.PerTemplate map[string]string`, `GoldenValues.SEVPerTemplate`, and the `MatchSEVMeasurement` helper that looks up the golden by template-keyed live measurement. |
+| `proxy-router/Dockerfile.tee` | Bakes immutable ENV config into the TEE image. Blockchain values are parameterized via `ARG` with mainnet defaults; overridden via `--build-arg` for testnet builds. **Logging values (`LOG_LEVEL_APP=info`, `LOG_LEVEL_TCP=warn`, `LOG_LEVEL_ETH_RPC=warn`, `LOG_LEVEL_STORAGE=warn`, plus `LOG_COLOR=false`, `LOG_JSON=true`, `LOG_IS_PROD=true`) are baked here and surfaced into the cosign-signed manifest's `baked_env` block — the privacy gate ensures the live TEE image cannot silently revert to `debug`-level app logging.** |
+| `proxy-router/docker-compose.tee.yml` | Canonical compose template for TEE deployment with 5 runtime secrets. |
+| `docs/02.3-proxy-router-tee.md` | Provider setup and consumer verification guide. |
 
 ---
 
@@ -310,14 +345,28 @@ This CI/CD hardening is the **foundation layer** for the full TEE attestation lo
 | **`GET /v1/models/attestation`** | Per-model attestation state endpoint for monitoring and forensics | **Done** — PR #699 |
 | **New env vars** | `TEE_PORTAL_URL`, `TEE_IMAGE_REPO`, `ARTIFACT_REGISTRY_URL`, `ARTIFACT_REGISTRY_REFRESH_INTERVAL` | **Done** — PR #699 |
 
+### Completed (this PR — SEV-SNP and v0.0.27-alpha.1 cutover)
+
+| Step | Description | Status |
+|---|---|---|
+| **SecretVM `v0.0.27-alpha.1` pin** | TDX + SEV rootfs URLs and SHA-256s pinned in `.github/tee/secretvm.env` (the portal currently only allows new VM provisioning on this release) | **Done** |
+| **SEV rootfs download + SHA-256 verify** | `Download SecretVM rootfs (TDX + SEV)` step pulls both ISOs; both fail-closed if the pinned SHA doesn't match | **Done** |
+| **SEV artifact registry fetch** | `Fetch SecretVM SEV artifact registry` step downloads `sev.json` from `scrtlabs/secretvm-verify` and records its SHA-256 in the manifest | **Done** |
+| **SEV measurement compute (5 templates)** | `Compute SEV-SNP measurement (per template)` step runs `compute-sev-measurement.py --all-templates` and emits per-template digests as job outputs | **Done** |
+| **Per-template SEV measurements in cosign-signed manifest** | `measurements.amd_sev_snp.per_template` block under the existing `cosign attest` flow | **Done** |
+| **Baked log-level fields in `baked_env`** | `Extract baked log levels from Dockerfile.tee` step reads the four `LOG_LEVEL_*` ENV lines plus `LOG_COLOR`/`LOG_JSON`/`LOG_IS_PROD` and writes them to the manifest. Hard-fails if any are missing or if `LOG_LEVEL_APP=debug` (privacy gate) | **Done** |
+| **Consumer parser update** | `internal/attestation/golden.go` renamed `amd_sev` → `amd_sev_snp` JSON tag, added `PerTemplate` map and `MatchSEVMeasurement` lookup helper | **Done** |
+| **Python ↔ Go parity regression test** | `internal/attestation/sev_python_parity_test.go` runs `compute-sev-measurement.py` as a subprocess and asserts identical hex output to `CalcSevMeasurement` for all 5 templates | **Done** |
+
 ### Remaining (Lower Priority / Future)
 
 | Area | Step | Status |
 |---|---|---|
 | CI/CD | Full RTMR0-2 *recomputation* in CI (today we verify RTMR0-2 by artifact-registry lookup, which is sufficient) | TODO — blocked on ACPI templates |
-| CI/CD | AMD SEV-SNP measurement via `sev-snp-measure` | TODO — TDX-only today |
+| CI/CD | Auto-deploy + post-deploy verification for an SEV test VM (TDX-only today; needs SEV-flavoured offsets, separate `SECRETVM_TEST_SEV_VM_UUID`, parallel `Deploy-SecretVM-Test-SEV` job) | TODO |
 | CI/CD | CVE scanning (Trivy/Grype) — advisory then gating | TODO |
+| CI/CD | Scheduled monitor that polls `secret-vm-build` releases AND `secretvm-verify/artifacts_registry/sev.json` for new versions, opens an issue/PR | TODO |
 | Proxy-router | Verifiable per-message signing using SecretVM TEE-bound key | Deferred to Phase 2b |
-| Proxy-router | Local in-process quote verification (remove `quote-parse` dependency on SCRT Labs) | Deferred to Phase 2b |
+| Proxy-router | Local in-process quote verification (remove `quote-parse` / `quote-parse-sev` dependency on SCRT Labs) | Deferred to Phase 2b |
 | Proxy-router | Co-located proxy-router + LLM in a single TDX VM (collapses both hops into one RTMR3) | Deferred to Phase 2b |
 | Proxy-router | NRAS alternatives for non-NVIDIA GPU vendors | Deferred to Phase 2b |

--- a/.github/tee/secretvm.env
+++ b/.github/tee/secretvm.env
@@ -1,25 +1,37 @@
-# SecretVM artifact configuration for RTMR3 computation
+# SecretVM artifact configuration for RTMR3 (Intel TDX) + SEV measurement (AMD SEV-SNP)
 # Update these when SCRT Labs publishes a new stable VM release.
 #
-# Source: https://github.com/scrtlabs/secret-vm-build/releases
-# Algorithm: scrtlabs/reproduce-mr (RTMR3 = replayRTMR of sha256(compose) + sha256(rootfs))
+# Source:    https://github.com/scrtlabs/secret-vm-build/releases
+# Algorithm: scrtlabs/reproduce-mr (Intel TDX RTMR3 = replayRTMR of sha256(compose) + sha256(rootfs))
+#            scrtlabs/secretvm-verify (AMD SEV-SNP launch digest via GCTX page-update chain)
 #
 # IMPORTANT: Always use the "prod" rootfs variant — SecretVM runs "environment prod"
-# even for developer portal deployments. Using "dev" rootfs produces wrong RTMR3.
+# even for developer portal deployments. Using "dev" rootfs produces wrong measurements.
+#
+# Compatibility note (2026-04-29):
+#   The SecretVM portal currently only allows starting *new* VMs on
+#   v0.0.27-alpha.1. Older releases (e.g. v0.0.25) can still run already-provisioned
+#   VMs but cannot be selected for new deployments.
 
-SECRETVM_RELEASE=v0.0.25
-SECRETVM_ROOTFS_VARIANT=rootfs-prod-tdx
+SECRETVM_RELEASE=v0.0.27-alpha.1
+SECRETVM_ROOTFS_VARIANT=rootfs-prod
 
 # Intel TDX rootfs (non-GPU, prod — used for proxy-router P-Node deployments)
-# URL is derived: .../download/${RELEASE}/${VARIANT_BASE}-${RELEASE}-tdx.iso
-SECRETVM_ROOTFS_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.25/rootfs-prod-v0.0.25-tdx.iso
-# SHA256 will be captured on first CI/CD run and pinned here
-SECRETVM_ROOTFS_TDX_SHA256=2a6d16965f5ce5143bcba614bb7896cdfc598a71c6e1ecc55efd3d8f74ba7c8a
+# URL pattern: .../download/${RELEASE}/${VARIANT}-${RELEASE}-tdx.iso
+SECRETVM_ROOTFS_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.27-alpha.1/rootfs-prod-v0.0.27-alpha.1-tdx.iso
+SECRETVM_ROOTFS_TDX_SHA256=1d638b068bc6f9254e74ea917818d4e09a7ffce8e486d54c5b5dbe9e6c44b261
 
-# AMD SEV rootfs (prod)
-# SECRETVM_ROOTFS_SEV_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.25/rootfs-prod-v0.0.25-sev.iso
-# SECRETVM_ROOTFS_SEV_SHA256=
+# AMD SEV-SNP rootfs (prod) — same compose, different platform binary
+# URL pattern: .../download/${RELEASE}/${VARIANT}-${RELEASE}-sev.iso
+SECRETVM_ROOTFS_SEV_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.27-alpha.1/rootfs-prod-v0.0.27-alpha.1-sev.iso
+SECRETVM_ROOTFS_SEV_SHA256=f44141c9a0cbed19ddf30b16929de33633e5631cfd68731e9ff9e4321d5775fd
+
+# SEV artifact registry — kernel/initrd/ovmf hashes + ovmf_sections for measurement compute.
+# Pulled from scrtlabs/secretvm-verify; pipeline picks the entry whose `vm_type` and
+# `artifacts_ver` match SECRETVM_ROOTFS_VARIANT (prod) and SECRETVM_RELEASE.
+SECRETVM_SEV_REGISTRY_URL=https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/sev.json
+SECRETVM_SEV_REGISTRY_VM_TYPE=prod
 
 # GPU variant (for co-located proxy+LLM deployments)
-# SECRETVM_ROOTFS_GPU_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.25/rootfs-gpu-prod-v0.0.25-tdx.iso
-# SECRETVM_ROOTFS_GPU_TDX_SHA256=
+# SECRETVM_ROOTFS_GPU_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.27-alpha.1/rootfs-gpu-prod-v0.0.27-alpha.1-tdx.iso
+# SECRETVM_ROOTFS_GPU_TDX_SHA256=ddf4b55edd296b13f046e4d515f5547c7e39da5afdea1bc1b71e23e645fe7a8a

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -441,6 +441,14 @@ jobs:
           source .github/tee/secretvm.env
           echo "release=$SECRETVM_RELEASE" >> $GITHUB_OUTPUT
           echo "rootfs_variant=$SECRETVM_ROOTFS_VARIANT" >> $GITHUB_OUTPUT
+          echo "rootfs_tdx_url=$SECRETVM_ROOTFS_TDX_URL" >> $GITHUB_OUTPUT
+          echo "rootfs_tdx_sha256=$SECRETVM_ROOTFS_TDX_SHA256" >> $GITHUB_OUTPUT
+          echo "rootfs_sev_url=${SECRETVM_ROOTFS_SEV_URL:-}" >> $GITHUB_OUTPUT
+          echo "rootfs_sev_sha256=${SECRETVM_ROOTFS_SEV_SHA256:-}" >> $GITHUB_OUTPUT
+          echo "sev_registry_url=${SECRETVM_SEV_REGISTRY_URL:-https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/sev.json}" >> $GITHUB_OUTPUT
+          echo "sev_registry_vm_type=${SECRETVM_SEV_REGISTRY_VM_TYPE:-prod}" >> $GITHUB_OUTPUT
+
+          # legacy aliases retained so older steps continue to compile
           echo "rootfs_url=$SECRETVM_ROOTFS_TDX_URL" >> $GITHUB_OUTPUT
           echo "rootfs_sha256=$SECRETVM_ROOTFS_TDX_SHA256" >> $GITHUB_OUTPUT
 
@@ -449,28 +457,48 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /tmp/secretvm-artifacts
-          key: secretvm-${{ steps.secretvm-config.outputs.release }}-${{ steps.secretvm-config.outputs.rootfs_variant }}
+          key: secretvm-${{ steps.secretvm-config.outputs.release }}-${{ steps.secretvm-config.outputs.rootfs_variant }}-tdx-sev
 
-      - name: Download SecretVM rootfs
+      - name: Download SecretVM rootfs (TDX + SEV)
         if: steps.cache-rootfs.outputs.cache-hit != 'true'
         run: |
           mkdir -p /tmp/secretvm-artifacts
-          echo "⬇️  Downloading SecretVM rootfs (${{ steps.secretvm-config.outputs.release }})..."
-          ROOTFS_FILE="/tmp/secretvm-artifacts/${{ steps.secretvm-config.outputs.rootfs_variant }}.iso"
-          curl -L --retry 3 --retry-delay 5 -o "$ROOTFS_FILE" \
-            "${{ steps.secretvm-config.outputs.rootfs_url }}"
-          
-          ACTUAL_SHA=$(sha256sum "$ROOTFS_FILE" | cut -d' ' -f1)
-          EXPECTED_SHA="${{ steps.secretvm-config.outputs.rootfs_sha256 }}"
-          
-          if [ -n "$EXPECTED_SHA" ]; then
-            echo "$EXPECTED_SHA  $ROOTFS_FILE" | sha256sum -c -
-            echo "✅ SecretVM rootfs downloaded and verified" >> $GITHUB_STEP_SUMMARY
+
+          echo "⬇️  Downloading SecretVM TDX rootfs (${{ steps.secretvm-config.outputs.release }})..."
+          TDX_FILE="/tmp/secretvm-artifacts/${{ steps.secretvm-config.outputs.rootfs_variant }}-tdx.iso"
+          curl -L --retry 3 --retry-delay 5 -o "$TDX_FILE" \
+            "${{ steps.secretvm-config.outputs.rootfs_tdx_url }}"
+
+          TDX_ACTUAL_SHA=$(sha256sum "$TDX_FILE" | cut -d' ' -f1)
+          TDX_EXPECTED_SHA="${{ steps.secretvm-config.outputs.rootfs_tdx_sha256 }}"
+          if [ -n "$TDX_EXPECTED_SHA" ]; then
+            echo "$TDX_EXPECTED_SHA  $TDX_FILE" | sha256sum -c -
+            echo "✅ SecretVM TDX rootfs downloaded and verified" >> $GITHUB_STEP_SUMMARY
           else
-            echo "⚠️  No expected SHA256 configured — rootfs hash: \`$ACTUAL_SHA\`" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️  No expected SHA256 configured — TDX rootfs hash: \`$TDX_ACTUAL_SHA\`" >> $GITHUB_STEP_SUMMARY
             echo "   PIN THIS in .github/tee/secretvm.env as SECRETVM_ROOTFS_TDX_SHA256" >> $GITHUB_STEP_SUMMARY
           fi
-          echo "   rootfs sha256: \`$ACTUAL_SHA\`" >> $GITHUB_STEP_SUMMARY
+          echo "   TDX rootfs sha256: \`$TDX_ACTUAL_SHA\`" >> $GITHUB_STEP_SUMMARY
+
+          if [ -n "${{ steps.secretvm-config.outputs.rootfs_sev_url }}" ]; then
+            echo "⬇️  Downloading SecretVM SEV rootfs (${{ steps.secretvm-config.outputs.release }})..."
+            SEV_FILE="/tmp/secretvm-artifacts/${{ steps.secretvm-config.outputs.rootfs_variant }}-sev.iso"
+            curl -L --retry 3 --retry-delay 5 -o "$SEV_FILE" \
+              "${{ steps.secretvm-config.outputs.rootfs_sev_url }}"
+
+            SEV_ACTUAL_SHA=$(sha256sum "$SEV_FILE" | cut -d' ' -f1)
+            SEV_EXPECTED_SHA="${{ steps.secretvm-config.outputs.rootfs_sev_sha256 }}"
+            if [ -n "$SEV_EXPECTED_SHA" ]; then
+              echo "$SEV_EXPECTED_SHA  $SEV_FILE" | sha256sum -c -
+              echo "✅ SecretVM SEV rootfs downloaded and verified" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "⚠️  No expected SHA256 configured — SEV rootfs hash: \`$SEV_ACTUAL_SHA\`" >> $GITHUB_STEP_SUMMARY
+              echo "   PIN THIS in .github/tee/secretvm.env as SECRETVM_ROOTFS_SEV_SHA256" >> $GITHUB_STEP_SUMMARY
+            fi
+            echo "   SEV rootfs sha256: \`$SEV_ACTUAL_SHA\`" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "ℹ️  SEV rootfs URL not configured — skipping SEV download" >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: Generate deployed compose with immutable digest
         id: generate-compose
@@ -494,20 +522,84 @@ jobs:
       - name: Compute RTMR3 (Intel TDX)
         id: compute-rtmr3
         run: |
-          ROOTFS_FILE="/tmp/secretvm-artifacts/${{ steps.secretvm-config.outputs.rootfs_variant }}.iso"
+          ROOTFS_FILE="/tmp/secretvm-artifacts/${{ steps.secretvm-config.outputs.rootfs_variant }}-tdx.iso"
           RTMR3=$(python3 proxy-router/scripts/compute-rtmr3.py \
             /tmp/docker-compose.tee.deployed.yml \
             "$ROOTFS_FILE" \
             --json)
-          
+
           RTMR3_HEX=$(echo "$RTMR3" | python3 -c "import sys,json; print(json.load(sys.stdin)['rtmr3'])")
           COMPOSE_HASH=$(echo "$RTMR3" | python3 -c "import sys,json; print(json.load(sys.stdin)['compose_sha256'])")
           ROOTFS_HASH=$(echo "$RTMR3" | python3 -c "import sys,json; print(json.load(sys.stdin)['rootfs_sha256'])")
-          
+
           echo "rtmr3=$RTMR3_HEX" >> $GITHUB_OUTPUT
           echo "🔐 Expected RTMR3: \`$RTMR3_HEX\`" >> $GITHUB_STEP_SUMMARY
           echo "   compose sha256: \`$COMPOSE_HASH\`" >> $GITHUB_STEP_SUMMARY
           echo "   rootfs sha256:  \`$ROOTFS_HASH\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Fetch SecretVM SEV artifact registry
+        id: sev-registry
+        if: steps.secretvm-config.outputs.rootfs_sev_url != ''
+        run: |
+          REGISTRY_URL="${{ steps.secretvm-config.outputs.sev_registry_url }}"
+          REGISTRY_FILE="/tmp/secretvm-artifacts/sev.json"
+          echo "⬇️  Fetching SEV artifact registry from $REGISTRY_URL..."
+          curl -L --retry 3 --retry-delay 5 -o "$REGISTRY_FILE" "$REGISTRY_URL"
+          REGISTRY_SHA=$(sha256sum "$REGISTRY_FILE" | cut -d' ' -f1)
+          echo "registry_path=$REGISTRY_FILE" >> $GITHUB_OUTPUT
+          echo "registry_sha256=$REGISTRY_SHA" >> $GITHUB_OUTPUT
+          echo "📋 SEV registry sha256: \`$REGISTRY_SHA\`" >> $GITHUB_STEP_SUMMARY
+          echo "   URL: \`$REGISTRY_URL\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Compute SEV-SNP measurement (per template)
+        id: compute-sev
+        if: steps.secretvm-config.outputs.rootfs_sev_url != ''
+        run: |
+          SEV_OUT=$(python3 proxy-router/scripts/compute-sev-measurement.py \
+            --registry "${{ steps.sev-registry.outputs.registry_path }}" \
+            --vm-type "${{ steps.secretvm-config.outputs.sev_registry_vm_type }}" \
+            --artifacts-ver "${{ steps.secretvm-config.outputs.release }}" \
+            --compose /tmp/docker-compose.tee.deployed.yml \
+            --all-templates --json)
+
+          # Persist the full JSON to a file so the manifest step can pull individual fields.
+          echo "$SEV_OUT" > /tmp/sev-measurements.json
+
+          SMALL=$(  echo "$SEV_OUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['per_template']['small'])")
+          MEDIUM=$( echo "$SEV_OUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['per_template']['medium'])")
+          LARGE=$(  echo "$SEV_OUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['per_template']['large'])")
+          XL2=$(    echo "$SEV_OUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['per_template']['2xlarge'])")
+          XL4=$(    echo "$SEV_OUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['per_template']['4xlarge'])")
+
+          echo "sev_measurement_small=$SMALL"     >> $GITHUB_OUTPUT
+          echo "sev_measurement_medium=$MEDIUM"   >> $GITHUB_OUTPUT
+          echo "sev_measurement_large=$LARGE"     >> $GITHUB_OUTPUT
+          echo "sev_measurement_2xlarge=$XL2"     >> $GITHUB_OUTPUT
+          echo "sev_measurement_4xlarge=$XL4"     >> $GITHUB_OUTPUT
+
+          KERNEL_HASH=$(echo "$SEV_OUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['kernel_hash'])")
+          INITRD_HASH=$(echo "$SEV_OUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['initrd_hash'])")
+          OVMF_HASH=$(  echo "$SEV_OUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['ovmf_hash'])")
+          ROOTFS_SHA=$( echo "$SEV_OUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['rootfs_hash'])")
+          CMDLINE=$(    echo "$SEV_OUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['kernel_cmdline'])")
+
+          echo "sev_kernel_hash=$KERNEL_HASH"     >> $GITHUB_OUTPUT
+          echo "sev_initrd_hash=$INITRD_HASH"     >> $GITHUB_OUTPUT
+          echo "sev_ovmf_hash=$OVMF_HASH"         >> $GITHUB_OUTPUT
+          echo "sev_rootfs_sha256=$ROOTFS_SHA"    >> $GITHUB_OUTPUT
+          echo "sev_kernel_cmdline=$CMDLINE"      >> $GITHUB_OUTPUT
+
+          echo "🔐 Expected SEV-SNP measurement (per template):" >> $GITHUB_STEP_SUMMARY
+          echo "   small   (1 vCPU):  \`$SMALL\`" >> $GITHUB_STEP_SUMMARY
+          echo "   medium  (2 vCPU):  \`$MEDIUM\`" >> $GITHUB_STEP_SUMMARY
+          echo "   large   (4 vCPU):  \`$LARGE\`" >> $GITHUB_STEP_SUMMARY
+          echo "   2xlarge (8 vCPU):  \`$XL2\`" >> $GITHUB_STEP_SUMMARY
+          echo "   4xlarge (16 vCPU): \`$XL4\`" >> $GITHUB_STEP_SUMMARY
+          echo "   kernel sha256:  \`$KERNEL_HASH\`" >> $GITHUB_STEP_SUMMARY
+          echo "   initrd sha256:  \`$INITRD_HASH\`" >> $GITHUB_STEP_SUMMARY
+          echo "   ovmf sha384:    \`$OVMF_HASH\`" >> $GITHUB_STEP_SUMMARY
+          echo "   rootfs sha256:  \`$ROOTFS_SHA\`" >> $GITHUB_STEP_SUMMARY
+          echo "   cmdline:        \`$CMDLINE\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Generate and attach SBOM
         run: |
@@ -517,6 +609,50 @@ jobs:
           syft "$TEE_IMAGE@$DIGEST" -o spdx-json=sbom-tee.spdx.json
           cosign attach sbom --sbom sbom-tee.spdx.json "$TEE_IMAGE@$DIGEST"
           echo "📦 SBOM generated and attached to TEE image" >> $GITHUB_STEP_SUMMARY
+
+      - name: Extract baked log levels from Dockerfile.tee
+        id: baked-loglevels
+        run: |
+          # Pin the manifest's baked_env LOG_LEVEL_* fields to whatever Dockerfile.tee bakes in.
+          # This guarantees the published attestation reflects the *actual* image contents and
+          # demonstrates that we are not running with debug-level logging in production
+          # (privacy concern: debug-level app logs could expose request/prompt payloads).
+          DF=proxy-router/Dockerfile.tee
+          extract() {
+            grep -E "^ENV $1=" "$DF" | head -n1 | sed -E "s/^ENV $1=//; s/[[:space:]]+$//"
+          }
+          LOG_LEVEL_APP=$(extract LOG_LEVEL_APP)
+          LOG_LEVEL_TCP=$(extract LOG_LEVEL_TCP)
+          LOG_LEVEL_ETH_RPC=$(extract LOG_LEVEL_ETH_RPC)
+          LOG_LEVEL_STORAGE=$(extract LOG_LEVEL_STORAGE)
+          LOG_COLOR=$(extract LOG_COLOR)
+          LOG_JSON=$(extract LOG_JSON)
+          LOG_IS_PROD=$(extract LOG_IS_PROD)
+
+          # Hard fail if the privacy-critical ones are missing or set to debug.
+          for var in LOG_LEVEL_APP LOG_LEVEL_TCP LOG_LEVEL_ETH_RPC LOG_LEVEL_STORAGE; do
+            val=$(eval echo \${$var})
+            if [ -z "$val" ]; then
+              echo "❌ $var is not baked in Dockerfile.tee — refusing to publish manifest" >&2
+              exit 1
+            fi
+            if [ "$val" = "debug" ] && [ "$var" = "LOG_LEVEL_APP" ]; then
+              echo "❌ LOG_LEVEL_APP=debug in Dockerfile.tee — privacy violation, refusing to publish manifest" >&2
+              exit 1
+            fi
+          done
+
+          echo "log_level_app=$LOG_LEVEL_APP"           >> $GITHUB_OUTPUT
+          echo "log_level_tcp=$LOG_LEVEL_TCP"           >> $GITHUB_OUTPUT
+          echo "log_level_eth_rpc=$LOG_LEVEL_ETH_RPC"   >> $GITHUB_OUTPUT
+          echo "log_level_storage=$LOG_LEVEL_STORAGE"   >> $GITHUB_OUTPUT
+          echo "log_color=$LOG_COLOR"                   >> $GITHUB_OUTPUT
+          echo "log_json=$LOG_JSON"                     >> $GITHUB_OUTPUT
+          echo "log_is_prod=$LOG_IS_PROD"               >> $GITHUB_OUTPUT
+
+          echo "📝 Baked log levels:" >> $GITHUB_STEP_SUMMARY
+          echo "   LOG_LEVEL_APP=$LOG_LEVEL_APP, LOG_LEVEL_TCP=$LOG_LEVEL_TCP, LOG_LEVEL_ETH_RPC=$LOG_LEVEL_ETH_RPC, LOG_LEVEL_STORAGE=$LOG_LEVEL_STORAGE" >> $GITHUB_STEP_SUMMARY
+          echo "   LOG_COLOR=$LOG_COLOR, LOG_JSON=$LOG_JSON, LOG_IS_PROD=$LOG_IS_PROD" >> $GITHUB_STEP_SUMMARY
 
       - name: Generate TEE attestation manifest
         run: |
@@ -528,12 +664,53 @@ jobs:
           RTMR3=${{ steps.compute-rtmr3.outputs.rtmr3 }}
           SECRETVM_RELEASE=${{ steps.secretvm-config.outputs.release }}
           ROOTFS_VARIANT=${{ steps.secretvm-config.outputs.rootfs_variant }}
-          ROOTFS_SHA256=${{ steps.secretvm-config.outputs.rootfs_sha256 }}
-          
+          ROOTFS_TDX_SHA256=${{ steps.secretvm-config.outputs.rootfs_tdx_sha256 }}
+          ROOTFS_SEV_SHA256=${{ steps.secretvm-config.outputs.rootfs_sev_sha256 }}
+
           COMPOSE_SHA="sha256:$(sha256sum /tmp/docker-compose.tee.deployed.yml | cut -d' ' -f1)"
           DOCKERFILE_SHA="sha256:$(sha256sum proxy-router/Dockerfile.tee | cut -d' ' -f1)"
           TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          
+
+          # SEV section is conditional on having computed measurements.
+          # Build it as standalone JSON first, then inject via --argjson into the main manifest.
+          if [ -n "${{ steps.compute-sev.outputs.sev_measurement_small }}" ]; then
+            SEV_BLOCK_JSON=$(jq -n \
+              --arg vm_type "${{ steps.secretvm-config.outputs.sev_registry_vm_type }}" \
+              --arg secretvm_release "$SECRETVM_RELEASE" \
+              --arg rootfs "$ROOTFS_SEV_SHA256" \
+              --arg kernel "${{ steps.compute-sev.outputs.sev_kernel_hash }}" \
+              --arg initrd "${{ steps.compute-sev.outputs.sev_initrd_hash }}" \
+              --arg ovmf "${{ steps.compute-sev.outputs.sev_ovmf_hash }}" \
+              --arg cmdline "${{ steps.compute-sev.outputs.sev_kernel_cmdline }}" \
+              --arg registry_url "${{ steps.secretvm-config.outputs.sev_registry_url }}" \
+              --arg registry_sha "${{ steps.sev-registry.outputs.registry_sha256 }}" \
+              --arg small   "${{ steps.compute-sev.outputs.sev_measurement_small }}" \
+              --arg medium  "${{ steps.compute-sev.outputs.sev_measurement_medium }}" \
+              --arg large   "${{ steps.compute-sev.outputs.sev_measurement_large }}" \
+              --arg xl2     "${{ steps.compute-sev.outputs.sev_measurement_2xlarge }}" \
+              --arg xl4     "${{ steps.compute-sev.outputs.sev_measurement_4xlarge }}" \
+              '{
+                vcpu_type: "EPYC",
+                vm_type: $vm_type,
+                secretvm_release: $secretvm_release,
+                rootfs_sha256: $rootfs,
+                kernel_hash: $kernel,
+                initrd_hash: $initrd,
+                ovmf_hash: $ovmf,
+                kernel_cmdline: $cmdline,
+                artifact_registry: { url: $registry_url, sha256: $registry_sha },
+                per_template: {
+                  small:    $small,
+                  medium:   $medium,
+                  large:    $large,
+                  "2xlarge": $xl2,
+                  "4xlarge": $xl4
+                }
+              }')
+          else
+            SEV_BLOCK_JSON='{"note":"SEV measurement not computed in this run (rootfs URL not configured)"}'
+          fi
+
           jq -n \
             --arg tee_image "${TEE_IMAGE}@${TEE_DIGEST}" \
             --arg tee_image_tag "${TEE_IMAGE}:${BUILDTAG}" \
@@ -551,12 +728,20 @@ jobs:
             --arg rtmr3 "$RTMR3" \
             --arg secretvm_release "$SECRETVM_RELEASE" \
             --arg rootfs_variant "$ROOTFS_VARIANT" \
-            --arg rootfs_sha256 "$ROOTFS_SHA256" \
+            --arg rootfs_tdx_sha256 "$ROOTFS_TDX_SHA256" \
             --arg baked_network "${{ steps.network-config.outputs.network }}" \
             --arg baked_diamond "${{ steps.network-config.outputs.diamond_contract_address }}" \
             --arg baked_mor_token "${{ steps.network-config.outputs.mor_token_address }}" \
             --arg baked_blockscout "${{ steps.network-config.outputs.blockscout_api_url }}" \
             --arg baked_chain_id "${{ steps.network-config.outputs.eth_node_chain_id }}" \
+            --arg log_level_app "${{ steps.baked-loglevels.outputs.log_level_app }}" \
+            --arg log_level_tcp "${{ steps.baked-loglevels.outputs.log_level_tcp }}" \
+            --arg log_level_eth_rpc "${{ steps.baked-loglevels.outputs.log_level_eth_rpc }}" \
+            --arg log_level_storage "${{ steps.baked-loglevels.outputs.log_level_storage }}" \
+            --arg log_color "${{ steps.baked-loglevels.outputs.log_color }}" \
+            --arg log_json "${{ steps.baked-loglevels.outputs.log_json }}" \
+            --arg log_is_prod "${{ steps.baked-loglevels.outputs.log_is_prod }}" \
+            --argjson sev_block "$SEV_BLOCK_JSON" \
             '{
               tee_image: $tee_image,
               tee_image_tag: $tee_image_tag,
@@ -589,9 +774,13 @@ jobs:
                 BLOCKSCOUT_API_URL: $baked_blockscout,
                 ETH_NODE_CHAIN_ID: $baked_chain_id,
                 PROXY_STORE_CHAT_CONTEXT: "false",
-                LOG_COLOR: "false",
-                LOG_JSON: "true",
-                LOG_IS_PROD: "true",
+                LOG_COLOR: $log_color,
+                LOG_JSON: $log_json,
+                LOG_IS_PROD: $log_is_prod,
+                LOG_LEVEL_APP: $log_level_app,
+                LOG_LEVEL_TCP: $log_level_tcp,
+                LOG_LEVEL_ETH_RPC: $log_level_eth_rpc,
+                LOG_LEVEL_STORAGE: $log_level_storage,
                 ENVIRONMENT: "production"
               },
               measurements: {
@@ -599,15 +788,13 @@ jobs:
                   rtmr3: $rtmr3,
                   secretvm_release: $secretvm_release,
                   rootfs_variant: $rootfs_variant,
-                  rootfs_sha256: $rootfs_sha256,
-                  note: "RTMR0-2 require full reproduce-mr with firmware/kernel/templates (Phase 1b follow-up)"
+                  rootfs_sha256: $rootfs_tdx_sha256,
+                  note: "RTMR3 measures (compose + rootfs); template-independent. RTMR0-2 verified at runtime via SecretVM TDX artifact registry lookup."
                 },
-                amd_sev_snp: {
-                  note: "SEV measurement computation not yet integrated"
-                }
+                amd_sev_snp: $sev_block
               }
             }' > tee-attestation-manifest.json
-          
+
           echo "📋 TEE attestation manifest:" >> $GITHUB_STEP_SUMMARY
           echo '```json' >> $GITHUB_STEP_SUMMARY
           cat tee-attestation-manifest.json >> $GITHUB_STEP_SUMMARY

--- a/proxy-router/.dockerignore
+++ b/proxy-router/.dockerignore
@@ -16,3 +16,4 @@ node_modules
 *.log
 tmp/
 temp/
+__pycache__/

--- a/proxy-router/.gitignore
+++ b/proxy-router/.gitignore
@@ -9,6 +9,7 @@ dist
 bin 
 proxy-router
 data*
+__pycache__/
 
 models-config.json
 rating-config.json

--- a/proxy-router/internal/attestation/golden.go
+++ b/proxy-router/internal/attestation/golden.go
@@ -50,7 +50,7 @@ type TEEPredicate struct {
 
 type TEEMeasurements struct {
 	IntelTDX *TDXMeasurements `json:"intel_tdx,omitempty"`
-	AMDSEV   *SEVMeasurements `json:"amd_sev,omitempty"`
+	AMDSEV   *SEVMeasurements `json:"amd_sev_snp,omitempty"`
 }
 
 type TDXMeasurements struct {
@@ -58,8 +58,19 @@ type TDXMeasurements struct {
 	SecretVMRelease string `json:"secretvm_release,omitempty"`
 }
 
+// SEVMeasurements is the SEV-SNP block of the signed attestation manifest.
+//
+// Because the SEV-SNP launch digest is a single cumulative SHA-384 that
+// includes the per-vCPU VMSA pages, one image produces *different*
+// `measurement` values for each VM template. The manifest therefore carries
+// a per-template map (`per_template`) covering every SecretVM-portal size
+// (small/medium/large/2xlarge/4xlarge). The legacy single-value
+// `Measurement` field is retained for backwards compatibility with manifests
+// that pre-date the per-template scheme.
 type SEVMeasurements struct {
-	Measurement string `json:"measurement,omitempty"`
+	Measurement     string            `json:"measurement,omitempty"`
+	PerTemplate     map[string]string `json:"per_template,omitempty"`
+	SecretVMRelease string            `json:"secretvm_release,omitempty"`
 }
 
 // GoldenValues contains the expected TEE register values extracted from a
@@ -71,8 +82,30 @@ type GoldenValues struct {
 	RTMR2 string
 	RTMR3 string
 
-	// AMD SEV-SNP
+	// AMD SEV-SNP — single legacy value (kept for backwards compatibility)
 	Measurement string
+
+	// AMD SEV-SNP — per-template map keyed by SecretVM template name
+	// (small/medium/large/2xlarge/4xlarge). The launch digest depends on
+	// vCPU count, so the manifest publishes one value per portal-selectable
+	// VM size; consumers pick the entry matching the live quote's family_id.
+	SEVPerTemplate map[string]string
+}
+
+// MatchSEVMeasurement returns the template name whose published golden SEV
+// measurement equals `live` (case-insensitive). Returns an empty string when
+// no template matches or when no per-template values were published.
+func (g *GoldenValues) MatchSEVMeasurement(live string) string {
+	if g == nil || live == "" {
+		return ""
+	}
+	live = strings.ToLower(strings.TrimSpace(live))
+	for tmpl, val := range g.SEVPerTemplate {
+		if strings.EqualFold(val, live) {
+			return tmpl
+		}
+	}
+	return ""
 }
 
 // DSSEEnvelope represents a Dead Simple Signing Envelope.
@@ -317,6 +350,12 @@ func (g *GoldenSource) verifyBundleLayer(
 	}
 	if m := predicate.Measurements.AMDSEV; m != nil {
 		values.Measurement = m.Measurement
+		if len(m.PerTemplate) > 0 {
+			values.SEVPerTemplate = make(map[string]string, len(m.PerTemplate))
+			for k, v := range m.PerTemplate {
+				values.SEVPerTemplate[k] = v
+			}
+		}
 	}
 
 	g.log.Infof("extracted golden values from verified attestation")
@@ -358,6 +397,12 @@ func parseAttestationPayload(payload []byte) (*GoldenValues, error) {
 	}
 	if m := statement.Predicate.Measurements.AMDSEV; m != nil {
 		values.Measurement = m.Measurement
+		if len(m.PerTemplate) > 0 {
+			values.SEVPerTemplate = make(map[string]string, len(m.PerTemplate))
+			for k, v := range m.PerTemplate {
+				values.SEVPerTemplate[k] = v
+			}
+		}
 	}
 
 	return values, nil

--- a/proxy-router/internal/attestation/sev_python_parity_test.go
+++ b/proxy-router/internal/attestation/sev_python_parity_test.go
@@ -1,0 +1,158 @@
+package attestation
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// parityFixtureArtifactsVer is the synthetic registry version used by the
+// parity test. It is intentionally NOT a real SCRT Labs release — the parity
+// test exercises algorithmic equivalence between sev_gctx.go and
+// compute-sev-measurement.py, NOT correctness of any specific upstream
+// release. Future SecretVM bumps in `.github/tee/secretvm.env` should NOT
+// require touching this file.
+const parityFixtureArtifactsVer = "parity-test-fixture-v1"
+
+// parityFixtureSevEntry is a frozen, hermetic SEV registry entry used to
+// drive the Go ↔ Python parity test. The byte values are plausible-shaped
+// (correct lengths and a realistic OVMF section table) but are NOT pinned
+// to any particular SecretVM release. The parity assertion checks only that
+// both implementations produce identical SHA-384 chains given identical
+// inputs — so any well-formed entry suffices.
+//
+// Sourced from scrtlabs/secretvm-verify SEV registry as of 2026-04-29 and
+// then frozen here. Keep this fixture stable; if you need to test against
+// the live production registry, write a separate (network-gated)
+// integration test.
+var parityFixtureSevEntry = &SevArtifactEntry{
+	VMType:            "prod",
+	ArtifactsVer:      parityFixtureArtifactsVer,
+	KernelHash:        "98c41a86a1ba6a9a9d772ae0b028835091b4930f79ea509b595d2080d7df90c2",
+	InitrdHash:        "6b19d1b356c1e791f5c1c3d7dd86a723b870c87ebdfe3f7ccace80215ac71d2e",
+	VcpuType:          "EPYC",
+	RootfsHash:        "f44141c9a0cbed19ddf30b16929de33633e5631cfd68731e9ff9e4321d5775fd",
+	OvmfHash:          "c581d3eaebf2941beb1f757de97497279b953a6999921cab05f9ed5268f9c0505d741f4021b5a3995c9893851cde190e",
+	SevHashesTableGPA: 8457216,
+	SevEsResetEIP:     8433668,
+	OvmfSections: []SevOvmfSection{
+		{GPA: 8388608, Size: 36864, SectionType: 1},
+		{GPA: 8429568, Size: 12288, SectionType: 1},
+		{GPA: 8441856, Size: 4096, SectionType: 2},
+		{GPA: 8445952, Size: 4096, SectionType: 3},
+		{GPA: 8450048, Size: 4096, SectionType: 4},
+		{GPA: 8458240, Size: 61440, SectionType: 1},
+		{GPA: 8454144, Size: 4096, SectionType: 16},
+	},
+}
+
+// TestComputeSevMeasurementPythonParity runs proxy-router/scripts/compute-sev-measurement.py
+// against a hermetic fixture and confirms it produces the same per-template launch
+// digests as the Go implementation in sev_gctx.go (CalcSevMeasurement). This is the
+// regression guard that keeps the CI/CD pipeline's Python tool in lockstep with the
+// runtime Go source-of-truth.
+//
+// The fixture (parityFixtureSevEntry) is intentionally version-agnostic — its
+// `artifacts_ver` is "parity-test-fixture-v1", NOT a real SecretVM release. Bumping
+// the production pin in `.github/tee/secretvm.env` does NOT require touching this
+// test; the test only proves "given the same inputs, both implementations produce
+// the same SHA-384 chains". For a freshness check against the live SCRT Labs
+// registry, write a separate (network-gated) integration test.
+//
+// Skipped when python3 is not on PATH (e.g. local Windows dev box).
+func TestComputeSevMeasurementPythonParity(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH; skipping parity test")
+	}
+
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..") // .../Morpheus-Lumerin-Node
+	scriptPath := filepath.Join(repoRoot, "proxy-router", "scripts", "compute-sev-measurement.py")
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Fatalf("compute-sev-measurement.py not found at %s: %s", scriptPath, err)
+	}
+
+	tmp := t.TempDir()
+	registryPath := filepath.Join(tmp, "sev.json")
+	registryJSON, err := json.Marshal([]*SevArtifactEntry{parityFixtureSevEntry})
+	if err != nil {
+		t.Fatalf("marshal registry fixture: %s", err)
+	}
+	if err := os.WriteFile(registryPath, registryJSON, 0o600); err != nil {
+		t.Fatalf("write registry fixture: %s", err)
+	}
+
+	composeContent := []byte("services:\n  proxy-router:\n    image: ghcr.io/example/test:latest\n")
+	composePath := filepath.Join(tmp, "docker-compose.tee.yml")
+	if err := os.WriteFile(composePath, composeContent, 0o600); err != nil {
+		t.Fatalf("write compose fixture: %s", err)
+	}
+
+	// Compute the Go-side expected values against the *actual* compose bytes.
+	composeHash := sha256.Sum256(composeContent)
+	composeShaHex := hex.EncodeToString(composeHash[:])
+	cmdline := fmt.Sprintf(
+		"console=ttyS0 loglevel=7 docker_compose_hash=%s rootfs_hash=%s",
+		composeShaHex, parityFixtureSevEntry.RootfsHash,
+	)
+
+	templates := []struct {
+		name  string
+		vcpus int
+	}{
+		{"small", 1},
+		{"medium", 2},
+		{"large", 4},
+		{"2xlarge", 8},
+		{"4xlarge", 16},
+	}
+
+	goExpected := make(map[string]string, len(templates))
+	for _, tmpl := range templates {
+		goExpected[tmpl.name] = CalcSevMeasurement(parityFixtureSevEntry, tmpl.vcpus, cmdline)
+		if len(goExpected[tmpl.name]) != 96 {
+			t.Fatalf("Go CalcSevMeasurement returned non-SHA-384 length for %s: %d hex chars",
+				tmpl.name, len(goExpected[tmpl.name]))
+		}
+	}
+
+	cmd := exec.Command("python3", scriptPath,
+		"--registry", registryPath,
+		"--vm-type", parityFixtureSevEntry.VMType,
+		"--artifacts-ver", parityFixtureArtifactsVer,
+		"--compose", composePath,
+		"--all-templates", "--json",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("python script failed: %s\n--- output ---\n%s", err, out)
+	}
+
+	var py struct {
+		ComposeSHA256 string            `json:"compose_sha256"`
+		PerTemplate   map[string]string `json:"per_template"`
+	}
+	if err := json.Unmarshal(out, &py); err != nil {
+		t.Fatalf("decode python output: %s\n--- output ---\n%s", err, out)
+	}
+
+	if !strings.EqualFold(py.ComposeSHA256, composeShaHex) {
+		t.Fatalf("compose_sha256 mismatch: python=%s go=%s", py.ComposeSHA256, composeShaHex)
+	}
+
+	for _, tmpl := range templates {
+		got := py.PerTemplate[tmpl.name]
+		want := goExpected[tmpl.name]
+		if !strings.EqualFold(got, want) {
+			t.Fatalf("SEV measurement mismatch for %s (vcpus=%d):\n  go     = %s\n  python = %s",
+				tmpl.name, tmpl.vcpus, want, got)
+		}
+	}
+}

--- a/proxy-router/scripts/compute-sev-measurement.py
+++ b/proxy-router/scripts/compute-sev-measurement.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""
+Compute expected AMD SEV-SNP launch-digest `measurement` values for a SecretVM
+deployment, one per vCPU template (small/medium/large/2xlarge/4xlarge).
+
+This is the byte-for-byte Python port of
+``proxy-router/internal/attestation/sev_gctx.go::CalcSevMeasurement`` (PR #718).
+The Go function is the runtime source-of-truth used by the consumer's Phase 1
+verifier and the P-Node BackendVerifier; this Python tool exists for the
+CI/CD pipeline (so it stays in lockstep with the existing
+``compute-rtmr3.py`` pattern for Intel TDX) and so providers/auditors can
+recompute the measurements independently.
+
+Mathematical model (per AMD SNP spec Section 8.17.2 Table 67):
+
+    PAGE_INFO    = ld_current(48) || contents(48) || u16_LE(0x70)
+                   || page_type(1) || imi/perms/reserved(5) || gpa_LE(8)
+    ld_next      = SHA-384(PAGE_INFO)
+
+The launch digest accumulates over the OVMF firmware sections, the kernel
+hashes table, then one VMSA page per vCPU. Section type semantics:
+
+    1  SNP_SEC_MEM       page_type 0x03 (zero), content = 48 zero bytes
+    2  SNP_SECRETS       page_type 0x05,        content = 48 zero bytes
+    3  CPUID             page_type 0x06,        content = 48 zero bytes
+    4  SVSM_CAA          page_type 0x03 (zero), content = 48 zero bytes
+    16 SNP_KERNEL_HASHES page_type 0x01 (normal), content = SHA-384(page)
+
+VMSA pages use page_type 0x02 at fixed GPA 0xFFFFFFFFF000 and content =
+SHA-384(vmsa_page). The BSP runs RIP = 0xfffffff0; APs use the registry's
+``sev_es_reset_eip`` value.
+
+Cmdline included in the kernel-hashes table:
+
+    "console=ttyS0 loglevel=7[ <cmdline_extra>] " \\
+    "docker_compose_hash=<compose-sha256> rootfs_hash=<rootfs-sha256>"
+
+The ``loglevel=7`` token is the Linux *kernel* log level controlled by SecretVM
+(NOT the proxy-router application log level — those are baked into the TEE
+image via Dockerfile.tee and recorded in the attestation manifest's
+``baked_env`` block).
+
+The canonical ``--artifacts-ver`` value comes from
+``.github/tee/secretvm.env`` (variable ``SECRETVM_RELEASE``); CI passes it in
+automatically. Run ``--help`` for the full flag set.
+
+Usage (single template — ``$RELEASE`` resolved by the caller, e.g. via
+``source .github/tee/secretvm.env`` or ``--artifacts-ver "$(grep ^SECRETVM_RELEASE
+.github/tee/secretvm.env | cut -d= -f2)"``):
+
+    python3 compute-sev-measurement.py \\
+        --registry sev.json \\
+        --vm-type prod \\
+        --artifacts-ver "$RELEASE" \\
+        --compose docker-compose.tee.yml \\
+        --template small
+
+Usage (all 5 templates as JSON, used by the CI pipeline):
+
+    python3 compute-sev-measurement.py \\
+        --registry sev.json \\
+        --vm-type prod \\
+        --artifacts-ver "$RELEASE" \\
+        --compose docker-compose.tee.yml \\
+        --all-templates --json
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+LD_SIZE = 48                          # SHA-384 digest size
+VMSA_GPA = 0xFFFFFFFFF000             # fixed VMSA load address
+VCPU_SIG_EPYC = 0x00800F12            # CPUID signature stored in RDX
+GUEST_FEATURES = 0x1                  # SEV_FEATURES bitmap
+BSP_EIP = 0xFFFFFFF0                  # BSP reset vector
+
+# Maps SecretVM template name -> vCPU count. Matches sev_gctx.go::VcpuMap.
+VCPU_MAP: dict[str, int] = {
+    "small":   1,
+    "medium":  2,
+    "large":   4,
+    "2xlarge": 8,
+    "4xlarge": 16,
+}
+
+SEV_HASH_TABLE_HEADER_GUID = "9438d606-4f22-4cc9-b479-a793d411fd21"
+SEV_KERNEL_ENTRY_GUID      = "4de79437-abd2-427f-b835-d5b172d2045b"
+SEV_INITRD_ENTRY_GUID      = "44baf731-3a2f-4bd7-9af1-41e29169781d"
+SEV_CMDLINE_ENTRY_GUID     = "97d02dd8-bd20-4c94-aa78-e7714d36ab2a"
+
+
+# ---------------------------------------------------------------------------
+# GCTX page-update primitive (mirrors sev_gctx.go::gctxUpdate)
+# ---------------------------------------------------------------------------
+
+def _sha384(data: bytes) -> bytes:
+    return hashlib.sha384(data).digest()
+
+
+def _gctx_update(ld: bytes, page_type: int, gpa: int, contents: bytes) -> bytes:
+    """One GCTX page-update: SHA-384 over a 0x70-byte PAGE_INFO struct."""
+    if len(ld) != LD_SIZE:
+        raise ValueError(f"ld must be {LD_SIZE} bytes, got {len(ld)}")
+    if len(contents) != LD_SIZE:
+        raise ValueError(f"contents must be {LD_SIZE} bytes, got {len(contents)}")
+
+    buf = bytearray(0x70)
+    buf[0:48] = ld
+    buf[48:96] = contents
+    buf[96:98] = (0x70).to_bytes(2, "little")  # page_info_len
+    buf[98] = page_type & 0xFF
+    # buf[99..103] = 0   (imi flag, vmpl perms, reserved) — already zero
+    buf[104:112] = gpa.to_bytes(8, "little")
+    return _sha384(bytes(buf))
+
+
+def _gctx_update_normal_pages(ld: bytes, start_gpa: int, data: bytes) -> bytes:
+    """page_type 0x01, content = SHA-384(page) — for SNP_KERNEL_HASHES."""
+    for offset in range(0, len(data), 4096):
+        page = data[offset:offset + 4096]
+        ld = _gctx_update(ld, 0x01, start_gpa + offset, _sha384(page))
+    return ld
+
+
+def _gctx_update_zero_pages(ld: bytes, gpa: int, size: int) -> bytes:
+    """page_type 0x03, content = 48 zero bytes — for SNP_SEC_MEM, SVSM_CAA."""
+    zeros = b"\x00" * LD_SIZE
+    for offset in range(0, size, 4096):
+        ld = _gctx_update(ld, 0x03, gpa + offset, zeros)
+    return ld
+
+
+def _gctx_update_secrets_page(ld: bytes, gpa: int) -> bytes:
+    """page_type 0x05, content = 48 zero bytes — for SNP_SECRETS."""
+    return _gctx_update(ld, 0x05, gpa, b"\x00" * LD_SIZE)
+
+
+def _gctx_update_cpuid_page(ld: bytes, gpa: int) -> bytes:
+    """page_type 0x06, content = 48 zero bytes — for CPUID."""
+    return _gctx_update(ld, 0x06, gpa, b"\x00" * LD_SIZE)
+
+
+def _gctx_update_vmsa_page(ld: bytes, vmsa: bytes) -> bytes:
+    """page_type 0x02 at fixed VMSA_GPA, content = SHA-384(vmsa_page)."""
+    return _gctx_update(ld, 0x02, VMSA_GPA, _sha384(vmsa))
+
+
+# ---------------------------------------------------------------------------
+# Hashes-table page (mirrors sev_gctx.go::buildHashesPage)
+# ---------------------------------------------------------------------------
+
+def _uuid_to_le(guid: str) -> bytes:
+    """RFC 4122 mixed-endian: groups 1-3 reverse, groups 4-5 stay BE."""
+    raw = bytes.fromhex(guid.replace("-", ""))
+    le = bytearray(raw)
+    le[0], le[1], le[2], le[3] = raw[3], raw[2], raw[1], raw[0]
+    le[4], le[5] = raw[5], raw[4]
+    le[6], le[7] = raw[7], raw[6]
+    return bytes(le)
+
+
+def _sev_hash_table_entry(guid: str, hash_bytes: bytes) -> bytes:
+    """50-byte entry: GUID(16 LE) + length(u16 LE = 50) + hash(32)."""
+    if len(hash_bytes) != 32:
+        raise ValueError(f"hash must be 32 bytes, got {len(hash_bytes)}")
+    entry = bytearray(50)
+    entry[0:16] = _uuid_to_le(guid)
+    entry[16:18] = (50).to_bytes(2, "little")
+    entry[18:50] = hash_bytes
+    return bytes(entry)
+
+
+def _build_hashes_page(
+    kernel_hash_hex: str,
+    initrd_hash_hex: str,
+    cmdline: str,
+    offset_in_page: int,
+) -> bytes:
+    """4096-byte page containing the QEMU SEV kernel-hashes table at ``offset_in_page``."""
+    kernel_hash = bytes.fromhex(kernel_hash_hex)
+    if initrd_hash_hex:
+        initrd_hash = bytes.fromhex(initrd_hash_hex)
+    else:
+        initrd_hash = hashlib.sha256(b"").digest()
+
+    # cmdline is null-terminated before hashing; empty cmdline hashes a single \0
+    cmdline_bytes = (cmdline.encode("utf-8") + b"\x00") if cmdline else b"\x00"
+    cmdline_hash = hashlib.sha256(cmdline_bytes).digest()
+
+    # SevHashTable layout: GUID(16) + length(u16) + cmdline(50) + initrd(50) + kernel(50) = 168
+    ht = bytearray(168)
+    ht[0:16] = _uuid_to_le(SEV_HASH_TABLE_HEADER_GUID)
+    ht[16:18] = (168).to_bytes(2, "little")
+    ht[18:68]  = _sev_hash_table_entry(SEV_CMDLINE_ENTRY_GUID, cmdline_hash)
+    ht[68:118] = _sev_hash_table_entry(SEV_INITRD_ENTRY_GUID,  initrd_hash)
+    ht[118:168] = _sev_hash_table_entry(SEV_KERNEL_ENTRY_GUID, kernel_hash)
+
+    # Pad to 16-byte alignment (176 bytes), then place inside a 4096-byte page.
+    padded = bytearray(176)
+    padded[0:168] = ht
+
+    page = bytearray(4096)
+    page[offset_in_page:offset_in_page + len(padded)] = padded
+    return bytes(page)
+
+
+# ---------------------------------------------------------------------------
+# VMSA page (mirrors sev_gctx.go::buildVmsaPage)
+# ---------------------------------------------------------------------------
+
+def _vmcb_seg(page: bytearray, off: int, sel: int, attr: int, lim: int, base: int) -> None:
+    page[off:off + 2]      = (sel & 0xFFFF).to_bytes(2, "little")
+    page[off + 2:off + 4]  = (attr & 0xFFFF).to_bytes(2, "little")
+    page[off + 4:off + 8]  = (lim & 0xFFFFFFFF).to_bytes(4, "little")
+    page[off + 8:off + 16] = (base & 0xFFFFFFFFFFFFFFFF).to_bytes(8, "little")
+
+
+def _build_vmsa_page(eip: int, vcpu_sig: int, guest_features: int) -> bytes:
+    """Mirrors buildVmsaPage(eip, vcpu_sig, guest_features) in sev_gctx.go."""
+    page = bytearray(4096)
+
+    cs_base = eip & 0xFFFF0000
+    rip     = eip & 0x0000FFFF
+
+    _vmcb_seg(page, 0x000, 0,      0x0093, 0xFFFF, 0)        # es
+    _vmcb_seg(page, 0x010, 0xF000, 0x009B, 0xFFFF, cs_base)  # cs
+    _vmcb_seg(page, 0x020, 0,      0x0093, 0xFFFF, 0)        # ss
+    _vmcb_seg(page, 0x030, 0,      0x0093, 0xFFFF, 0)        # ds
+    _vmcb_seg(page, 0x040, 0,      0x0093, 0xFFFF, 0)        # fs
+    _vmcb_seg(page, 0x050, 0,      0x0093, 0xFFFF, 0)        # gs
+    _vmcb_seg(page, 0x060, 0,      0x0000, 0xFFFF, 0)        # gdtr
+    _vmcb_seg(page, 0x070, 0,      0x0082, 0xFFFF, 0)        # ldtr
+    _vmcb_seg(page, 0x080, 0,      0x0000, 0xFFFF, 0)        # idtr
+    _vmcb_seg(page, 0x090, 0,      0x008B, 0xFFFF, 0)        # tr
+
+    def put_u64(off: int, val: int) -> None:
+        page[off:off + 8] = (val & 0xFFFFFFFFFFFFFFFF).to_bytes(8, "little")
+
+    def put_u32(off: int, val: int) -> None:
+        page[off:off + 4] = (val & 0xFFFFFFFF).to_bytes(4, "little")
+
+    def put_u16(off: int, val: int) -> None:
+        page[off:off + 2] = (val & 0xFFFF).to_bytes(2, "little")
+
+    put_u64(0x0D0, 0x1000)              # efer (SVME)
+    put_u64(0x148, 0x40)                # cr4 (MCE)
+    put_u64(0x158, 0x10)                # cr0 (PE)
+    put_u64(0x160, 0x400)               # dr7
+    put_u64(0x168, 0xFFFF0FF0)          # dr6
+    put_u64(0x170, 0x2)                 # rflags
+    put_u64(0x178, rip)                 # rip
+    put_u64(0x268, 0x0007040600070406)  # g_pat
+    put_u64(0x310, vcpu_sig)            # rdx (CPUID sig)
+    put_u64(0x3B0, guest_features)      # sev_features
+    put_u64(0x3E8, 0x1)                 # xcr0
+    put_u32(0x408, 0x1F80)              # mxcsr
+    put_u16(0x410, 0x037F)              # x87_fcw
+
+    return bytes(page)
+
+
+# ---------------------------------------------------------------------------
+# Top-level measurement (mirrors sev_gctx.go::CalcSevMeasurement)
+# ---------------------------------------------------------------------------
+
+def calc_sev_measurement(entry: dict[str, Any], vcpus: int, cmdline: str) -> str:
+    """Compute the SEV-SNP launch digest for the given registry entry + vCPU count."""
+    ld = bytes.fromhex(entry["ovmf_hash"])
+    if len(ld) != LD_SIZE:
+        raise ValueError(
+            f"ovmf_hash must decode to {LD_SIZE} bytes (96 hex chars), got {len(ld)}"
+        )
+
+    sev_hashes_table_gpa = int(entry["sev_hashes_table_gpa"])
+    offset_in_page = sev_hashes_table_gpa & 0xFFF
+    hashes_page = _build_hashes_page(
+        entry["kernel_hash"],
+        entry.get("initrd_hash", ""),
+        cmdline,
+        offset_in_page,
+    )
+
+    for sec in entry["ovmf_sections"]:
+        gpa = int(sec["gpa"])
+        size = int(sec["size"])
+        st = int(sec["section_type"])
+        if st == 1:        # SNP_SEC_MEM
+            ld = _gctx_update_zero_pages(ld, gpa, size)
+        elif st == 2:      # SNP_SECRETS
+            ld = _gctx_update_secrets_page(ld, gpa)
+        elif st == 3:      # CPUID
+            ld = _gctx_update_cpuid_page(ld, gpa)
+        elif st == 4:      # SVSM_CAA
+            ld = _gctx_update_zero_pages(ld, gpa, size)
+        elif st == 0x10:   # SNP_KERNEL_HASHES
+            ld = _gctx_update_normal_pages(ld, gpa, hashes_page)
+        # Unknown section types are silently ignored — Go behaviour.
+
+    ap_eip = int(entry["sev_es_reset_eip"])
+    for i in range(vcpus):
+        eip = BSP_EIP if i == 0 else ap_eip
+        vmsa = _build_vmsa_page(eip, VCPU_SIG_EPYC, GUEST_FEATURES)
+        ld = _gctx_update_vmsa_page(ld, vmsa)
+
+    return ld.hex()
+
+
+# ---------------------------------------------------------------------------
+# Helpers + CLI
+# ---------------------------------------------------------------------------
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(1 << 16)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def build_cmdline(compose_sha256: str, rootfs_hash: str, cmdline_extra: str = "") -> str:
+    prefix = "console=ttyS0 loglevel=7"
+    if cmdline_extra:
+        prefix += " " + cmdline_extra
+    return f"{prefix} docker_compose_hash={compose_sha256} rootfs_hash={rootfs_hash}"
+
+
+def find_registry_entry(
+    registry: list[dict[str, Any]], vm_type: str, artifacts_ver: str
+) -> dict[str, Any]:
+    for e in registry:
+        if e.get("vm_type") == vm_type and e.get("artifacts_ver") == artifacts_ver:
+            return e
+    raise SystemExit(
+        f"no SEV registry entry found for vm_type={vm_type} artifacts_ver={artifacts_ver}"
+    )
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--registry", required=True, type=Path, help="path to SEV artifact registry JSON")
+    p.add_argument("--vm-type", required=True, help="registry vm_type (e.g. prod, dev, gpu_prod)")
+    p.add_argument("--artifacts-ver", required=True,
+                   help="registry artifacts_ver — must match SECRETVM_RELEASE from "
+                        ".github/tee/secretvm.env (the SCRT Labs portal-mandated release)")
+    p.add_argument("--compose", required=True, type=Path, help="path to docker-compose.tee.yml (deployed/digest-pinned)")
+    p.add_argument(
+        "--template",
+        choices=sorted(VCPU_MAP.keys()),
+        help="single template to compute (default: all 5 if --all-templates is set)",
+    )
+    p.add_argument("--all-templates", action="store_true", help="compute measurement for every template in VCPU_MAP")
+    p.add_argument("--json", action="store_true", help="emit a structured JSON object")
+    args = p.parse_args()
+
+    if not args.template and not args.all_templates:
+        p.error("specify either --template or --all-templates")
+
+    registry = json.loads(args.registry.read_text())
+    if not isinstance(registry, list):
+        raise SystemExit("registry must be a JSON array")
+
+    entry = find_registry_entry(registry, args.vm_type, args.artifacts_ver)
+    compose_sha = sha256_file(args.compose)
+    cmdline = build_cmdline(compose_sha, entry["rootfs_hash"], entry.get("cmdline_extra", ""))
+
+    if args.template:
+        templates = [args.template]
+    else:
+        templates = list(VCPU_MAP.keys())
+
+    measurements: dict[str, str] = {}
+    for tmpl in templates:
+        measurements[tmpl] = calc_sev_measurement(entry, VCPU_MAP[tmpl], cmdline)
+
+    if args.json:
+        out = {
+            "vm_type":               args.vm_type,
+            "artifacts_ver":         args.artifacts_ver,
+            "compose_sha256":        compose_sha,
+            "kernel_hash":           entry["kernel_hash"],
+            "initrd_hash":           entry["initrd_hash"],
+            "ovmf_hash":             entry["ovmf_hash"],
+            "rootfs_hash":           entry["rootfs_hash"],
+            "sev_hashes_table_gpa":  entry["sev_hashes_table_gpa"],
+            "sev_es_reset_eip":      entry["sev_es_reset_eip"],
+            "kernel_cmdline":        cmdline,
+            "vcpu_type":             entry.get("vcpu_type", "EPYC"),
+            "per_template":          measurements,
+        }
+        if entry.get("cmdline_extra"):
+            out["cmdline_extra"] = entry["cmdline_extra"]
+        json.dump(out, sys.stdout, indent=2)
+        print()
+    else:
+        for tmpl, m in measurements.items():
+            print(f"{tmpl}\t{m}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Promotes #722 from \`dev\` to \`test\`. Single commit:

- \`beeb09c\` — feat(cicd-tee): pin SecretVM v0.0.27-alpha.1, SEV-SNP per-template measurements, baked LOG_LEVEL_* in attestation manifest

## What this delivers to the test environment

- TEE pipeline pinned to **SecretVM v0.0.27-alpha.1** (SCRT Labs' new portal-mandated release)
- AMD SEV-SNP per-template launch digests (×5: small/medium/large/2xlarge/4xlarge) computed in CI and signed into the attestation manifest at \`measurements.amd_sev_snp.per_template\`
- Privacy gate: \`LOG_LEVEL_*\` extracted from \`Dockerfile.tee\` and signed into \`baked_env\`; build hard-fails if \`LOG_LEVEL_APP=debug\` or any required \`LOG_LEVEL_*\` is missing
- \`golden.go\` parser updated (\`amd_sev\` → \`amd_sev_snp\`; \`PerTemplate\` map; \`MatchSEVMeasurement(live)\` helper)
- Hermetic Go ↔ Python parity test ensures CI's \`compute-sev-measurement.py\` stays in lockstep with runtime \`sev_gctx.go\`

## Why this is safe

End-to-end already validated on the cicd branch (run [25120743562](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/25120743562)):

- ✅ Standard image built and pushed to GHCR
- ✅ TEE image built and pushed (with cosign keyless signature + SBOM)
- ✅ SecretVM SEV artifact registry fetched, all 5 per-template SEV measurements computed
- ✅ TDX RTMR3 computed, manifest assembled with \`amd_sev_snp.per_template\` + \`baked_env.LOG_*\` + signed and attached to GHCR
- ✅ Deployed to the new SecretVM test instance (UUID updated by ops to point at v0.0.27-alpha.1 VM)
- ✅ Post-deploy attestation poll: live RTMR3 from VM matched expected RTMR3 from the manifest on attempt 2/12 (after VM reboot)

The dev-branch run ([25122325951](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/25122325951)) is also green; per existing repo policy, GHCR-push and SecretVM-deploy jobs only fire for \`cicd/*\`, \`test\`, and \`main\` branches, so the dev run validated tests + tag generation only. Merging into \`test\` will retrigger the full pipeline (this time with \`:latest-test\` tag promotion).

## Scope explicitly NOT in this PR

- SEV auto-deploy + auto-verify (\`Deploy-SecretVM-Test\` extracts RTMR3 at a TDX-quote-specific offset, so it's still TDX-only). Manual SEV verification works today via the runtime verifier consuming \`SEVPerTemplate\` from the signed manifest. SEV auto-deploy is a tracked follow-up.

## Test plan (after merge to test)

- [ ] CI-CD on \`test\` branch runs cleanly: standard image + TEE image both built, signed, pushed; \`:latest-test\` tag promoted
- [ ] Deploy-SecretVM-Test runs against the new test VM UUID and post-deploy RTMR3 poll matches manifest \`intel_tdx.rtmr3\`
- [ ] Manual: pull manifest from GHCR for the new \`:latest-test\` tag, confirm \`measurements.amd_sev_snp.per_template\` has 5 entries and \`baked_env.LOG_LEVEL_APP=info\` (not debug)


Made with [Cursor](https://cursor.com)