### PR TITLE
fix(docs): Pagefind navbar search for self-hosted nodedocs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -253,9 +253,6 @@
       }
     ]
   },
-  "search": {
-    "prompt": "Ask anything about Morpheus, the proxy-router, sessions, or providers..."
-  },
   "redirects": [
     { "source": "/00-overview", "destination": "/concepts/architecture" },
     { "source": "/01-model-setup", "destination": "/providers/full/model-setup" },

--- a/docs/scripts/build-site.mjs
+++ b/docs/scripts/build-site.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Build static docs site: mint export → postprocess (Pagefind + llms.txt).
+ * Build static docs site: mint export → postprocess (Pagefind navbar search + llms.txt).
  * Usage: SITE_URL=https://nodedocs.mor.org node scripts/build-site.mjs [outDir]
  */
 import { execSync } from "child_process";

--- a/docs/scripts/postprocess-export.mjs
+++ b/docs/scripts/postprocess-export.mjs
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 /**
- * Post-process a mint export directory: Pagefind index + UI hook + llms.txt.
+ * Post-process a mint export directory: Pagefind index + navbar search + llms.txt.
+ *
+ * Mintlify's built-in search (docs.json "search") targets Mintlify Cloud and prompts
+ * for CLI login on self-hosted S3/CloudFront exports. We use Pagefind (static index)
+ * in the top navbar instead.
+ *
  * Usage: SITE_URL=https://nodedocs.mor.org node scripts/postprocess-export.mjs <siteDir>
  */
 import { execSync } from "child_process";
@@ -28,27 +33,62 @@ execSync(
 );
 
 const pagefindSnippet = `
-<link href="/pagefind/pagefind-ui.css" rel="stylesheet">
-<script src="/pagefind/pagefind-ui.js"></script>
-<script>
-  window.addEventListener("DOMContentLoaded", function () {
-    if (typeof PagefindUI === "undefined") return;
-    var mount = document.createElement("di" + "v");
-    mount.id = "pagefind-ui";
-    mount.style.cssText = "position:fixed;bottom:1rem;right:1rem;z-index:9999;max-width:420px;width:100%;";
-    document.body.appendChild(mount);
-    new PagefindUI({
-      element: "#pagefind-ui",
-      showSubResults: true,
-      resetStyles: false
-    });
-  });
+<link href="/pagefind/pagefind-component-ui.css" rel="stylesheet">
+<style>
+  /* Mintlify export still renders cloud-search buttons; we replace them with Pagefind. */
+  #search-bar-entry,
+  #search-bar-entry-mobile {
+    display: none !important;
+  }
+  .nodedocs-navbar-search {
+    width: 100%;
+    max-width: 36rem;
+  }
+  .nodedocs-navbar-search pagefind-searchbox {
+    display: block;
+    width: 100%;
+  }
+</style>
+<script type="module">
+  import "/pagefind/pagefind-component-ui.js";
+
+  function mountNavbarSearch() {
+    const desktopSlot =
+      document.getElementById("search-bar-entry")?.parentElement ??
+      document.querySelector("#navbar .justify-center");
+
+    if (desktopSlot && !desktopSlot.querySelector("pagefind-searchbox")) {
+      desktopSlot.innerHTML = "";
+      desktopSlot.classList.add("nodedocs-navbar-search");
+      const searchbox = document.createElement("pagefind-searchbox");
+      searchbox.setAttribute(
+        "placeholder",
+        "Search documentation…"
+      );
+      desktopSlot.appendChild(searchbox);
+    }
+
+    const mobileBtn = document.getElementById("search-bar-entry-mobile");
+    if (mobileBtn && !mobileBtn.dataset.pagefindReplaced) {
+      mobileBtn.dataset.pagefindReplaced = "true";
+      mobileBtn.style.display = "none";
+      const trigger = document.createElement("pagefind-modal-trigger");
+      trigger.setAttribute("aria-label", "Search documentation");
+      mobileBtn.insertAdjacentElement("afterend", trigger);
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", mountNavbarSearch);
+  } else {
+    mountNavbarSearch();
+  }
 </script>
 `;
 
 function injectPagefind(htmlPath) {
   let html = fs.readFileSync(htmlPath, "utf8");
-  if (html.includes("pagefind-ui.js")) return;
+  if (html.includes("pagefind-component-ui.js")) return;
   if (html.includes("</body>")) {
     html = html.replace("</body>", `${pagefindSnippet}\n</body>`);
     fs.writeFileSync(htmlPath, html);
@@ -66,7 +106,7 @@ function walkHtml(dir) {
   }
 }
 
-console.log("Injecting Pagefind UI…");
+console.log("Injecting Pagefind navbar search…");
 walkHtml(siteDir);
 
 console.log("Post-process complete.");


### PR DESCRIPTION
## Summary
- Backport of #738 (already on `test`): remove Mintlify cloud `search` config and mount **Pagefind** in the top navbar for static S3/CloudFront deploys.
- Removes the duplicate bottom-right Pagefind widget.

## Context
Brings `dev` in line with `test` for docs search behavior. After #739 (Alex branding) and this PR merge, `dev` and `test` will have parity on:
- Pagefind navbar search (#738 / this PR)
- Logo + green brand colors (#737 / #739 on test)

## Test plan
- [ ] Merge to `dev`
- [ ] Docs workflow validates on PR
- [ ] After next `test` deploy, spot-check https://nodedocs.dev.mor.org


Made with [Cursor](https://cursor.com)