### PR TITLE
chore(dev): realign build.yml to test + add inference contract RFP

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,7 @@ name: CI-CD
 # CI/CD Pipeline for Morpheus Lumerin Node
 # 
 # Branch Strategy:
-#   • dev: Build-only (TEMPORARY): verify, tag, proxy-router docker test, CLI/router executables,
-#     UI desktop builds, and GitHub pre-release (vX.Y.Z-dev) with router/CLI/UI assets — no GHCR,
-#     TEE, AWS, or SecretVM deploy. Revert after test→main promotion is unblocked.
+#   • dev: Build and test only (no deployment)
 #   • test: Build, test, and deploy to AWS DEV environment (Titan dev + Morpheus dev consumer node)
 #   • main: Build, test, create release, and deploy to AWS PRD environment (Titan lmn + Morpheus prd consumer/provider nodes)
 #
@@ -455,7 +453,6 @@ jobs:
           echo "rootfs_sev_sha256=${SECRETVM_ROOTFS_SEV_SHA256:-}" >> $GITHUB_OUTPUT
           echo "sev_registry_url=${SECRETVM_SEV_REGISTRY_URL:-https://raw.githubusercontent.com/scrtlabs/secretvm-verify/main/artifacts_registry/sev.json}" >> $GITHUB_OUTPUT
           echo "sev_registry_vm_type=${SECRETVM_SEV_REGISTRY_VM_TYPE:-prod}" >> $GITHUB_OUTPUT
-          echo "sev_registry_artifacts_ver=${SECRETVM_SEV_REGISTRY_ARTIFACTS_VER:-$SECRETVM_RELEASE}" >> $GITHUB_OUTPUT
 
           # legacy aliases retained so older steps continue to compile
           echo "rootfs_url=$SECRETVM_ROOTFS_TDX_URL" >> $GITHUB_OUTPUT
@@ -567,7 +564,7 @@ jobs:
           SEV_OUT=$(python3 proxy-router/scripts/compute-sev-measurement.py \
             --registry "${{ steps.sev-registry.outputs.registry_path }}" \
             --vm-type "${{ steps.secretvm-config.outputs.sev_registry_vm_type }}" \
-            --artifacts-ver "${{ steps.secretvm-config.outputs.sev_registry_artifacts_ver }}" \
+            --artifacts-ver "${{ steps.secretvm-config.outputs.release }}" \
             --compose /tmp/docker-compose.tee.deployed.yml \
             --all-templates --json)
 
