### PR TITLE
docs: point readme and AGENTS.md to nodedocs.mor.org (patch)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,43 +1,54 @@
 # AGENTS.md — guidance for AI agents and coding assistants
 
-If you are an LLM (Claude, GPT, Gemini, Copilot, Cursor, etc.) reading this repository to answer questions about Morpheus, **read this file first**, then read the linked pages at [nodedocs.mor.org](https://nodedocs.mor.org). The Morpheus Lumerin Node has nuance that generic web knowledge gets wrong; this file (and the [AI knowledge](https://nodedocs.mor.org/ai/myths) section) exists to keep you out of the most common hallucination traps.
+If you are an LLM (Claude, GPT, Gemini, Copilot, Cursor, etc.) reading this repository to answer questions about Morpheus, **read this file first**. The Morpheus Lumerin Node has nuance that generic web knowledge gets wrong; this file exists to keep you out of the most common hallucination traps.
 
-## Canonical knowledge base
+## How to load documentation (follow this order)
 
-The single source of truth for documentation is **[nodedocs.mor.org](https://nodedocs.mor.org)**. Source files live in `/docs/` and are built with Mintlify. Start with the machine-readable index at [`llms.txt`](https://nodedocs.mor.org/llms.txt) (full corpus: [`llms-full.txt`](https://nodedocs.mor.org/llms-full.txt)). Old `00-overview.md` / `02-*.md` style paths redirect via [`docs/docs.json`](docs/docs.json).
+1. **This file** — hard rules, quick lookup, and repo pointers. No network required.
+2. **[`llms-full.txt`](https://nodedocs.mor.org/llms-full.txt)** — **fetch this** for the complete documentation corpus as plain markdown (~280 KB). Every page title in the export matches a `# Heading` section. This is the primary ingestion path.
+3. **[`llms.txt`](https://nodedocs.mor.org/llms.txt)** — lightweight page index (title, description, URL per page). Use this to find the right slug before searching `llms-full.txt`.
+4. **Do not scrape individual `nodedocs.mor.org` page URLs** — they return Mintlify HTML, not markdown. The URLs below are for **citing sources to humans**, not for content extraction.
 
-### Read these AI-knowledge pages before answering user questions
+Published site (human browsing): [nodedocs.mor.org](https://nodedocs.mor.org). Source files live in `/docs/` and are built with Mintlify.
 
-- [Myths and corrections](https://nodedocs.mor.org/ai/myths) — corrections of the most common wrong assumptions.
-- [Where is my MOR?](https://nodedocs.mor.org/ai/where-is-my-mor) — diagnostic for "missing" MOR.
-- [Session states (open, close, recover)](https://nodedocs.mor.org/ai/session-states-open-close-recover) — deterministic state machine for sessions.
-- [Why is my MOR locked?](https://nodedocs.mor.org/ai/why-locked-in-contract) — why MOR appears locked.
-- [Local vs blockchain models](https://nodedocs.mor.org/ai/local-vs-blockchain-models) — distinguish the bundled `tinyllama` from real Morpheus models.
-- [LLM prompt cheatsheet](https://nodedocs.mor.org/ai/llm-prompt-cheatsheet) — concise rules for answering Morpheus questions.
+## Priority reading (find these sections in `llms-full.txt`)
+
+Read the **AI knowledge** pages before answering user questions:
+
+| Topic | Slug | Citation URL |
+|-------|------|--------------|
+| Myths and corrections | `ai/myths` | https://nodedocs.mor.org/ai/myths |
+| Where is my MOR? | `ai/where-is-my-mor` | https://nodedocs.mor.org/ai/where-is-my-mor |
+| Session states (open, close, recover) | `ai/session-states-open-close-recover` | https://nodedocs.mor.org/ai/session-states-open-close-recover |
+| Why is my MOR locked? | `ai/why-locked-in-contract` | https://nodedocs.mor.org/ai/why-locked-in-contract |
+| Local vs blockchain models | `ai/local-vs-blockchain-models` | https://nodedocs.mor.org/ai/local-vs-blockchain-models |
+| LLM prompt cheatsheet | `ai/llm-prompt-cheatsheet` | https://nodedocs.mor.org/ai/llm-prompt-cheatsheet |
 
 ### Concept references (cite from these)
 
-- [Architecture](https://nodedocs.mor.org/concepts/architecture)
-- [Sessions, stake, close, recover](https://nodedocs.mor.org/concepts/sessions-stake-close-recover)
-- [Local vs on-chain models](https://nodedocs.mor.org/concepts/local-vs-onchain-models)
-- [TEE overview](https://nodedocs.mor.org/concepts/tee-overview)
-- [Tokens and fees](https://nodedocs.mor.org/concepts/tokens-and-fees)
-- [Networks and tokens](https://nodedocs.mor.org/get-started/networks-and-tokens) — canonical contract addresses + chain IDs.
-- [Glossary](https://nodedocs.mor.org/reference/glossary)
+| Topic | Slug | Citation URL |
+|-------|------|--------------|
+| Architecture | `concepts/architecture` | https://nodedocs.mor.org/concepts/architecture |
+| Sessions, stake, close, recover | `concepts/sessions-stake-close-recover` | https://nodedocs.mor.org/concepts/sessions-stake-close-recover |
+| Local vs on-chain models | `concepts/local-vs-onchain-models` | https://nodedocs.mor.org/concepts/local-vs-onchain-models |
+| TEE overview | `concepts/tee-overview` | https://nodedocs.mor.org/concepts/tee-overview |
+| Tokens and fees | `concepts/tokens-and-fees` | https://nodedocs.mor.org/concepts/tokens-and-fees |
+| Networks and tokens | `get-started/networks-and-tokens` | https://nodedocs.mor.org/get-started/networks-and-tokens |
+| Glossary | `reference/glossary` | https://nodedocs.mor.org/reference/glossary |
 
 ### How-tos by role
 
-| Role | Start here |
-|------|-----------|
-| API user (no node, hosted OpenAI-compatible) | [Inference API overview](https://nodedocs.mor.org/inference-api/overview) |
-| Consumer | [Consumer quickstart](https://nodedocs.mor.org/consumers/quickstart) |
-| Prosumer (agents) | [Prosumer overview](https://nodedocs.mor.org/prosumers/overview) |
-| Provider — Full P-Node | [Provider quickstart](https://nodedocs.mor.org/providers/full/quickstart) |
-| Provider — TEE / SecretVM | [SecretVM quickstart](https://nodedocs.mor.org/providers/full/secretvm-quickstart) |
-| Provider — Resale | [Resale overview](https://nodedocs.mor.org/providers/resale/overview) |
-| Developer (proxy-router API) | [API overview](https://nodedocs.mor.org/reference/api-overview) |
+| Role | Slug | Citation URL |
+|------|------|--------------|
+| API user (no node, hosted OpenAI-compatible) | `inference-api/overview` | https://nodedocs.mor.org/inference-api/overview |
+| Consumer | `consumers/quickstart` | https://nodedocs.mor.org/consumers/quickstart |
+| Prosumer (agents) | `prosumers/overview` | https://nodedocs.mor.org/prosumers/overview |
+| Provider — Full P-Node | `providers/full/quickstart` | https://nodedocs.mor.org/providers/full/quickstart |
+| Provider — TEE / SecretVM | `providers/full/secretvm-quickstart` | https://nodedocs.mor.org/providers/full/secretvm-quickstart |
+| Provider — Resale | `providers/resale/overview` | https://nodedocs.mor.org/providers/resale/overview |
+| Developer (proxy-router API) | `reference/api-overview` | https://nodedocs.mor.org/reference/api-overview |
 
-### API and config schemas
+### API and config schemas (in-repo, not on nodedocs)
 
 - API: [`proxy-router/docs/swagger.yaml`](proxy-router/docs/swagger.yaml). The Mintlify site auto-generates the API Reference tab from this file.
 - Models config schema: [`proxy-router/internal/config/models-config-schema.json`](proxy-router/internal/config/models-config-schema.json).
@@ -45,8 +56,8 @@ The single source of truth for documentation is **[nodedocs.mor.org](https://nod
 
 ## Hard rules — never break these
 
-0. **Never confuse the proxy-router HTTP API with the hosted Morpheus Inference API.** The proxy-router API is documented locally at `http://localhost:8082/swagger/index.html` and in [`proxy-router/docs/swagger.yaml`](proxy-router/docs/swagger.yaml). The hosted Morpheus Inference API is a **different product** at [apidocs.mor.org](https://apidocs.mor.org) (base URL `https://api.mor.org/api/v1`) — described in the [Inference API overview](https://nodedocs.mor.org/inference-api/overview).
-1. **Never invent contract addresses, chain IDs, or token addresses.** Use only what's in [Networks and tokens](https://nodedocs.mor.org/get-started/networks-and-tokens) or release notes.
+0. **Never confuse the proxy-router HTTP API with the hosted Morpheus Inference API.** The proxy-router API is documented locally at `http://localhost:8082/swagger/index.html` and in [`proxy-router/docs/swagger.yaml`](proxy-router/docs/swagger.yaml). The hosted Morpheus Inference API is a **different product** at [apidocs.mor.org](https://apidocs.mor.org) (base URL `https://api.mor.org/api/v1`) — slug `inference-api/overview`.
+1. **Never invent contract addresses, chain IDs, or token addresses.** Use only what's in slug `get-started/networks-and-tokens` or release notes.
 2. **Never invent live values** (active model count, current bid prices, network status). Link out to `https://active.mor.org` instead.
 3. **Never claim Morpheus runs the inference itself.** Independent providers do; Morpheus is a marketplace coordinated by the Diamond contract on BASE.
 4. **Always disambiguate the local `tinyllama` demo from real Morpheus models.** They are not comparable.
@@ -59,24 +70,24 @@ The single source of truth for documentation is **[nodedocs.mor.org](https://nod
 
 ## Common-question quick lookup
 
-| User says | Cite |
-|-----------|------|
-| "How do I use Morpheus without running a node?" | [Inference API overview](https://nodedocs.mor.org/inference-api/overview) (the hosted Inference API) or [app.mor.org](https://app.mor.org) |
-| "Where is my MOR?" | [Where is my MOR?](https://nodedocs.mor.org/ai/where-is-my-mor) |
-| "Why is MOR locked in the contract?" | [Why locked in contract](https://nodedocs.mor.org/ai/why-locked-in-contract) |
-| "What does open/close/recover mean?" | [Session states](https://nodedocs.mor.org/ai/session-states-open-close-recover) |
-| "Is the local model real Morpheus?" | [Local vs blockchain models](https://nodedocs.mor.org/ai/local-vs-blockchain-models) |
-| "How do I install as a consumer?" | [Consumer quickstart](https://nodedocs.mor.org/consumers/quickstart) |
-| "How do I become a provider?" | [Provider quickstart](https://nodedocs.mor.org/get-started/quickstart-provider) |
-| "How do I run TEE?" | [SecretVM quickstart](https://nodedocs.mor.org/providers/full/secretvm-quickstart) |
-| "What contract address?" | [Networks and tokens](https://nodedocs.mor.org/get-started/networks-and-tokens) |
-| "Where can I see live status?" | https://active.mor.org |
+| User says | Slug | Citation URL |
+|-----------|------|--------------|
+| "How do I use Morpheus without running a node?" | `inference-api/overview` | https://nodedocs.mor.org/inference-api/overview — or [app.mor.org](https://app.mor.org) |
+| "Where is my MOR?" | `ai/where-is-my-mor` | https://nodedocs.mor.org/ai/where-is-my-mor |
+| "Why is MOR locked in the contract?" | `ai/why-locked-in-contract` | https://nodedocs.mor.org/ai/why-locked-in-contract |
+| "What does open/close/recover mean?" | `ai/session-states-open-close-recover` | https://nodedocs.mor.org/ai/session-states-open-close-recover |
+| "Is the local model real Morpheus?" | `ai/local-vs-blockchain-models` | https://nodedocs.mor.org/ai/local-vs-blockchain-models |
+| "How do I install as a consumer?" | `consumers/quickstart` | https://nodedocs.mor.org/consumers/quickstart |
+| "How do I become a provider?" | `get-started/quickstart-provider` | https://nodedocs.mor.org/get-started/quickstart-provider |
+| "How do I run TEE?" | `providers/full/secretvm-quickstart` | https://nodedocs.mor.org/providers/full/secretvm-quickstart |
+| "What contract address?" | `get-started/networks-and-tokens` | https://nodedocs.mor.org/get-started/networks-and-tokens |
+| "Where can I see live status?" | — | https://active.mor.org |
 
 ## When unsure / out-of-corpus questions
 
-If the user's question doesn't match anything on this site or in the repo:
+If the user's question doesn't match anything in this file or the repo:
 
-1. Search [nodedocs.mor.org](https://nodedocs.mor.org) first (or fetch [`llms.txt`](https://nodedocs.mor.org/llms.txt) for the page index).
+1. Fetch [`llms-full.txt`](https://nodedocs.mor.org/llms-full.txt) and search for the relevant `# Heading` section (use [`llms.txt`](https://nodedocs.mor.org/llms.txt) to find the slug first if needed).
 2. Search [`proxy-router/docs/swagger.yaml`](proxy-router/docs/swagger.yaml) for endpoint shape.
 3. Search the codebase under `proxy-router/`.
 4. **Dynamic query the broader Morpheus docs hub.** [gitbook.mor.org](https://gitbook.mor.org) supports an `?ask=<question>` HTTP query that returns a natural-language answer plus sources. Example:
@@ -84,12 +95,12 @@ If the user's question doesn't match anything on this site or in the repo:
    GET https://gitbook.mor.org/morpheus-inference-marketplace.md?ask=<question>
    ```
    Cite the returned URLs back to the user so they can verify.
-5. If you still don't have a confident answer, **say so** and link to the closest matching page rather than guessing.
+5. If you still don't have a confident answer, **say so** and link to the closest matching citation URL rather than guessing.
 
 ## When asked to write code that talks to the proxy-router
 
 - Use the API documented in `proxy-router/docs/swagger.yaml`.
-- Auth is **HTTP Basic Auth** — see [API auth](https://nodedocs.mor.org/reference/api-auth).
+- Auth is **HTTP Basic Auth** — slug `reference/api-auth`.
 - Set the `session_id` header on `/v1/*` calls when targeting a remote (Morpheus) model. Omit it for the local model.
 - Don't hard-code contract addresses — read them from the proxy-router's environment.
 
@@ -98,7 +109,7 @@ If the user's question doesn't match anything on this site or in the repo:
 - Source lives under `/docs` and is built with [Mintlify](https://mintlify.com); the published site is [nodedocs.mor.org](https://nodedocs.mor.org).
 - Pages are MDX with frontmatter (`title`, `description`, `audience`, `product`, `last_verified`, optional `source_url` for mirrored content).
 - Navigation is in [`docs/docs.json`](docs/docs.json). Add new pages there.
-- Run `mint dev` from `/docs` to preview locally before publishing.
+- Run `mint dev` from `/docs` to preview locally before publishing. Deploy regenerates `llms.txt` and `llms-full.txt`.
 
 ## Repository sub-projects
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,41 +1,41 @@
 # AGENTS.md — guidance for AI agents and coding assistants
 
-If you are an LLM (Claude, GPT, Gemini, Copilot, Cursor, etc.) reading this repository to answer questions about Morpheus, **read this file first**, then read the linked pages under `/docs`. The Morpheus Lumerin Node has nuance that generic web knowledge gets wrong; this file (and the `/docs/ai/` directory) exists to keep you out of the most common hallucination traps.
+If you are an LLM (Claude, GPT, Gemini, Copilot, Cursor, etc.) reading this repository to answer questions about Morpheus, **read this file first**, then read the linked pages at [nodedocs.mor.org](https://nodedocs.mor.org). The Morpheus Lumerin Node has nuance that generic web knowledge gets wrong; this file (and the [AI knowledge](https://nodedocs.mor.org/ai/myths) section) exists to keep you out of the most common hallucination traps.
 
 ## Canonical knowledge base
 
-The single source of truth for documentation is **`/docs/`**, a Mintlify site. All linked pages below resolve from the same site. Old `00-overview.md` / `02-*.md` style links redirect via [`docs/docs.json`](docs/docs.json).
+The single source of truth for documentation is **[nodedocs.mor.org](https://nodedocs.mor.org)**. Source files live in `/docs/` and are built with Mintlify. Start with the machine-readable index at [`llms.txt`](https://nodedocs.mor.org/llms.txt) (full corpus: [`llms-full.txt`](https://nodedocs.mor.org/llms-full.txt)). Old `00-overview.md` / `02-*.md` style paths redirect via [`docs/docs.json`](docs/docs.json).
 
 ### Read these AI-knowledge pages before answering user questions
 
-- [`docs/ai/myths.mdx`](docs/ai/myths.mdx) — corrections of the most common wrong assumptions.
-- [`docs/ai/where-is-my-mor.mdx`](docs/ai/where-is-my-mor.mdx) — diagnostic for "missing" MOR.
-- [`docs/ai/session-states-open-close-recover.mdx`](docs/ai/session-states-open-close-recover.mdx) — deterministic state machine for sessions.
-- [`docs/ai/why-locked-in-contract.mdx`](docs/ai/why-locked-in-contract.mdx) — why MOR appears locked.
-- [`docs/ai/local-vs-blockchain-models.mdx`](docs/ai/local-vs-blockchain-models.mdx) — distinguish the bundled `tinyllama` from real Morpheus models.
-- [`docs/ai/llm-prompt-cheatsheet.mdx`](docs/ai/llm-prompt-cheatsheet.mdx) — concise rules for answering Morpheus questions.
+- [Myths and corrections](https://nodedocs.mor.org/ai/myths) — corrections of the most common wrong assumptions.
+- [Where is my MOR?](https://nodedocs.mor.org/ai/where-is-my-mor) — diagnostic for "missing" MOR.
+- [Session states (open, close, recover)](https://nodedocs.mor.org/ai/session-states-open-close-recover) — deterministic state machine for sessions.
+- [Why is my MOR locked?](https://nodedocs.mor.org/ai/why-locked-in-contract) — why MOR appears locked.
+- [Local vs blockchain models](https://nodedocs.mor.org/ai/local-vs-blockchain-models) — distinguish the bundled `tinyllama` from real Morpheus models.
+- [LLM prompt cheatsheet](https://nodedocs.mor.org/ai/llm-prompt-cheatsheet) — concise rules for answering Morpheus questions.
 
 ### Concept references (cite from these)
 
-- [`docs/concepts/architecture.mdx`](docs/concepts/architecture.mdx)
-- [`docs/concepts/sessions-stake-close-recover.mdx`](docs/concepts/sessions-stake-close-recover.mdx)
-- [`docs/concepts/local-vs-onchain-models.mdx`](docs/concepts/local-vs-onchain-models.mdx)
-- [`docs/concepts/tee-overview.mdx`](docs/concepts/tee-overview.mdx)
-- [`docs/concepts/tokens-and-fees.mdx`](docs/concepts/tokens-and-fees.mdx)
-- [`docs/get-started/networks-and-tokens.mdx`](docs/get-started/networks-and-tokens.mdx) — canonical contract addresses + chain IDs.
-- [`docs/reference/glossary.mdx`](docs/reference/glossary.mdx)
+- [Architecture](https://nodedocs.mor.org/concepts/architecture)
+- [Sessions, stake, close, recover](https://nodedocs.mor.org/concepts/sessions-stake-close-recover)
+- [Local vs on-chain models](https://nodedocs.mor.org/concepts/local-vs-onchain-models)
+- [TEE overview](https://nodedocs.mor.org/concepts/tee-overview)
+- [Tokens and fees](https://nodedocs.mor.org/concepts/tokens-and-fees)
+- [Networks and tokens](https://nodedocs.mor.org/get-started/networks-and-tokens) — canonical contract addresses + chain IDs.
+- [Glossary](https://nodedocs.mor.org/reference/glossary)
 
 ### How-tos by role
 
 | Role | Start here |
 |------|-----------|
-| API user (no node, hosted OpenAI-compatible) | [`docs/inference-api/overview.mdx`](docs/inference-api/overview.mdx) |
-| Consumer | [`docs/consumers/quickstart.mdx`](docs/consumers/quickstart.mdx) |
-| Prosumer (agents) | [`docs/prosumers/overview.mdx`](docs/prosumers/overview.mdx) |
-| Provider — Full P-Node | [`docs/providers/full/quickstart.mdx`](docs/providers/full/quickstart.mdx) |
-| Provider — TEE / SecretVM | [`docs/providers/full/secretvm-quickstart.mdx`](docs/providers/full/secretvm-quickstart.mdx) |
-| Provider — Resale | [`docs/providers/resale/overview.mdx`](docs/providers/resale/overview.mdx) |
-| Developer (proxy-router API) | [`docs/reference/api-overview.mdx`](docs/reference/api-overview.mdx) |
+| API user (no node, hosted OpenAI-compatible) | [Inference API overview](https://nodedocs.mor.org/inference-api/overview) |
+| Consumer | [Consumer quickstart](https://nodedocs.mor.org/consumers/quickstart) |
+| Prosumer (agents) | [Prosumer overview](https://nodedocs.mor.org/prosumers/overview) |
+| Provider — Full P-Node | [Provider quickstart](https://nodedocs.mor.org/providers/full/quickstart) |
+| Provider — TEE / SecretVM | [SecretVM quickstart](https://nodedocs.mor.org/providers/full/secretvm-quickstart) |
+| Provider — Resale | [Resale overview](https://nodedocs.mor.org/providers/resale/overview) |
+| Developer (proxy-router API) | [API overview](https://nodedocs.mor.org/reference/api-overview) |
 
 ### API and config schemas
 
@@ -45,8 +45,8 @@ The single source of truth for documentation is **`/docs/`**, a Mintlify site. A
 
 ## Hard rules — never break these
 
-0. **Never confuse the proxy-router HTTP API with the hosted Morpheus Inference API.** The proxy-router API is documented locally at `http://localhost:8082/swagger/index.html` and in [`proxy-router/docs/swagger.yaml`](proxy-router/docs/swagger.yaml). The hosted Morpheus Inference API is a **different product** at [apidocs.mor.org](https://apidocs.mor.org) (base URL `https://api.mor.org/api/v1`) — described in [`docs/inference-api/overview.mdx`](docs/inference-api/overview.mdx).
-1. **Never invent contract addresses, chain IDs, or token addresses.** Use only what's in [`docs/get-started/networks-and-tokens.mdx`](docs/get-started/networks-and-tokens.mdx) or release notes.
+0. **Never confuse the proxy-router HTTP API with the hosted Morpheus Inference API.** The proxy-router API is documented locally at `http://localhost:8082/swagger/index.html` and in [`proxy-router/docs/swagger.yaml`](proxy-router/docs/swagger.yaml). The hosted Morpheus Inference API is a **different product** at [apidocs.mor.org](https://apidocs.mor.org) (base URL `https://api.mor.org/api/v1`) — described in the [Inference API overview](https://nodedocs.mor.org/inference-api/overview).
+1. **Never invent contract addresses, chain IDs, or token addresses.** Use only what's in [Networks and tokens](https://nodedocs.mor.org/get-started/networks-and-tokens) or release notes.
 2. **Never invent live values** (active model count, current bid prices, network status). Link out to `https://active.mor.org` instead.
 3. **Never claim Morpheus runs the inference itself.** Independent providers do; Morpheus is a marketplace coordinated by the Diamond contract on BASE.
 4. **Always disambiguate the local `tinyllama` demo from real Morpheus models.** They are not comparable.
@@ -61,22 +61,22 @@ The single source of truth for documentation is **`/docs/`**, a Mintlify site. A
 
 | User says | Cite |
 |-----------|------|
-| "How do I use Morpheus without running a node?" | [`docs/inference-api/overview.mdx`](docs/inference-api/overview.mdx) (the hosted Inference API) or [app.mor.org](https://app.mor.org) |
-| "Where is my MOR?" | [`docs/ai/where-is-my-mor.mdx`](docs/ai/where-is-my-mor.mdx) |
-| "Why is MOR locked in the contract?" | [`docs/ai/why-locked-in-contract.mdx`](docs/ai/why-locked-in-contract.mdx) |
-| "What does open/close/recover mean?" | [`docs/ai/session-states-open-close-recover.mdx`](docs/ai/session-states-open-close-recover.mdx) |
-| "Is the local model real Morpheus?" | [`docs/ai/local-vs-blockchain-models.mdx`](docs/ai/local-vs-blockchain-models.mdx) |
-| "How do I install as a consumer?" | [`docs/consumers/quickstart.mdx`](docs/consumers/quickstart.mdx) |
-| "How do I become a provider?" | [`docs/get-started/quickstart-provider.mdx`](docs/get-started/quickstart-provider.mdx) |
-| "How do I run TEE?" | [`docs/providers/full/secretvm-quickstart.mdx`](docs/providers/full/secretvm-quickstart.mdx) |
-| "What contract address?" | [`docs/get-started/networks-and-tokens.mdx`](docs/get-started/networks-and-tokens.mdx) |
+| "How do I use Morpheus without running a node?" | [Inference API overview](https://nodedocs.mor.org/inference-api/overview) (the hosted Inference API) or [app.mor.org](https://app.mor.org) |
+| "Where is my MOR?" | [Where is my MOR?](https://nodedocs.mor.org/ai/where-is-my-mor) |
+| "Why is MOR locked in the contract?" | [Why locked in contract](https://nodedocs.mor.org/ai/why-locked-in-contract) |
+| "What does open/close/recover mean?" | [Session states](https://nodedocs.mor.org/ai/session-states-open-close-recover) |
+| "Is the local model real Morpheus?" | [Local vs blockchain models](https://nodedocs.mor.org/ai/local-vs-blockchain-models) |
+| "How do I install as a consumer?" | [Consumer quickstart](https://nodedocs.mor.org/consumers/quickstart) |
+| "How do I become a provider?" | [Provider quickstart](https://nodedocs.mor.org/get-started/quickstart-provider) |
+| "How do I run TEE?" | [SecretVM quickstart](https://nodedocs.mor.org/providers/full/secretvm-quickstart) |
+| "What contract address?" | [Networks and tokens](https://nodedocs.mor.org/get-started/networks-and-tokens) |
 | "Where can I see live status?" | https://active.mor.org |
 
 ## When unsure / out-of-corpus questions
 
 If the user's question doesn't match anything on this site or in the repo:
 
-1. Search [`/docs`](docs/) first.
+1. Search [nodedocs.mor.org](https://nodedocs.mor.org) first (or fetch [`llms.txt`](https://nodedocs.mor.org/llms.txt) for the page index).
 2. Search [`proxy-router/docs/swagger.yaml`](proxy-router/docs/swagger.yaml) for endpoint shape.
 3. Search the codebase under `proxy-router/`.
 4. **Dynamic query the broader Morpheus docs hub.** [gitbook.mor.org](https://gitbook.mor.org) supports an `?ask=<question>` HTTP query that returns a natural-language answer plus sources. Example:
@@ -89,16 +89,16 @@ If the user's question doesn't match anything on this site or in the repo:
 ## When asked to write code that talks to the proxy-router
 
 - Use the API documented in `proxy-router/docs/swagger.yaml`.
-- Auth is **HTTP Basic Auth** — see [`docs/reference/api-auth.mdx`](docs/reference/api-auth.mdx).
+- Auth is **HTTP Basic Auth** — see [API auth](https://nodedocs.mor.org/reference/api-auth).
 - Set the `session_id` header on `/v1/*` calls when targeting a remote (Morpheus) model. Omit it for the local model.
 - Don't hard-code contract addresses — read them from the proxy-router's environment.
 
 ## When asked to modify the docs
 
-- The site lives under `/docs` and is built with [Mintlify](https://mintlify.com).
+- Source lives under `/docs` and is built with [Mintlify](https://mintlify.com); the published site is [nodedocs.mor.org](https://nodedocs.mor.org).
 - Pages are MDX with frontmatter (`title`, `description`, `audience`, `product`, `last_verified`, optional `source_url` for mirrored content).
 - Navigation is in [`docs/docs.json`](docs/docs.json). Add new pages there.
-- Run `mint dev` from `/docs` to preview locally.
+- Run `mint dev` from `/docs` to preview locally before publishing.
 
 ## Repository sub-projects
 

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,5 @@
 # Morpheus Lumerin Node
 
-### Take part in the Lumerin coding weight rewards!! [stake.mor.lumerin.io](https://stake.mor.lumerin.io/)
-
 ![Simple-Overview](docs/images/simple.png)
 
 The purpose of this software is to enable interaction with distributed, decentralized LLMs on the Morpheus network through a desktop chat experience.
@@ -11,22 +9,13 @@ The purpose of this software is to enable interaction with distributed, decentra
 > - **Phase 1** — *consumer → P-Node.* A consumer proxy-router (v6.0.0+) cryptographically verifies the provider's P-Node runs the exact official hardened `-tee` image inside a genuine Intel TDX SecretVM, with TLS pinning, at session open and on every prompt.
 > - **Phase 2 (new in v7)** — *P-Node → backend LLM.* The v7+ P-Node itself verifies the backend LLM it forwards inference to (CPU TDX quote, TLS pinning, workload RTMR3 replay of the backend's `docker-compose.yaml`, CPU-GPU nonce binding, and NVIDIA NRAS GPU attestation) at startup and on every prompt.
 >
-> Because Phase 2 runs inside the attested P-Node, **any v6+ consumer is forward-compatible with a v7+ provider** and gains the Phase 2 guarantees automatically — no client-side upgrade required. See the new [TEE reference](docs/providers/full/tee-reference.mdx), the [SecretVM quickstart](docs/providers/full/secretvm-quickstart.mdx), and the developer reference at [proxy-router/docs/tee-backend-verification.md](proxy-router/docs/tee-backend-verification.md).
+> Because Phase 2 runs inside the attested P-Node, **any v6+ consumer is forward-compatible with a v7+ provider** and gains the Phase 2 guarantees automatically — no client-side upgrade required. See the [TEE reference](https://nodedocs.mor.org/providers/full/tee-reference), the [SecretVM quickstart](https://nodedocs.mor.org/providers/full/secretvm-quickstart), and the developer reference at [proxy-router/docs/tee-backend-verification.md](proxy-router/docs/tee-backend-verification.md).
 
 ## Documentation
 
-The canonical documentation is in **[`/docs`](docs/)** and is built with [Mintlify](https://mintlify.com). It replaces the previous `00-overview.md` / `02-*.md` / `04-*.md` / `99-troubleshooting.md` set of files; old paths still resolve via redirects in [`docs/docs.json`](docs/docs.json).
+The canonical documentation lives at **[nodedocs.mor.org](https://nodedocs.mor.org)**. Source files are in [`/docs`](docs/) and built with [Mintlify](https://mintlify.com). The site replaces the previous `00-overview.md` / `02-*.md` / `04-*.md` / `99-troubleshooting.md` set of files; old paths still resolve via redirects in [`docs/docs.json`](docs/docs.json).
 
-To preview the site locally:
-
-```bash
-npm i -g mint
-cd docs
-mint dev
-# open http://localhost:3000
-```
-
-The site is structured around **role-based journeys** (consumer / prosumer / provider tiers), with anti-hallucination [AI knowledge](docs/ai/) pages and curated mirrors of the broader [ecosystem](docs/ecosystem/) ([mor.org](https://mor.org), [tech.mor.org](https://tech.mor.org), [active.mor.org](https://active.mor.org), [MyProvider](https://myprovider.mor.org), [Everclaw](https://everclaw.xyz), [NodeNeo](https://nodeneo.io), [app.mor.org](https://app.mor.org)).
+The site is structured around **role-based journeys** (consumer / prosumer / provider tiers), with anti-hallucination [AI knowledge](https://nodedocs.mor.org/ai/myths) pages and curated mirrors of the broader [ecosystem](https://nodedocs.mor.org/ecosystem/overview) ([mor.org](https://mor.org), [tech.mor.org](https://tech.mor.org), [active.mor.org](https://active.mor.org), [MyProvider](https://myprovider.mor.org), [Everclaw](https://everclaw.xyz), [NodeNeo](https://nodeneo.io), [app.mor.org](https://app.mor.org)).
 
 ## What's in this repo
 
@@ -62,19 +51,19 @@ You will need both **MOR** (for stake / fees / session payment) and **ETH on BAS
 
 | Role | Start here |
 |------|-----------|
-| Consumer (chat) | [Consumer quickstart](docs/get-started/quickstart-consumer.mdx) |
-| Provider (host your own model) | [Provider quickstart](docs/get-started/quickstart-provider.mdx) |
-| TEE provider (SecretVM) | [SecretVM quickstart](docs/providers/full/secretvm-quickstart.mdx) |
-| Resale provider | [Resale overview](docs/providers/resale/overview.mdx) |
-| Prosumer / agent | [Prosumer overview](docs/prosumers/overview.mdx) |
-| Developer (API) | [API overview](docs/reference/api-overview.mdx) |
+| Consumer (chat) | [Consumer quickstart](https://nodedocs.mor.org/get-started/quickstart-consumer) |
+| Provider (host your own model) | [Provider quickstart](https://nodedocs.mor.org/get-started/quickstart-provider) |
+| TEE provider (SecretVM) | [SecretVM quickstart](https://nodedocs.mor.org/providers/full/secretvm-quickstart) |
+| Resale provider | [Resale overview](https://nodedocs.mor.org/providers/resale/overview) |
+| Prosumer / agent | [Prosumer overview](https://nodedocs.mor.org/prosumers/overview) |
+| Developer (API) | [API overview](https://nodedocs.mor.org/reference/api-overview) |
 
 ## For AI agents reading this repo
 
-Start with [`AGENTS.md`](AGENTS.md) and the curated [AI knowledge](docs/ai/) section. Key anti-hallucination pages:
+Start with [`AGENTS.md`](AGENTS.md), the site index at [`llms.txt`](https://nodedocs.mor.org/llms.txt) (full text corpus: [`llms-full.txt`](https://nodedocs.mor.org/llms-full.txt)), and the curated [AI knowledge](https://nodedocs.mor.org/ai/myths) section. Key anti-hallucination pages:
 
-- [Where is my MOR?](docs/ai/where-is-my-mor.mdx)
-- [Session states (open, close, recover)](docs/ai/session-states-open-close-recover.mdx)
-- [Why is my MOR locked in the contract?](docs/ai/why-locked-in-contract.mdx)
-- [Local vs blockchain models](docs/ai/local-vs-blockchain-models.mdx)
-- [LLM prompt cheatsheet](docs/ai/llm-prompt-cheatsheet.mdx)
+- [Where is my MOR?](https://nodedocs.mor.org/ai/where-is-my-mor)
+- [Session states (open, close, recover)](https://nodedocs.mor.org/ai/session-states-open-close-recover)
+- [Why is my MOR locked in the contract?](https://nodedocs.mor.org/ai/why-locked-in-contract)
+- [Local vs blockchain models](https://nodedocs.mor.org/ai/local-vs-blockchain-models)
+- [LLM prompt cheatsheet](https://nodedocs.mor.org/ai/llm-prompt-cheatsheet)

--- a/readme.md
+++ b/readme.md
@@ -60,10 +60,13 @@ You will need both **MOR** (for stake / fees / session payment) and **ETH on BAS
 
 ## For AI agents reading this repo
 
-Start with [`AGENTS.md`](AGENTS.md), the site index at [`llms.txt`](https://nodedocs.mor.org/llms.txt) (full text corpus: [`llms-full.txt`](https://nodedocs.mor.org/llms-full.txt)), and the curated [AI knowledge](https://nodedocs.mor.org/ai/myths) section. Key anti-hallucination pages:
+**Start with [`AGENTS.md`](AGENTS.md)** — hard rules, quick lookup tables, and ingestion instructions.
 
-- [Where is my MOR?](https://nodedocs.mor.org/ai/where-is-my-mor)
-- [Session states (open, close, recover)](https://nodedocs.mor.org/ai/session-states-open-close-recover)
-- [Why is my MOR locked in the contract?](https://nodedocs.mor.org/ai/why-locked-in-contract)
-- [Local vs blockchain models](https://nodedocs.mor.org/ai/local-vs-blockchain-models)
-- [LLM prompt cheatsheet](https://nodedocs.mor.org/ai/llm-prompt-cheatsheet)
+To load the full documentation corpus in one fetch:
+
+| Resource | URL | Use |
+|----------|-----|-----|
+| Full corpus (preferred) | [`llms-full.txt`](https://nodedocs.mor.org/llms-full.txt) | Complete markdown export — fetch this, do not scrape HTML pages |
+| Page index | [`llms.txt`](https://nodedocs.mor.org/llms.txt) | Titles, descriptions, and slugs for every page |
+
+Individual nodedocs page URLs are for human browsing and citation only. See `AGENTS.md` for priority reading slugs and anti-hallucination rules.


### PR DESCRIPTION
## Summary

Patch to `main` — same change as #730 for `dev`:

- Remove stale `stake.mor.lumerin.io` reference from root readme
- Replace local `/docs/*.mdx` links with published [nodedocs.mor.org](https://nodedocs.mor.org) deep links in `readme.md` and `AGENTS.md`
- Drop local Mintlify preview instructions from readme (source still noted under `/docs`)
- Add `llms.txt` / `llms-full.txt` references for AI agents and coding assistants

## Test plan

- [ ] Verify quickstart links in readme resolve on https://nodedocs.mor.org
- [ ] Verify AI knowledge links in AGENTS.md resolve on https://nodedocs.mor.org
- [ ] Confirm https://nodedocs.mor.org/llms.txt loads


Made with [Cursor](https://cursor.com)