### PR TITLE
fix(tee): pin SecretVM to v0.0.27 (portal Production aligned)

### DIFF
--- a/.github/tee/secretvm.env
+++ b/.github/tee/secretvm.env
@@ -7,13 +7,6 @@
 #
 # IMPORTANT: Always use the "prod" rootfs variant — SecretVM runs "environment prod"
 # even for developer portal deployments. Using "dev" rootfs produces wrong measurements.
-#
-# Compatibility note (2026-05-23):
-#   GitHub latest stable Production release is v0.0.27 (non-prerelease). TDX and SEV
-#   verify registries both publish prod entries for this version. The SecretVM portal UI
-#   may still show an older artifacts version (e.g. v0.0.26-beta.1) until SCRT rolls the
-#   cluster forward — CI/manifests pin to v0.0.27 regardless. Existing VMs on older
-#   rootfs continue to run; RTMR3/SEV verification requires the VM rootfs to match.
 
 SECRETVM_RELEASE=v0.0.27
 SECRETVM_ROOTFS_VARIANT=rootfs-prod


### PR DESCRIPTION
## Summary
Same change as the dev PR (#749), applied to `test`. SCRT Labs rolled the portal Production environment to **v0.0.27**; build artifacts, `secretvm-verify` registries, and the portal all agree.

On `test` the rootfs URLs/SHA-256s were already v0.0.27 — this commit removes the leftover portal-compatibility note so the file matches `dev` (we only release versions we can deploy at the exact pinned version).

## Validation
- TDX rootfs `sha256 1a5d9ea4…` matches the live release
- SEV rootfs `sha256 17122d51…` matches the live release **and** the registry `rootfs_hash`
- `sev.json` prod **v0.0.27** entry present; `tdx.csv` prod **v0.0.27** rows present

## Test plan
- [ ] Merge to `test`; watch SecretVM test deployment
- [ ] e2e attestation verification
- [ ] Then update the existing test → main promotion PR

Made with [Cursor](https://cursor.com)