### PR TITLE
fix(tee): pin SecretVM to v0.0.26-beta.1 for portal Production deploys

### DIFF
--- a/.github/tee/secretvm.env
+++ b/.github/tee/secretvm.env
@@ -8,32 +8,33 @@
 # IMPORTANT: Always use the "prod" rootfs variant — SecretVM runs "environment prod"
 # even for developer portal deployments. Using "dev" rootfs produces wrong measurements.
 #
-# Compatibility note (2026-05-23):
-#   GitHub latest stable Production release is v0.0.27 (non-prerelease). TDX and SEV
-#   verify registries both publish prod entries for this version. The SecretVM portal UI
-#   may still show an older artifacts version (e.g. v0.0.26-beta.1) until SCRT rolls the
-#   cluster forward — CI/manifests pin to v0.0.27 regardless. Existing VMs on older
-#   rootfs continue to run; RTMR3/SEV verification requires the VM rootfs to match.
+# Compatibility note (2026-05-29):
+#   The SecretVM portal Production environment currently only allows
+#   v0.0.26-beta.1 for new VM provisioning. GitHub may list newer stable releases
+#   (e.g. v0.0.27) but those cannot be deployed until SCRT rolls the cluster forward.
 
-SECRETVM_RELEASE=v0.0.27
+SECRETVM_RELEASE=v0.0.26-beta.1
 SECRETVM_ROOTFS_VARIANT=rootfs-prod
 
 # Intel TDX rootfs (non-GPU, prod — used for proxy-router P-Node deployments)
 # URL pattern: .../download/${RELEASE}/${VARIANT}-${RELEASE}-tdx.iso
-SECRETVM_ROOTFS_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.27/rootfs-prod-v0.0.27-tdx.iso
-SECRETVM_ROOTFS_TDX_SHA256=1a5d9ea46607fe46f0ad8055ee01afa033aaded7251a38253baff470d33506c8
+SECRETVM_ROOTFS_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.26-beta.1/rootfs-prod-v0.0.26-beta.1-tdx.iso
+SECRETVM_ROOTFS_TDX_SHA256=780214c693218c6c13342526571705b8152f7b3139eba46b53a49d0d27cf68fe
 
 # AMD SEV-SNP rootfs (prod) — same compose, different platform binary
 # URL pattern: .../download/${RELEASE}/${VARIANT}-${RELEASE}-sev.iso
-SECRETVM_ROOTFS_SEV_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.27/rootfs-prod-v0.0.27-sev.iso
-SECRETVM_ROOTFS_SEV_SHA256=17122d51dbaed224d08bc0c17e72d7047d60175c7274a0d366167fc29b3fe4cf
+SECRETVM_ROOTFS_SEV_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.26-beta.1/rootfs-prod-v0.0.26-beta.1-sev.iso
+SECRETVM_ROOTFS_SEV_SHA256=30abaaa5cff341c9d1b6c509f965d1a18c6b2fd446cf46d4ec2602ab3f06ff5c
 
 # SEV artifact registry — kernel/initrd/ovmf hashes + ovmf_sections for measurement compute.
 # Pulled from scrtlabs/secretvm-verify; pipeline picks the entry whose `vm_type` and
-# `artifacts_ver` match SECRETVM_SEV_REGISTRY_VM_TYPE (prod) and SECRETVM_RELEASE.
+# `artifacts_ver` match SECRETVM_SEV_REGISTRY_VM_TYPE and SECRETVM_SEV_REGISTRY_ARTIFACTS_VER.
+# Note: the portal offers v0.0.26-beta.1 rootfs while the verify registry only lists
+# v0.0.26-beta.2 for prod SEV metadata — override below keeps CI measurement working.
 SECRETVM_SEV_REGISTRY_URL=https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/sev.json
 SECRETVM_SEV_REGISTRY_VM_TYPE=prod
+SECRETVM_SEV_REGISTRY_ARTIFACTS_VER=v0.0.26-beta.2
 
 # GPU variant (for co-located proxy+LLM deployments)
-# SECRETVM_ROOTFS_GPU_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.27/rootfs-gpu-prod-v0.0.27-tdx.iso
+# SECRETVM_ROOTFS_GPU_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.26-beta.1/rootfs-gpu-prod-v0.0.26-beta.1-tdx.iso
 # SECRETVM_ROOTFS_GPU_TDX_SHA256=

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -455,6 +455,7 @@ jobs:
           echo "rootfs_sev_sha256=${SECRETVM_ROOTFS_SEV_SHA256:-}" >> $GITHUB_OUTPUT
           echo "sev_registry_url=${SECRETVM_SEV_REGISTRY_URL:-https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/sev.json}" >> $GITHUB_OUTPUT
           echo "sev_registry_vm_type=${SECRETVM_SEV_REGISTRY_VM_TYPE:-prod}" >> $GITHUB_OUTPUT
+          echo "sev_registry_artifacts_ver=${SECRETVM_SEV_REGISTRY_ARTIFACTS_VER:-$SECRETVM_RELEASE}" >> $GITHUB_OUTPUT
 
           # legacy aliases retained so older steps continue to compile
           echo "rootfs_url=$SECRETVM_ROOTFS_TDX_URL" >> $GITHUB_OUTPUT
@@ -566,7 +567,7 @@ jobs:
           SEV_OUT=$(python3 proxy-router/scripts/compute-sev-measurement.py \
             --registry "${{ steps.sev-registry.outputs.registry_path }}" \
             --vm-type "${{ steps.secretvm-config.outputs.sev_registry_vm_type }}" \
-            --artifacts-ver "${{ steps.secretvm-config.outputs.release }}" \
+            --artifacts-ver "${{ steps.secretvm-config.outputs.sev_registry_artifacts_ver }}" \
             --compose /tmp/docker-compose.tee.deployed.yml \
             --all-templates --json)
 


### PR DESCRIPTION
## Summary
- Re-pin `.github/tee/secretvm.env` to **v0.0.26-beta.1**, the only SecretVM artifacts version currently deployable from the portal Production environment.
- Restore `SECRETVM_SEV_REGISTRY_ARTIFACTS_VER=v0.0.26-beta.2` override and wire `build.yml` to use it — the portal ships beta.1 rootfs but `secretvm-verify` only publishes prod SEV metadata under beta.2.

## Test plan
- [ ] Merge to `dev` and confirm TEE build job downloads/verifies `rootfs-prod-v0.0.26-beta.1-{tdx,sev}.iso`
- [ ] Confirm SEV measurement compute succeeds with registry artifacts_ver override
- [ ] Deploy digest-pinned compose to SecretVM test VM via portal/CLI


Made with [Cursor](https://cursor.com)