@@ -961,7 +958,7 @@ jobs:
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
       (
-        (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test' || github.ref == 'refs/heads/dev')) ||
+        (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true') 
       )
     needs:
@@ -2202,7 +2199,7 @@ jobs:
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
       (
-        (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test' || github.ref == 'refs/heads/dev')) ||
+        (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true')
       )
     runs-on: macos-latest
@@ -2266,7 +2263,7 @@ jobs:
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
       (
-        (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test' || github.ref == 'refs/heads/dev')) ||
+        (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true')
       )
     runs-on: ubuntu-22.04
@@ -2329,7 +2326,7 @@ jobs:
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
       (
-        (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test' || github.ref == 'refs/heads/dev')) ||
+        (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true')
       )
     runs-on: ubuntu-22.04
@@ -2392,7 +2389,7 @@ jobs:
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
       (
-        (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test' || github.ref == 'refs/heads/dev')) ||
+        (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true')
       )
     runs-on: macos-15-intel
@@ -2456,7 +2453,7 @@ jobs:
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
       (
-        (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test' || github.ref == 'refs/heads/dev')) ||
+        (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true')
       )
     runs-on: windows-latest
@@ -2535,116 +2532,6 @@ jobs:
         with:
           path: ./ui-desktop/dist/win-x64-morpheus-app-${{ needs.Generate-Tag.outputs.vfull }}.exe
           name: win-x64-morpheus-app-${{ needs.Generate-Tag.outputs.vfull }}.exe
-
-  Dev-UI-Release:
-    name: Upload Dev Pre-release (desktop + CLI + router)
-    if: |
-      github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/dev'
-    needs:
-      - Generate-Tag
-      - Build-Service-Executables
-      - UI-macOS-latest-arm64
-      - UI-macOS-15-intel-x64
-      - UI-Ubuntu-22-x64
-      - UI-Ubuntu-22-arm64
-      - UI-Windows-avx2-x64
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Clone
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v7
-        with:
-          path: ./artifact
-          merge-multiple: true
-
-      - name: Verify artifact contents
-        run: |
-          echo "🔍 Contents of ./artifact:"
-          ls -lh ./artifact
-
-      - name: Generate release notes
-        run: |
-          VERSION=${{ needs.Generate-Tag.outputs.vfull }}
-          TAG=${{ needs.Generate-Tag.outputs.tag_name }}
-
-          cat << RELEASE_NOTES > release_notes.md
-          ## Dev pre-release ($TAG)
-
-          Desktop, proxy-router, and CLI builds from the \`dev\` branch. No container or TEE assets in this release.
-
-          ### Desktop Application
-
-          | Platform | Download |
-          |----------|----------|
-          | **Windows** (x64) | [\`win-x64-morpheus-app-${VERSION}.exe\`](../../releases/download/${TAG}/win-x64-morpheus-app-${VERSION}.exe) |
-          | **macOS** (Apple Silicon) | [\`mac-arm64-morpheus-app-${VERSION}.dmg\`](../../releases/download/${TAG}/mac-arm64-morpheus-app-${VERSION}.dmg) |
-          | **macOS** (Intel) | [\`mac-x64-morpheus-app-${VERSION}.dmg\`](../../releases/download/${TAG}/mac-x64-morpheus-app-${VERSION}.dmg) |
-          | **Linux** (x64) | [\`linux-x86_64-morpheus-app-${VERSION}.AppImage\`](../../releases/download/${TAG}/linux-x86_64-morpheus-app-${VERSION}.AppImage) |
-          | **Linux** (ARM64) | [\`linux-arm64-morpheus-app-${VERSION}.AppImage\`](../../releases/download/${TAG}/linux-arm64-morpheus-app-${VERSION}.AppImage) |
-
-          ### Proxy Router
-
-          | Platform | Download |
-          |----------|----------|
-          | **Linux** (x64) | [\`linux-x86_64-morpheus-router-${VERSION}\`](../../releases/download/${TAG}/linux-x86_64-morpheus-router-${VERSION}) |
-          | **Linux** (ARM64) | [\`linux-arm64-morpheus-router-${VERSION}\`](../../releases/download/${TAG}/linux-arm64-morpheus-router-${VERSION}) |
-          | **macOS** (Apple Silicon) | [\`mac-arm64-morpheus-router-${VERSION}\`](../../releases/download/${TAG}/mac-arm64-morpheus-router-${VERSION}) |
-          | **macOS** (Intel) | [\`mac-x64-morpheus-router-${VERSION}\`](../../releases/download/${TAG}/mac-x64-morpheus-router-${VERSION}) |
-          | **Windows** (x64) | [\`win-x64-morpheus-router-${VERSION}.exe\`](../../releases/download/${TAG}/win-x64-morpheus-router-${VERSION}.exe) |
-
-          ### CLI
-
-          | Platform | Download |
-          |----------|----------|
-          | **Linux** (x64) | [\`linux-x86_64-morpheus-cli-${VERSION}\`](../../releases/download/${TAG}/linux-x86_64-morpheus-cli-${VERSION}) |
-          | **Linux** (ARM64) | [\`linux-arm64-morpheus-cli-${VERSION}\`](../../releases/download/${TAG}/linux-arm64-morpheus-cli-${VERSION}) |
-          | **macOS** (Apple Silicon) | [\`mac-arm64-morpheus-cli-${VERSION}\`](../../releases/download/${TAG}/mac-arm64-morpheus-cli-${VERSION}) |
-          | **macOS** (Intel) | [\`mac-x64-morpheus-cli-${VERSION}\`](../../releases/download/${TAG}/mac-x64-morpheus-cli-${VERSION}) |
-          | **Windows** (x64) | [\`win-x64-morpheus-cli-${VERSION}.exe\`](../../releases/download/${TAG}/win-x64-morpheus-cli-${VERSION}.exe) |
-
-          > Rolling alias: \`latest-dev\` git tag tracks the newest dev pre-release.
-          RELEASE_NOTES
-
-          echo "" >> release_notes.md
-          echo "---" >> release_notes.md
-          echo "" >> release_notes.md
-          echo "## Commit" >> release_notes.md
-          echo "" >> release_notes.md
-          git log -1 --pretty=format:"%B" ${{ github.sha }} >> release_notes.md
-          cat release_notes.md
-
-      - name: Create dev pre-release and upload assets
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG=${{ needs.Generate-Tag.outputs.tag_name }}
-          echo "📦 Creating dev pre-release $TAG..."
-          gh release create "$TAG" \
-            --title "Dev pre-release $TAG" \
-            --notes-file release_notes.md \
-            --prerelease \
-            ./artifact/*
-          echo "✅ Dev pre-release $TAG created with $(ls -1 ./artifact | wc -l) assets"
-
-      - name: Update latest-dev tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG=${{ needs.Generate-Tag.outputs.tag_name }}
-          echo "🔄 Updating 'latest-dev' tag to point to $TAG..."
-          git push origin :refs/tags/latest-dev 2>/dev/null || true
-          git tag -f latest-dev
-          git push origin latest-dev
-          echo "✅ 'latest-dev' tag updated"
 
   UI-Release:
     name: Upload UI-Desktop Release

--- a/smart-contracts/docs/inference-contract-enhancements-rfp.md
+++ b/smart-contracts/docs/inference-contract-enhancements-rfp.md
@@ -1,0 +1,579 @@
+# Inference Contract Enhancements — Contractor RFP
+
+**Product:** Morpheus Lumerin Node — Inference Diamond (BASE)  
+**Repository:** [`smart-contracts/`](../)  
+**Status:** Draft for contractor scoping  
+**Last updated:** 2026-05-29  
+**Audience:** Smart contract engineering contractor, Morpheus protocol team
+
+---
+
+## 1. Purpose
+
+This document consolidates a review of the current Inference Diamond facets (`ModelRegistry`, `Marketplace`, `ProviderRegistry`, `SessionRouter`) and proposes enhancements aimed at **user-facing simplification**, **marketplace integrity**, and **developer experience**.
+
+It is intended as a scoping brief for a smart contract contractor: prioritized backlog, acceptance criteria, migration constraints, and open design decisions.
+
+### 1.1 Canonical code references
+
+| Facet | Path |
+|-------|------|
+| ModelRegistry | [`contracts/diamond/facets/ModelRegistry.sol`](../contracts/diamond/facets/ModelRegistry.sol) |
+| Marketplace | [`contracts/diamond/facets/Marketplace.sol`](../contracts/diamond/facets/Marketplace.sol) |
+| ProviderRegistry | [`contracts/diamond/facets/ProviderRegistry.sol`](../contracts/diamond/facets/ProviderRegistry.sol) |
+| SessionRouter | [`contracts/diamond/facets/SessionRouter.sol`](../contracts/diamond/facets/SessionRouter.sol) |
+| Model struct | [`contracts/interfaces/storage/IModelStorage.sol`](../contracts/interfaces/storage/IModelStorage.sol) |
+| Session struct | [`contracts/interfaces/storage/ISessionStorage.sol`](../contracts/interfaces/storage/ISessionStorage.sol) |
+
+### 1.2 Related product docs (behavior today)
+
+- [Session states (open, close, claim)](../../docs/ai/session-states-open-close-recover.mdx)
+- [Why is my MOR locked?](../../docs/ai/why-locked-in-contract.mdx)
+- [Tokens and fees](../../docs/concepts/tokens-and-fees.mdx)
+- [Rewards and economics](../../docs/concepts/rewards-and-economics.mdx)
+
+---
+
+## 2. Current architecture (baseline)
+
+The Inference Contract is a Diamond proxy with four primary write facets and shared storage slots.
+
+| Facet | Role today |
+|-------|------------|
+| **ModelRegistry** | Any wallet meeting min stake registers a model. `modelId = keccak256(owner, baseModelId)`. Re-registering with the same `baseModelId` **upserts** metadata and adds stake. |
+| **Marketplace** | Providers post bids (`pricePerSecond`). Reposting auto-deletes the prior active bid for that provider↔model pair. Charges **0.3 MOR** `marketplaceBidFee` per post. |
+| **ProviderRegistry** | Provider bond + endpoint string. Re-register upserts endpoint and adds stake. |
+| **SessionRouter** | Open/close sessions, stipend-based duration, early-close timelock, provider payouts from `fundingAccount` or user escrow. |
+
+### 2.1 Key behavioral facts (contract-verified)
+
+1. **Model identity is per-owner, not global.** Two providers can each register `"glm-5.1"` as a display name; they are unrelated on-chain models with different `modelId`s.
+
+2. **No global name idempotency.** `modelRegister` does not check for existing names. Idempotency exists only for `(modelOwner, baseModelId)`.
+
+3. **`fee` on Model is unused.** Documented as a royalty placeholder; not referenced in settlement logic.
+
+4. **Direct pay vs staking is structurally identical** except for who pays the provider at close. Duration, early-close lock, and `stakeToStipend` math are the same for both modes.
+
+5. **Early close requires a second transaction.** Funds parked in `userStakesOnHold[]` must be claimed via `withdrawUserStakes` — no proxy-router HTTP route exists today.
+
+6. **Read queries are fragmented.** A complete model-market or session view requires multiple chain calls (see §5).
+
+7. **Provider reward limiter period is 365 days** in contract (`PROVIDER_REWARD_LIMITER_PERIOD`). Some product docs incorrectly describe it as 1 day — contractor should not change this without explicit product sign-off.
+
+---
+
+## 3. Prioritized backlog
+
+Items are grouped by **impact** and tagged with an **objective**. Each item includes acceptance criteria and migration notes.
+
+### Legend
+
+| Tag | Meaning |
+|-----|---------|
+| 🔴 High | Direct user confusion or marketplace integrity risk |
+| 🟡 Medium | Provider onboarding, data quality, economics clarity |
+| 🟢 Low | Hygiene, mostly off-chain, or incremental |
+
+| Objective | Focus |
+|-----------|-------|
+| **UX** | Consumer/provider confusion, "where's my MOR?", opaque pricing |
+| **Integrity** | Model sprawl, duplicates, wrong metadata |
+| **DX** | Read APIs, indexer/app integration |
+| **Economics** | Fees, direct pay, provider rewards |
+
+---
+
+### Phase 1 — Quick wins (read-only, low risk)
+
+#### H2 · UX · Session quote view
+
+**Problem:** Session duration uses `stakeToStipend(amount) / pricePerSecond`, not `amount / pricePerSecond`. Consumers cannot infer how much stake buys how much access.
+
+**Proposal:** Add read-only functions (new `QueryFacet` or extend `SessionRouter`):
+
+```solidity
+function quoteSession(
+    bytes32 bidId_,
+    uint256 amount_,
+    bool isDirectPaymentFromUser_
+) external view returns (
+    uint256 stipend,
+    uint128 durationSeconds,
+    uint128 endsAt,
+    uint256 pricePerSecond,
+    bytes32 modelId,
+    address provider
+);
+```
+
+**Acceptance criteria:**
+- [ ] Pure `view`; no state changes.
+- [ ] `endsAt` matches what `openSession` would set for the same inputs at `block.timestamp`.
+- [ ] Documented formula references `stakeToStipend`, `getSessionEnd`, `maxSessionDuration`.
+- [ ] Hardhat tests cover stake-pool and direct-pay flag paths.
+
+**Migration:** Additive facet cut; no storage migration.
+
+---
+
+#### H5 · DX · Aggregated read-only facet
+
+**Problem:** Building a model picker or enriched session view requires a call chain:
+
+| Use case | Current calls |
+|----------|---------------|
+| Pick a model | `getModel` → `getModelActiveBids` → `getBid` (×N) → `getProvider` (×N) |
+| Session detail | `getSession` → `getBid` → `getModel` → `getProvider` |
+
+**Proposal:** New **QueryFacet** (view-only, joins existing storage):
+
+```solidity
+struct SessionView {
+    Session session;
+    Bid bid;
+    Model model;
+    Provider provider;
+    uint256 providerClaimable;   // optional
+    uint256 userOnHold;          // optional
+}
+
+struct ModelBidView {
+    Bid bid;
+    Provider provider;
+    ProviderModelStats stats;    // optional
+}
+
+function getSessionView(bytes32 sessionId_) external view returns (SessionView memory);
+function getBidView(bytes32 bidId_) external view returns (ModelBidView memory);
+function getModelBidsEnriched(bytes32 modelId_, uint256 offset_, uint256 limit_)
+    external view returns (ModelBidView[] memory, uint256 total);
+```
+
+**Acceptance criteria:**
+- [ ] All functions are `view`.
+- [ ] Paginated list functions respect existing `Paginator` patterns.
+- [ ] Gas benchmarks documented for typical page sizes (e.g. 20 bids).
+- [ ] Does not duplicate write storage; reads from existing slots only.
+
+**Migration:** Additive facet cut.
+
+**Downstream:** Morpheus proxy-router may adopt these to reduce multicall complexity (`proxy-router/internal/repositories/registries/`).
+
+---
+
+#### M6 · UX/Economics · Provider earnings transparency
+
+**Problem:** Provider earnings are capped by `provider.stake - limitPeriodEarned` over `PROVIDER_REWARD_LIMITER_PERIOD` (365 days). This is opaque to providers and misdocumented in places.
+
+**Proposal:**
+
+```solidity
+function getProviderEarningsStatus(address provider_) external view returns (
+    uint256 stake,
+    uint256 earnedThisPeriod,
+    uint256 remainingCapacity,
+    uint128 periodEnd
+);
+```
+
+**Acceptance criteria:**
+- [ ] Values match `_claimForProvider` limiter logic exactly.
+- [ ] Tests cover period rollover (`limitPeriodEnd` reset).
+
+**Migration:** Additive. Optional follow-up (separate item): make `PROVIDER_REWARD_LIMITER_PERIOD` owner-configurable — requires product decision.
+
+---
+
+#### M5 · Economics · Unused `fee` field
+
+**Problem:** `Model.fee` is writable on every `modelRegister` but never used in settlement. Creates confusion and wasted calldata.
+
+**Proposal (pick one, document choice in PR):**
+
+| Option | Action |
+|--------|--------|
+| A | Reject non-zero `fee` until royalty logic is implemented |
+| B | Remove field in storage migration (breaking ABI) |
+| C | Wire fee as model-owner royalty on session close (new economics — scope separately) |
+
+**Acceptance criteria (Option A — recommended for Phase 1):**
+- [ ] `modelRegister` reverts if `fee_ != 0` with clear error.
+- [ ] Existing models with `fee == 0` unaffected.
+- [ ] Interface comment updated.
+
+**Migration:** Option A is non-breaking. Options B/C need explicit governance approval.
+
+---
+
+#### L4 · Hygiene · Input validation bounds
+
+**Problem:** `name`, `tags`, `endpoint` have TODO comments for length limits; unbounded strings allow griefing via calldata size.
+
+**Proposal:**
+- Max length on `name` (e.g. 64 bytes).
+- Max count and max length per tag (e.g. 10 tags × 32 bytes).
+- Max length on `endpoint` (e.g. 256 bytes).
+- Reject empty `name` on create.
+
+**Acceptance criteria:**
+- [ ] Revert with named errors on violation.
+- [ ] Existing active records grandfathered OR migration script documented if retroactive enforcement is required.
+
+**Migration:** Forward-only enforcement on new writes is lowest risk.
+
+---
+
+### Phase 2 — UX and economics (state-changing)
+
+#### H1 · UX · Rethink direct pay vs staking
+
+**Problem:** `isDirectPaymentFromUser` only changes **who pays the provider** (`fundingAccount` vs user escrow). Everything else — duration via stipend, early-close day-lock, `endsAt` calculation — is identical. Users expect direct pay to behave like prepayment for N seconds at the bid price.
+
+**Current code paths:**
+- Duration: `getSessionEnd` → `stakeToStipend(amount) / pricePerSecond` for **both** modes.
+- Early-close lock: `_rewardUserAfterClose` applies `userStakesOnHold` for **both** modes.
+
+**Proposal:** Split into two semantically distinct session modes:
+
+| Mode | Duration | Early-close refund | Provider paid from |
+|------|----------|-------------------|-------------------|
+| **Pool / stake session** | `stakeToStipend(amount) / pricePerSecond` | Existing day-lock logic (or H3 simplification) | `fundingAccount` |
+| **Direct-pay session** | `amount / pricePerSecond` (capped by `maxSessionDuration`) | Immediate unused refund (no stipend lock) | User escrow in contract |
+
+**Acceptance criteria:**
+- [ ] Direct-pay sessions: `endsAt = openedAt + min(amount / pricePerSecond, maxSessionDuration)`.
+- [ ] Direct-pay early close: user receives unused escrow immediately; no `userStakesOnHold` row for direct-pay mode.
+- [ ] Stake-pool sessions: preserve existing stipend math (unless H3 also approved).
+- [ ] `openSession` API: consider renaming flag in ABI/docs (`isDirectPaymentFromUser` → clearer name) with backward-compatible overload or deprecated alias.
+- [ ] Full Hardhat regression suite for both modes × natural close × early close × dispute.
+- [ ] Migration guide for proxy-router (`directPayment` body field) and MorpheusUI.
+
+**Migration:** Breaking behavior change for direct-pay users. Requires facet upgrade + coordinated client release. Feature flag or opt-in period recommended.
+
+---
+
+#### H3 · UX · Early-close timelock and harvest
+
+**Problem:** Early close (`closedAt < endsAt`) parks a computed slice in `userStakesOnHold[user]` with `releaseAt = startOfDay(closedAt) + 1 day`. User must call `withdrawUserStakes` separately. This is the #1 "where's my MOR?" support driver after active sessions.
+
+**Proposal (select or combine):**
+
+| Option | Description |
+|--------|-------------|
+| **H3a** | Auto-transfer releasable on-hold rows at end of `closeSession` when `releaseAt <= block.timestamp` |
+| **H3b** | Remove or shorten day-lock for **non-disputed** early closes; retain provider on-hold only on dispute |
+| **H3c** | Add `withdrawAllUserStakes(user)` without iteration cap |
+| **H3d** | Emit `UserStakeOnHold(user, amount, releaseAt)` event for indexers and wallet UIs |
+
+**Acceptance criteria:**
+- [ ] Document anti-gaming rationale for any retained lock period.
+- [ ] Natural expiration path unchanged: full refund in same `closeSession` txn, no on-hold row.
+- [ ] Disputed close (`closeoutType == 1`) provider on-hold behavior preserved unless explicitly changed.
+- [ ] Tests for multi-row `userStakesOnHold` arrays and partial release.
+- [ ] Gas analysis for H3a auto-sweep on close.
+
+**Migration:** Facet upgrade. If H3b removes consumer lock entirely, update [session-states doc](../../docs/ai/session-states-open-close-recover.mdx) and tech.mor.org checker.
+
+**Parallel (non-contract):** Add proxy-router HTTP route for `withdrawUserStakes` if any lock remains.
+
+---
+
+#### M3 · Provider onboarding · Bid update without full repost
+
+**Problem:** Changing bid price requires `deleteModelBid` + `postModelBid`, paying **0.3 MOR** fee each post. Docs already warn providers about fee accumulation during setup.
+
+**Proposal:**
+
+```solidity
+function updateBidPrice(bytes32 bidId_, uint256 newPricePerSecond_) external;
+```
+
+- Same min/max price checks as `postModelBid`.
+- No `marketplaceBidFee` (or reduced fee — product decision).
+- Only active bid owner (or delegate) may call.
+- Emits `MarketplaceBidUpdated`.
+
+**Acceptance criteria:**
+- [ ] Inactive/deleted bids cannot be updated.
+- [ ] Price bounds enforced.
+- [ ] Existing `postModelBid` auto-delete behavior unchanged for new bid creation flow.
+- [ ] Tests: update price, open session on updated bid, close session settlement unchanged.
+
+**Migration:** Additive function. Proxy-router should expose `PATCH /blockchain/bids/:id` or equivalent.
+
+---
+
+#### M4 · Provider onboarding · Explicit endpoint update
+
+**Problem:** Endpoint changes require calling `providerRegister` with `amount_=0`, which re-validates min stake but is undocumented as an "update" path.
+
+**Proposal:**
+
+```solidity
+function providerUpdateEndpoint(string calldata endpoint_) external;
+```
+
+**Acceptance criteria:**
+- [ ] Only active provider (or delegate) may call.
+- [ ] Stake unchanged; no token transfer.
+- [ ] Same endpoint length bounds as L4.
+
+**Migration:** Additive. Document equivalence with existing `providerRegister(..., 0, endpoint)` if both remain.
+
+---
+
+### Phase 3 — Marketplace model (governance, breaking)
+
+#### H4 · Integrity · Model name sprawl and duplicates
+
+**Problem:** No global uniqueness. Display names are free-form strings. Users cannot tell if `"GLM-5.1"` and `"glm-5.1"` are the same offering.
+
+**Design options (contractor must implement **one** chosen by Morpheus governance before coding):
+
+| Option | Description | Pros | Cons |
+|--------|-------------|------|------|
+| **A — Canonical registry** | Governance/multisig registers global `canonicalModelId`; providers only `postModelBid`. | Clean marketplace, single metadata owner | Centralization, governance workload |
+| **B — Soft dedup** | `nameKey = normalize(name)` index; block or warn on duplicate per `capability` | Decentralized registration | Wrong metadata still blocks names (see §4) |
+| **C — Curated allowlist** | Only approved addresses may `modelRegister` | Simple | Same as A with extra role management |
+
+**Acceptance criteria (Option A — recommended default in RFP):**
+- [ ] `modelRegister` restricted to `MODEL_REGISTRAR_ROLE` (or `onlyOwner`).
+- [ ] Global `mapping(bytes32 nameKey => bytes32 modelId)` or explicit `canonicalModelId` bytes32 chosen by registrar.
+- [ ] `normalize(name)`: lowercase, trim, collapse separators — exact algorithm spec'd and tested.
+- [ ] Providers register only via `postModelBid` against canonical models.
+- [ ] Migration plan for existing per-owner models (sunset, alias map, or grandfather).
+
+**Migration:** Breaking. Requires governance vote, indexer updates, provider re-registration campaign.
+
+---
+
+#### M1 · Integrity · Typed model capabilities
+
+**Problem:** Capabilities are untyped `string[] tags`. `"tee"` is convention only. No way to filter LLM vs STT vs TTS vs embedding on-chain.
+
+**Proposal:**
+
+```solidity
+enum Capability { LLM, STT, TTS, EMBEDDING /* extensible */ }
+
+struct Model {
+    // ... existing fields ...
+    Capability capability;
+    bytes32[] secondaryTags;  // e.g. keccak256("tee")
+}
+
+function addCapability(uint8 capabilityId_, string calldata name_) external onlyOwner;
+```
+
+- Bids must reference a model; optional rule: reject bids where provider endpoint capability mismatches model (off-chain enforcement may suffice).
+- Owner can add new capability enum values via governed extension.
+
+**Acceptance criteria:**
+- [ ] Every new model registration requires valid `capability`.
+- [ ] `getModel` / QueryFacet views expose capability.
+- [ ] Storage layout migration documented (Diamond storage gap strategy).
+
+**Migration:** Storage change to `Model` struct. Existing models need default capability assignment in migration script.
+
+---
+
+#### M2 · Provider onboarding · Governance-only model creation
+
+**Problem:** Open model registration forces every provider to stake 0.1 MOR per model and creates duplicate display names.
+
+**Proposal:** Pair with H4 Option A — remove public `modelRegister` except for registrar role. Providers only:
+1. `providerRegister`
+2. `postModelBid(canonicalModelId, price)`
+
+**Acceptance criteria:**
+- [ ] Unauthorized `modelRegister` reverts.
+- [ ] Provider onboarding docs updated: model stake no longer required for typical providers.
+- [ ] Model stake refund path preserved for registrars.
+
+**Migration:** Same as H4.
+
+---
+
+#### M7 · Data quality · Structured model metadata
+
+**Problem:** Only `name`, `tags[]`, `ipfsCID`. No filterable size class, context window, or security requirements on-chain.
+
+**Proposal:** Extend `Model` or canonical registry entry:
+
+| Field | Type | Example |
+|-------|------|---------|
+| `paramSizeBucket` | `uint8` enum | 7B, 8B, 70B |
+| `contextTokens` | `uint32` | 8192 |
+| `securityFlags` | `uint8` bitmask | TEE_REQUIRED, TEE_OPTIONAL |
+| `metadataHash` | `bytes32` | keccak256 of IPFS JSON schema |
+
+Heavy detail remains on IPFS; on-chain fields are for filtering and marketplace UX.
+
+**Acceptance criteria:**
+- [ ] Schema version in IPFS JSON documented.
+- [ ] `metadataHash` mismatch optionally rejectable on update (governance choice).
+
+**Migration:** Storage extension; pairs with H4/M1.
+
+---
+
+### Phase 4 — Lower priority / mostly off-chain
+
+#### L1 · Model veracity
+
+**Problem:** On-chain stats (`tpsScaled1000`, `ttftMs`) are provider-signed at close. No attestation that runtime model weights match registered name.
+
+**Contract scope (minimal):**
+- Optional `attestationHash` on `Model` or `Bid`.
+- Optional `verificationLevel` per provider-model pair (oracle/governance set).
+
+**Primary work:** Off-chain benchmarks, TEE attestation (see [TEE Attestation Architecture](../../.ai-docs/TEE_Attestation_Architecture.md)), challenge/dispute with slashing — separate RFP.
+
+---
+
+#### L2 · Rating / interrogation standards
+
+**Problem:** Rating is post-hoc latency only, not model identity verification.
+
+**Contract scope:** Extend stats or emit dispute outcome events. Standard definition is product work, not contract-only.
+
+---
+
+#### L3 · Storage hygiene
+
+- Remove on-chain `closeoutReceipt` bytes (TODO already in `SessionRouter`; store `tps`/`ttft` + receipt hash).
+- Compact `OnHold` struct; consider hours instead of epoch seconds (TODO in interface).
+- Document unbounded `userStakesOnHold[user]` array growth risk.
+
+---
+
+#### L5 · Name → modelId reverse index
+
+Only meaningful if H4 canonical registry is adopted:
+
+```solidity
+mapping(bytes32 nameKey => bytes32 canonicalModelId)
+function resolveModelByName(string calldata name_) external view returns (bytes32);
+```
+
+---
+
+## 4. Open design decision — metadata ownership
+
+Before Phase 3, Morpheus governance must resolve:
+
+> If `qwen3:8b` is registered with wrong capability (e.g. embeddings-only metadata on an LLM slot), who may update or revoke that metadata?
+
+| Approach | Metadata owner | Duplicate name handling |
+|----------|----------------|-------------------------|
+| Canonical registry (A) | Governance / registrar multisig | Global unique `nameKey` |
+| Open + normalized names (B) | First registrant | Duplicates blocked per capability |
+| Open + dispute (C) | First registrant until challenged | Duplicates allowed until slashed |
+
+**Recommendation:** Option A (canonical registry) for clearest provider onboarding and consumer trust. Option B creates the rights problem Alex identified without a governance escape hatch.
+
+---
+
+## 5. Appendix A — Direct pay equals staking (evidence)
+
+### Duration (both modes)
+
+```solidity
+// SessionRouter.sol — getSessionEnd
+uint128 duration_ = uint128(stakeToStipend(amount_, openedAt_) / pricePerSecond_);
+```
+
+Direct pay flag is **not** passed to `getSessionEnd`.
+
+### Early-close lock (both modes)
+
+```solidity
+// SessionRouter.sol — _rewardUserAfterClose
+if (!isClosingLate_) {
+    userStakeToLock_ = userStake.min(stipendToStake(userInitialLock_, startOfClosedAt_));
+    userStakesOnHold[session.user].push(OnHold(userStakeToLock_, startOfClosedAt_ + 1 days));
+}
+```
+
+Direct pay only affects `userStakeToProvider` subtraction before lock calculation; lock still applies.
+
+### Provider payout (only difference)
+
+```solidity
+// SessionRouter.sol — _claimForProvider
+if (session.isDirectPaymentFromUser) {
+    IERC20(token).safeTransfer(bid.provider, amount_);
+} else {
+    IERC20(token).safeTransferFrom(fundingAccount, bid.provider, amount_);
+}
+```
+
+---
+
+## 6. Appendix B — Mapping from brainstorming list
+
+| Source item | Verdict | Backlog ID |
+|-------------|---------|------------|
+| Model name idempotency (`GLM-5.1` vs `glm-5.1`) | Not global; per-owner upsert only | H4, L4, L5 |
+| Restrict model creation to core group | Not implemented | M2, H4 |
+| Capability / size / TEE structure | Tags only today | M1, M7 |
+| Reduce duplicate names | No enforcement | H4 |
+| Model veracity / rating | Latency stats only | L1, L2 |
+| Early-close timelock — still needed? | Implemented; major UX pain | H3 |
+| Better post-close harvest | Manual `withdrawUserStakes` | H3 |
+| Stake → access opacity | Stipend math | H2, H1 |
+| Direct pay enhancements | Same as stake except payer | H1 |
+| Modify facets | Upsert via register; bids delete+repost | M3, M4 |
+| Provider reward transparency | 365-day cap opaque | M6 |
+| Unused `fee` field | Confirmed unused | M5 |
+| Aggregated read faucets | Not on-chain | H5 |
+
+---
+
+## 7. Suggested delivery phases for contractor SOW
+
+| Phase | Items | Risk | Est. dependency |
+|-------|-------|------|-----------------|
+| **1** | H2, H5, M6, M5 (Option A), L4 | Low | None |
+| **2** | H3, M3, M4, H1 | Medium | Product sign-off on H1/H3 behavior |
+| **3** | H4, M1, M2, M7 | High | Governance decision §4 |
+| **4** | L1–L3, L5 | Low–Medium | Phase 3 if L5 |
+
+### Deliverables per phase
+
+1. Solidity implementation + interfaces
+2. Hardhat test coverage ≥ existing facet standards
+3. Storage layout diagram (Diamond slots affected)
+4. Migration script / facet cut instructions
+5. Breaking change changelog for proxy-router team
+6. NatSpec on all new public functions
+
+### Out of scope (separate workstreams)
+
+- Proxy-router HTTP routes (except coordination notes)
+- MorpheusUI changes
+- Capital Contract / stake-for-liquidity
+- Hosted Inference API (`api.mor.org`) billing
+- TEE attestation implementation (see `.ai-docs/`)
+
+---
+
+## 8. Questions for contractor proposal
+
+Please address in your response:
+
+1. Recommended approach for **H4** (§4) given upgradeability constraints.
+2. Gas budget for **H5** enriched list views at 20 and 100 bids.
+3. Strategy for **H1** backward compatibility (new function vs flag behavior change).
+4. Storage migration technique for **M1/M7** Model struct extension.
+5. Test plan for **H3** early-close changes including dispute path.
+6. Timeline and cost breakdown by phase (§7).
+
+---
+
+## 9. Revision history
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-29 | Morpheus team (AI-assisted review) | Initial RFP from contract review + brainstorming list |


### PR DESCRIPTION
## Summary
Recovers the `dev` CI baseline by realigning `.github/workflows/build.yml` to the `test` version, and adds the inference-contract enhancements RFP doc.

**`build.yml` (now byte-identical to `test`):**
- Removes the **temporary dev-push desktop build + `vX.Y.Z-dev` pre-release jobs** (the staged "dev builds" that were never meant to live in the pipeline).
- Removes the **`SECRETVM_SEV_REGISTRY_ARTIFACTS_VER` override indirection** (leftover from the v0.0.26-beta.1 episode, #747). It was harmless (defaults to `$SECRETVM_RELEASE`) but unwanted — we always deploy exact versions, so the decoupling is not something we want in the tree.
- Net: dev/test/main CI fully aligned; `dev` stays **build + test only** (no deploy, no release).

**`secretvm.env`:** already matched `test` (clean v0.0.27, no override) — no change.

**Docs:** add `smart-contracts/docs/inference-contract-enhancements-rfp.md`.

## Notes
- After this lands on `dev`, the only remaining `dev`-ahead delta vs `test`/`main` is the expected feature work (ui-desktop modernization + `proxy-router/mobile` SDK + ethclient changes), intentionally staged on `dev`.
- `test` and `main` are currently content-identical.

## Test plan
- [ ] Confirm dev-push CI runs verify/build/test jobs only (no deploy/release/desktop-package jobs)
- [ ] Diff check: `git diff origin/test origin/dev -- .github/workflows/build.yml .github/tee/secretvm.env` is empty after merge

Made with [Cursor](https://cursor.com)