### PR TITLE
fix(tee): pin SecretVM to v0.0.27 (portal Production aligned)

### DIFF
--- a/.github/tee/secretvm.env
+++ b/.github/tee/secretvm.env
@@ -7,34 +7,26 @@
 #
 # IMPORTANT: Always use the "prod" rootfs variant — SecretVM runs "environment prod"
 # even for developer portal deployments. Using "dev" rootfs produces wrong measurements.
-#
-# Compatibility note (2026-05-29):
-#   The SecretVM portal Production environment currently only allows
-#   v0.0.26-beta.1 for new VM provisioning. GitHub may list newer stable releases
-#   (e.g. v0.0.27) but those cannot be deployed until SCRT rolls the cluster forward.
 
-SECRETVM_RELEASE=v0.0.26-beta.1
+SECRETVM_RELEASE=v0.0.27
 SECRETVM_ROOTFS_VARIANT=rootfs-prod
 
 # Intel TDX rootfs (non-GPU, prod — used for proxy-router P-Node deployments)
 # URL pattern: .../download/${RELEASE}/${VARIANT}-${RELEASE}-tdx.iso
-SECRETVM_ROOTFS_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.26-beta.1/rootfs-prod-v0.0.26-beta.1-tdx.iso
-SECRETVM_ROOTFS_TDX_SHA256=780214c693218c6c13342526571705b8152f7b3139eba46b53a49d0d27cf68fe
+SECRETVM_ROOTFS_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.27/rootfs-prod-v0.0.27-tdx.iso
+SECRETVM_ROOTFS_TDX_SHA256=1a5d9ea46607fe46f0ad8055ee01afa033aaded7251a38253baff470d33506c8
 
 # AMD SEV-SNP rootfs (prod) — same compose, different platform binary
 # URL pattern: .../download/${RELEASE}/${VARIANT}-${RELEASE}-sev.iso
-SECRETVM_ROOTFS_SEV_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.26-beta.1/rootfs-prod-v0.0.26-beta.1-sev.iso
-SECRETVM_ROOTFS_SEV_SHA256=30abaaa5cff341c9d1b6c509f965d1a18c6b2fd446cf46d4ec2602ab3f06ff5c
+SECRETVM_ROOTFS_SEV_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.27/rootfs-prod-v0.0.27-sev.iso
+SECRETVM_ROOTFS_SEV_SHA256=17122d51dbaed224d08bc0c17e72d7047d60175c7274a0d366167fc29b3fe4cf
 
 # SEV artifact registry — kernel/initrd/ovmf hashes + ovmf_sections for measurement compute.
 # Pulled from scrtlabs/secretvm-verify; pipeline picks the entry whose `vm_type` and
-# `artifacts_ver` match SECRETVM_SEV_REGISTRY_VM_TYPE and SECRETVM_SEV_REGISTRY_ARTIFACTS_VER.
-# Note: the portal offers v0.0.26-beta.1 rootfs while the verify registry only lists
-# v0.0.26-beta.2 for prod SEV metadata — override below keeps CI measurement working.
+# `artifacts_ver` match SECRETVM_SEV_REGISTRY_VM_TYPE (prod) and SECRETVM_RELEASE.
 SECRETVM_SEV_REGISTRY_URL=https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/sev.json
 SECRETVM_SEV_REGISTRY_VM_TYPE=prod
-SECRETVM_SEV_REGISTRY_ARTIFACTS_VER=v0.0.26-beta.2
 
 # GPU variant (for co-located proxy+LLM deployments)
-# SECRETVM_ROOTFS_GPU_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.26-beta.1/rootfs-gpu-prod-v0.0.26-beta.1-tdx.iso
+# SECRETVM_ROOTFS_GPU_TDX_URL=https://github.com/scrtlabs/secret-vm-build/releases/download/v0.0.27/rootfs-gpu-prod-v0.0.27-tdx.iso
 # SECRETVM_ROOTFS_GPU_TDX_SHA256=


### PR DESCRIPTION
## Summary
SCRT Labs rolled the portal Production environment to **v0.0.27**. Build artifacts, the `secretvm-verify` registries, and the portal now all agree, so we can pin the exact deployable version.

- `.github/tee/secretvm.env` → v0.0.27 TDX + SEV rootfs URLs and SHA-256s
- Dropped the temporary `SECRETVM_SEV_REGISTRY_ARTIFACTS_VER` override (no longer needed — `sev.json` has a prod v0.0.27 entry; `build.yml` falls back to `SECRETVM_RELEASE`)
- Removed the portal-compatibility note (we only release versions we can deploy at the exact pinned version)

## Validation
- TDX rootfs `sha256 1a5d9ea4…` matches the live release
- SEV rootfs `sha256 17122d51…` matches the live release **and** the registry `rootfs_hash`
- `sev.json` prod **v0.0.27** entry present; `tdx.csv` prod **v0.0.27** rows present (small/medium/large)

## Test plan
- [ ] Merge to `dev`; confirm TEE build downloads/verifies `rootfs-prod-v0.0.27-{tdx,sev}.iso`
- [ ] Confirm SEV measurement compute resolves prod v0.0.27 registry entry
- [ ] Deploy to SecretVM test VM + e2e attestation

Made with [Cursor](https://cursor.com)