### PR TITLE
feat(ui): add speech-to-text & text-to-speech chat + Secure (TEE) UX

### DIFF
--- a/proxy-router/internal/chatstorage/genericchatstorage/chat_completion.go
+++ b/proxy-router/internal/chatstorage/genericchatstorage/chat_completion.go
@@ -3,10 +3,32 @@ package genericchatstorage
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
 	"github.com/sashabaranov/go-openai"
 )
+
+// reasoningDetail mirrors one entry of OpenRouter's structured "reasoning_details"
+// array, which is used (alongside or instead of the plain "reasoning" string) for
+// models that emit summaries or encrypted chain-of-thought. Only the textual parts
+// are relevant for token counting.
+type reasoningDetail struct {
+	Text    string `json:"text"`
+	Summary string `json:"summary"`
+	Data    string `json:"data"`
+}
+
+// joinReasoningDetails concatenates the textual fields of a reasoning_details array.
+func joinReasoningDetails(details []reasoningDetail) string {
+	var b strings.Builder
+	for _, d := range details {
+		b.WriteString(d.Text)
+		b.WriteString(d.Summary)
+		b.WriteString(d.Data)
+	}
+	return b.String()
+}
 
 type OpenAICompletionRequestExtra struct {
 	openai.ChatCompletionRequest
@@ -119,6 +141,39 @@ func (c ChatCompletionResponseExtra) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
+// ReasoningContent returns the message reasoning field from the original JSON,
+// if present. Reasoning ("thinking") models return chain-of-thought here
+// separately from the answer content (choices[].message.content). Providers
+// disagree on the field name: Venice/DeepSeek use "reasoning_content" while
+// ollama/gpt-oss use "reasoning".
+func (c *ChatCompletionResponseExtra) ReasoningContent() string {
+	if c.originalJSON == nil {
+		return ""
+	}
+	raw := c.originalJSON["choices"]
+	if raw == nil {
+		return ""
+	}
+	var choices []struct {
+		Message struct {
+			ReasoningContent string            `json:"reasoning_content"`
+			Reasoning        string            `json:"reasoning"`
+			ReasoningDetails []reasoningDetail `json:"reasoning_details"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(raw, &choices); err != nil || len(choices) == 0 {
+		return ""
+	}
+	m := choices[0].Message
+	if m.ReasoningContent != "" {
+		return m.ReasoningContent
+	}
+	if m.Reasoning != "" {
+		return m.Reasoning
+	}
+	return joinReasoningDetails(m.ReasoningDetails)
+}
+
 // SetOriginalJSONUsage updates the usage field in originalJSON
 func (c *ChatCompletionResponseExtra) SetOriginalJSONUsage(usageBytes []byte) {
 	if c.originalJSON == nil {
@@ -224,6 +279,35 @@ func (c *ChatCompletionStreamResponseExtra) OriginalChoicesJSON() json.RawMessag
 		return nil
 	}
 	return c.originalJSON["choices"]
+}
+
+// ReasoningContent returns the delta reasoning field from the original JSON,
+// if present. Reasoning ("thinking") models stream chain-of-thought separately
+// from the answer content. Providers disagree on the field name: Venice/DeepSeek
+// use "reasoning_content" while ollama/gpt-oss use "reasoning".
+func (c *ChatCompletionStreamResponseExtra) ReasoningContent() string {
+	raw := c.OriginalChoicesJSON()
+	if raw == nil {
+		return ""
+	}
+	var choices []struct {
+		Delta struct {
+			ReasoningContent string            `json:"reasoning_content"`
+			Reasoning        string            `json:"reasoning"`
+			ReasoningDetails []reasoningDetail `json:"reasoning_details"`
+		} `json:"delta"`
+	}
+	if err := json.Unmarshal(raw, &choices); err != nil || len(choices) == 0 {
+		return ""
+	}
+	d := choices[0].Delta
+	if d.ReasoningContent != "" {
+		return d.ReasoningContent
+	}
+	if d.Reasoning != "" {
+		return d.Reasoning
+	}
+	return joinReasoningDetails(d.ReasoningDetails)
 }
 
 func (c *ChatCompletionStreamResponseExtra) SetOriginalJSONUsage(usageBytes []byte) {

--- a/proxy-router/internal/chatstorage/genericchatstorage/completion.go
+++ b/proxy-router/internal/chatstorage/genericchatstorage/completion.go
@@ -139,19 +139,7 @@ func (c *ChunkStreaming) ReasoningContent() string {
 	if c.data == nil {
 		return ""
 	}
-	raw := c.data.OriginalChoicesJSON()
-	if raw == nil {
-		return ""
-	}
-	var choices []struct {
-		Delta struct {
-			ReasoningContent string `json:"reasoning_content"`
-		} `json:"delta"`
-	}
-	if err := json.Unmarshal(raw, &choices); err != nil || len(choices) == 0 {
-		return ""
-	}
-	return choices[0].Delta.ReasoningContent
+	return c.data.ReasoningContent()
 }
 
 func (c *ChunkStreaming) Data() interface{} {

--- a/proxy-router/internal/proxyapi/proxy_receiver.go
+++ b/proxy-router/internal/proxyapi/proxy_receiver.go
@@ -181,8 +181,11 @@ func (s *ProxyReceiver) createCompletionCallback(
 	promptTokens int,
 	sendResponse SendResponse,
 ) genericchatstorage.CompletionCallback {
-	// Track accumulated content for streaming responses
+	// Track accumulated content for streaming responses. Reasoning ("thinking")
+	// tokens are accumulated separately and folded into completion_tokens so
+	// they are billed the same as regular output tokens.
 	var accumulatedContent strings.Builder
+	var accumulatedReasoning strings.Builder
 
 	return func(ctx context.Context, completion genericchatstorage.Chunk, aiEngineErrorResponse *genericchatstorage.AiEngineErrorResponse) error {
 		if aiEngineErrorResponse != nil {
@@ -225,6 +228,8 @@ func (s *ProxyReceiver) createCompletionCallback(
 					if len(data.Choices) > 0 {
 						accumulatedContent.WriteString(data.Choices[0].Delta.Content)
 					}
+					// Accumulate reasoning ("thinking") delta, if any
+					accumulatedReasoning.WriteString(streamChunk.ReasoningContent())
 
 					// Check if this is the final chunk (has finish_reason or Usage data)
 					isFinalChunk := false
@@ -235,9 +240,10 @@ func (s *ProxyReceiver) createCompletionCallback(
 						isFinalChunk = true
 					}
 
-					// On final chunk, calculate and update usage
+					// On final chunk, calculate and update usage. Reasoning tokens
+					// are counted as completion tokens.
 					if isFinalChunk {
-						completionTokens := lib.CountTokens(accumulatedContent.String())
+						completionTokens := lib.CountTokens(accumulatedContent.String()) + lib.CountTokens(accumulatedReasoning.String())
 						updateUsageInStreamResponse(data, promptTokens, completionTokens)
 						*inputTokens = promptTokens
 						*outputTokens = completionTokens
@@ -248,12 +254,13 @@ func (s *ProxyReceiver) createCompletionCallback(
 			// Non-streaming: handle full response
 			if textChunk, ok := completion.(*genericchatstorage.ChunkText); ok {
 				if data, ok := textChunk.Data().(*genericchatstorage.ChatCompletionResponseExtra); ok {
-					// Calculate completion tokens from the full response content
+					// Calculate completion tokens from the full response content.
+					// Reasoning ("thinking") tokens are counted as completion tokens.
 					completionContent := ""
 					if len(data.Choices) > 0 {
 						completionContent = data.Choices[0].Message.Content
 					}
-					completionTokens := lib.CountTokens(completionContent)
+					completionTokens := lib.CountTokens(completionContent) + lib.CountTokens(data.ReasoningContent())
 					updateUsageInResponse(data, promptTokens, completionTokens)
 					*inputTokens = promptTokens
 					*outputTokens = completionTokens

--- a/proxy-router/internal/proxyapi/proxy_sender.go
+++ b/proxy-router/internal/proxyapi/proxy_sender.go
@@ -842,8 +842,11 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 
 	retryCount := 0
 
-	// Track accumulated content for streaming token calculation
+	// Track accumulated content for streaming token calculation. Reasoning
+	// ("thinking") tokens are accumulated separately and folded into
+	// completion_tokens so they are billed like regular output tokens.
 	var accumulatedContent strings.Builder
+	var accumulatedReasoning strings.Builder
 
 	for {
 		if ctx.Err() != nil {
@@ -962,7 +965,7 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 		}
 
 		// Process the AI response based on the request type
-		result, tokens, shouldStop, err := p.processAIResponse(requestType, aiResponse, responses, promptTokens, &accumulatedContent)
+		result, tokens, shouldStop, err := p.processAIResponse(requestType, aiResponse, responses, promptTokens, &accumulatedContent, &accumulatedReasoning)
 		if err != nil {
 			return nil, ttftMs, inputTokens, outputTokens, err
 		}
@@ -987,14 +990,14 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 }
 
 // processAIResponse handles different response types and returns the appropriate chunk
-func (p *ProxyServiceSender) processAIResponse(requestType string, aiResponse []byte, responses []interface{}, promptTokens int, accumulatedContent *strings.Builder) (gcs.Chunk, int, bool, error) {
+func (p *ProxyServiceSender) processAIResponse(requestType string, aiResponse []byte, responses []interface{}, promptTokens int, accumulatedContent *strings.Builder, accumulatedReasoning *strings.Builder) (gcs.Chunk, int, bool, error) {
 	switch requestType {
 	case "audio_transcription":
 		return p.handleAudioTranscription(aiResponse, responses)
 	case "audio_speech":
 		return p.handleAudioSpeech(aiResponse, responses)
 	case "chat_completion":
-		return p.handleChatCompletion(aiResponse, responses, promptTokens, accumulatedContent)
+		return p.handleChatCompletion(aiResponse, responses, promptTokens, accumulatedContent, accumulatedReasoning)
 	case "embeddings":
 		return p.handleEmbeddings(aiResponse, responses)
 	default:
@@ -1063,7 +1066,7 @@ func (p *ProxyServiceSender) handleAudioSpeech(aiResponse []byte, responses []in
 }
 
 // handleChatCompletion processes chat completion responses
-func (p *ProxyServiceSender) handleChatCompletion(aiResponse []byte, responses []interface{}, promptTokens int, accumulatedContent *strings.Builder) (gcs.Chunk, int, bool, error) {
+func (p *ProxyServiceSender) handleChatCompletion(aiResponse []byte, responses []interface{}, promptTokens int, accumulatedContent *strings.Builder, accumulatedReasoning *strings.Builder) (gcs.Chunk, int, bool, error) {
 	var controlMsg string
 	if err := json.Unmarshal(aiResponse, &controlMsg); err == nil && controlMsg == "[DONE]" {
 		chunk := gcs.NewChunkControl(controlMsg)
@@ -1089,6 +1092,8 @@ func (p *ProxyServiceSender) handleChatCompletion(aiResponse []byte, responses [
 		if hasChoices {
 			accumulatedContent.WriteString(streamResponse.Choices[0].Delta.Content)
 		}
+		// Accumulate reasoning ("thinking") delta, if any
+		accumulatedReasoning.WriteString(streamResponse.ReasoningContent())
 
 		// Check if this is the final chunk (has finish_reason or Usage data)
 		isFinalChunk := false
@@ -1099,10 +1104,11 @@ func (p *ProxyServiceSender) handleChatCompletion(aiResponse []byte, responses [
 			isFinalChunk = true
 		}
 
-		// On final chunk, calculate and add usage_from_consumer
+		// On final chunk, calculate and add usage_from_consumer. Reasoning
+		// tokens are counted as completion tokens.
 		usageTokens := 0
 		if isFinalChunk {
-			completionTokens := lib.CountTokens(accumulatedContent.String())
+			completionTokens := lib.CountTokens(accumulatedContent.String()) + lib.CountTokens(accumulatedReasoning.String())
 			lib.SetUsageFromConsumer(&streamResponse, promptTokens, completionTokens)
 			usageTokens = completionTokens
 		}
@@ -1117,12 +1123,13 @@ func (p *ProxyServiceSender) handleChatCompletion(aiResponse []byte, responses [
 	var chatResponse gcs.ChatCompletionResponseExtra
 	err = json.Unmarshal(aiResponse, &chatResponse)
 	if err == nil && len(chatResponse.Choices) > 0 && chatResponse.Object == "chat.completion" {
-		// Calculate completion tokens from the full response content
+		// Calculate completion tokens from the full response content.
+		// Reasoning ("thinking") tokens are counted as completion tokens.
 		completionContent := ""
 		if len(chatResponse.Choices) > 0 {
 			completionContent = chatResponse.Choices[0].Message.Content
 		}
-		completionTokens := lib.CountTokens(completionContent)
+		completionTokens := lib.CountTokens(completionContent) + lib.CountTokens(chatResponse.ReasoningContent())
 		lib.SetUsageFromConsumer(&chatResponse, promptTokens, completionTokens)
 
 		chunk := gcs.NewChunkText(&chatResponse)

--- a/ui-desktop/buildResources/entitlements.mac.plist
+++ b/ui-desktop/buildResources/entitlements.mac.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+</dict>
+</plist>

--- a/ui-desktop/buildResources/entitlements.mac.plist
+++ b/ui-desktop/buildResources/entitlements.mac.plist
@@ -12,12 +12,6 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
-	<key>com.apple.security.device.camera</key>
-	<true/>
-	<key>com.apple.security.network.client</key>
-	<true/>
-	<key>com.apple.security.network.server</key>
-	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 </dict>

--- a/ui-desktop/src/main/index.ts
+++ b/ui-desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, shell } from 'electron'
+import { app, BrowserWindow, ipcMain, session, shell, systemPreferences } from 'electron'
 import { electronApp, is, optimizer } from '@electron-toolkit/utils'
 import {
   default as install,
@@ -63,6 +63,36 @@ app
   .then(() => {
     // Set app user model id for windows
     electronApp.setAppUserModelId('com.electron')
+
+    // Allow the renderer to use the microphone (STT recording) and other
+    // media devices. Without an explicit handler Electron does not grant the
+    // `media` permission, so getUserMedia() yields a silent track instead of
+    // throwing. On macOS we also proactively request the OS-level mic grant.
+    const grantedPermissions = new Set(['media', 'mediaKeySystem', 'audioCapture', 'videoCapture'])
+
+    session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
+      callback(grantedPermissions.has(permission))
+    })
+
+    session.defaultSession.setPermissionCheckHandler((_webContents, permission) => {
+      return grantedPermissions.has(permission)
+    })
+
+    if (process.platform === 'darwin') {
+      const micStatus = systemPreferences.getMediaAccessStatus('microphone')
+      logger.info(`Microphone access status: ${micStatus}`)
+      if (micStatus === 'denied' || micStatus === 'restricted') {
+        logger.error(
+          `Microphone access is "${micStatus}". macOS will return a SILENT audio track. ` +
+            `Reset it with: tccutil reset Microphone com.github.Electron (dev) ` +
+            `or enable it in System Settings > Privacy & Security > Microphone, then restart.`
+        )
+      }
+      systemPreferences
+        .askForMediaAccess('microphone')
+        .then((granted) => logger.info(`Microphone access granted: ${granted}`))
+        .catch((err) => logger.error('Failed requesting microphone access', err))
+    }
 
     // Default open or close DevTools by F12 in development
     // and ignore CommandOrControl + R in production.

--- a/ui-desktop/src/renderer/src/components/chat/Chat.styles.tsx
+++ b/ui-desktop/src/renderer/src/components/chat/Chat.styles.tsx
@@ -294,3 +294,92 @@ export const VideoContainer = styled.div`
 export const SubPriceLabel = styled.span`
   color: ${(p) => p.theme.colors.morMain};
 `;
+
+export const AudioInputZone = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 14px 16px;
+  border: 1px dashed rgba(255, 255, 255, 0.2);
+  border-radius: 12px;
+
+  &[data-disabled='true'] {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+`;
+
+export const AudioActionBtn = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid ${(p) => p.theme.colors.morMain};
+  background: transparent;
+  color: ${(p) => p.theme.colors.morMain};
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+
+  &:hover {
+    background: rgba(32, 220, 142, 0.12);
+  }
+
+  &[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &[data-recording='true'] {
+    border-color: #ff5b5b;
+    color: #ff5b5b;
+    background: rgba(255, 91, 91, 0.12);
+  }
+`;
+
+export const AudioHint = styled.span`
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.55);
+`;
+
+export const TtsControlsRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+  padding: 0 16px 10px;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.7);
+
+  label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+  }
+
+  select,
+  input[type='text'] {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 6px;
+    color: white;
+    padding: 4px 8px;
+    font-size: 13px;
+  }
+
+  select:focus,
+  input:focus {
+    outline: none !important;
+    border-color: ${(p) => p.theme.colors.morMain};
+  }
+`;
+
+export const AudioPlayer = styled.audio`
+  width: 320px;
+  max-width: 100%;
+  margin-top: 4px;
+`;

--- a/ui-desktop/src/renderer/src/components/chat/Chat.tsx
+++ b/ui-desktop/src/renderer/src/components/chat/Chat.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
 // import component 👇
 import Drawer from 'react-modern-drawer';
-import { IconHistory, IconArrowUp, IconMessagePlus } from '@tabler/icons-react';
+import {
+  IconHistory,
+  IconArrowUp,
+  IconMessagePlus,
+  IconShieldLock,
+  IconUpload,
+  IconMicrophone,
+  IconPlayerStopFilled,
+} from '@tabler/icons-react';
 import {
   View,
   ContainerTitle,
@@ -26,6 +34,11 @@ import {
   ChatIntroButton,
   SendBtnWrapper,
   Btn,
+  AudioInputZone,
+  AudioActionBtn,
+  AudioHint,
+  TtsControlsRow,
+  AudioPlayer,
 } from './Chat.styles';
 import { BtnAccent } from '../dashboard/BalanceBlock.styles';
 import withChatState from '../../store/hocs/withChatState';
@@ -43,6 +56,9 @@ import {
   getColor,
   isClosed,
   generateHashId,
+  isSecureModel,
+  SECURE_BADGE_TOOLTIP,
+  getModelModality,
 } from './utils';
 import { Cooldown } from './Cooldown';
 import ImageViewer from 'react-simple-image-viewer';
@@ -53,6 +69,20 @@ import { ApiGateway } from 'src/main/src/client/apiGateway';
 let abort = false;
 let cancelScroll = false;
 const userMessage = { user: 'Me', role: 'user', icon: 'M', color: '#20dc8e' };
+
+// Common TTS voice presets. Names are backend-specific (Kokoro `af_*`,
+// OpenAI `alloy`/`nova`/...), so the field also accepts free-text input.
+const TTS_VOICES = [
+  'af_bella',
+  'af_alloy',
+  'af_sky',
+  'af_nicole',
+  'am_adam',
+  'am_michael',
+  'alloy',
+  'nova',
+  'shimmer',
+];
 
 type ChatProps = {
   client: ApiGateway;
@@ -116,8 +146,21 @@ const Chat = (props: ChatProps) => {
 
   const [chat, setChat] = useState<ChatData | undefined>(undefined);
 
+  // TTS controls + STT recording state
+  const [ttsVoice, setTtsVoice] = useState('af_bella');
+  const [ttsSpeed, setTtsSpeed] = useState(1);
+  const [recording, setRecording] = useState(false);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const audioChunksRef = useRef<Blob[]>([]);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const peakLevelRef = useRef<number>(0);
+  const levelRafRef = useRef<number | null>(null);
+
   const modelName = selectedModel?.Name || 'Model';
   const isLocal = chat?.isLocal;
+  const isSecure = isSecureModel(selectedModel);
+  const modality = getModelModality(selectedModel);
 
   const providerAddress = isLocal
     ? '(local)'
@@ -391,33 +434,64 @@ const Chat = (props: ChatProps) => {
       }
 
       const model = chainData.models.find((m) => m.Id == history.modelId);
-      history.messages.forEach((m) => {
-        const modelName = model.Name || 'Model';
+      const modelName = model?.Name || 'Model';
+      const aiIcon = modelName.toUpperCase()[0];
+      const aiColor = getColor(aiIcon);
 
-        const aiIcon = modelName.toUpperCase()[0];
-        const aiColor = getColor(aiIcon);
+      (history.messages || []).forEach((m: any) => {
+        const prompt = m?.prompt || {};
+        // Prompt shape differs by modality:
+        //  - LLM/chat: { messages: [{ content }] }
+        //  - TTS:      { input: '...' } (audio response is not stored replayably)
+        //  - STT:      audio request (no messages); response is the transcript,
+        //              flagged with isAudioContent on the stored message.
+        const isChatPrompt =
+          Array.isArray(prompt.messages) && prompt.messages.length > 0;
+        const isTtsPrompt =
+          !isChatPrompt && typeof prompt.input === 'string';
+        const isSttMessage = !isChatPrompt && !isTtsPrompt && !!m.isAudioContent;
+
+        let userText: string;
+        if (isChatPrompt) {
+          userText = prompt.messages[0]?.content ?? '';
+        } else if (isTtsPrompt) {
+          userText = prompt.input;
+        } else if (isSttMessage) {
+          // The uploaded/recorded audio is not retained in a replayable form.
+          userText = prompt.Prompt || prompt.prompt || '🎤 Audio input';
+        } else {
+          userText = '';
+        }
 
         messages.push({
           id: makeId(16),
-          text: m.prompt.messages[0].content,
+          text: userText,
           user: userMessage.user,
           role: userMessage.role,
           icon: userMessage.icon,
           color: userMessage.color,
         });
-        messages.push({
+
+        const assistant: HistoryMessage = {
           id: makeId(16),
           text: m.response,
           user: modelName,
           role: 'assistant',
           icon: aiIcon,
           color: aiColor,
-          isImageContent: m.isImageContent,
-          isVideoRawContent: m.isVideoRawContent,
-        });
+        };
+        if (isTtsPrompt) {
+          // Synthesized audio is not persisted in a replayable form.
+          assistant.text = '[Audio response — replay is not available from history]';
+        } else if (!isSttMessage) {
+          assistant.isImageContent = m.isImageContent;
+          assistant.isVideoRawContent = m.isVideoRawContent;
+        }
+        messages.push(assistant);
       });
       setMessages(messages);
     } catch (e) {
+      console.error('Failed to load chat history', e);
       props.toasts.toast('error', 'Failed to load chat history');
     }
   };
@@ -718,6 +792,222 @@ const Chat = (props: ChatProps) => {
     return memoState;
   };
 
+  const buildAudioHeaders = async () => {
+    const headers: Record<string, string> = {};
+    if (isLocal) {
+      headers['model_id'] = selectedModel.Id;
+    } else {
+      headers['session_id'] = activeSession.Id;
+    }
+    if (chat?.id) {
+      headers['chat_id'] = chat.id;
+    }
+    const authHeaders = await props.client.getAuthHeaders();
+    return { ...headers, ...authHeaders };
+  };
+
+  const audioIconProps = () => {
+    const icon = modelName.toUpperCase()[0];
+    return {
+      icon,
+      color: getColor(icon),
+      user: modelName,
+      role: 'assistant',
+    };
+  };
+
+  // TTS: text in -> synthesized audio out
+  const callSpeech = async (text: string) => {
+    const userText = { id: makeId(16), text, ...userMessage };
+    let memoState = [...messages, userText];
+    setMessages(memoState);
+    scrollToBottom();
+
+    try {
+      const headers = await buildAudioHeaders();
+      const response = await fetch(
+        `${props.config.chain.localProxyRouterUrl}/v1/audio/speech`,
+        {
+          method: 'POST',
+          headers: { ...headers, 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            input: text,
+            voice: ttsVoice,
+            response_format: 'mp3',
+            speed: Number(ttsSpeed),
+          }),
+        },
+      );
+
+      if (!response || !response.ok) {
+        props.toasts.toast('error', 'Failed to synthesize speech');
+        return memoState;
+      }
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      memoState = [
+        ...memoState,
+        { id: makeId(16), text: url, isAudioContent: true, ...audioIconProps() },
+      ];
+      setMessages(memoState);
+      scrollToBottom();
+    } catch (e) {
+      props.toasts.toast('error', 'Something goes wrong. Try later.');
+      console.error(e);
+    }
+    return memoState;
+  };
+
+  // STT: audio in -> transcription text out
+  const callTranscription = async (file: File) => {
+    const userAudioUrl = URL.createObjectURL(file);
+    let memoState = [
+      ...messages,
+      {
+        id: makeId(16),
+        text: userAudioUrl,
+        isAudioContent: true,
+        ...userMessage,
+      },
+    ];
+    setMessages(memoState);
+    scrollToBottom();
+
+    if (messages.length === 0 && chat) {
+      setChatsData([...chatData, { ...chat, title: file.name || 'Transcription' }]);
+    }
+
+    try {
+      const headers = await buildAudioHeaders();
+      const form = new FormData();
+      form.append('file', file);
+      form.append('response_format', 'json');
+
+      // NB: do not set Content-Type; the browser adds the multipart boundary.
+      const response = await fetch(
+        `${props.config.chain.localProxyRouterUrl}/v1/audio/transcriptions`,
+        {
+          method: 'POST',
+          headers,
+          body: form,
+        },
+      );
+
+      if (!response || !response.ok) {
+        props.toasts.toast('error', 'Failed to transcribe audio');
+        return memoState;
+      }
+
+      const contentType = response.headers.get('content-type') || '';
+      let transcript = '';
+      if (contentType.includes('application/json')) {
+        const data = await response.json();
+        transcript = data?.text ?? JSON.stringify(data);
+      } else {
+        transcript = await response.text();
+      }
+
+      memoState = [
+        ...memoState,
+        { id: makeId(16), text: transcript, ...audioIconProps() },
+      ];
+      setMessages(memoState);
+      scrollToBottom();
+    } catch (e) {
+      props.toasts.toast('error', 'Something goes wrong. Try later.');
+      console.error(e);
+    }
+    return memoState;
+  };
+
+  const handleAudioFile = (file?: File | null) => {
+    if (!file || isDisabled) {
+      return;
+    }
+    setIsSpinning(true);
+    callTranscription(file).finally(() => setIsSpinning(false));
+  };
+
+  const startRecording = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+
+      // Detect a silent/muted input (e.g. macOS handing us a denied mic track):
+      // sample the peak amplitude while recording so we can warn the user
+      // instead of submitting silence that transcribes to garbage.
+      peakLevelRef.current = 0;
+      try {
+        const AudioCtx =
+          window.AudioContext || (window as any).webkitAudioContext;
+        const audioContext = new AudioCtx();
+        audioContextRef.current = audioContext;
+        const source = audioContext.createMediaStreamSource(stream);
+        const analyser = audioContext.createAnalyser();
+        analyser.fftSize = 2048;
+        source.connect(analyser);
+        const data = new Uint8Array(analyser.fftSize);
+        const sampleLevel = () => {
+          analyser.getByteTimeDomainData(data);
+          let peak = 0;
+          for (let i = 0; i < data.length; i++) {
+            peak = Math.max(peak, Math.abs(data[i] - 128));
+          }
+          peakLevelRef.current = Math.max(peakLevelRef.current, peak);
+          levelRafRef.current = requestAnimationFrame(sampleLevel);
+        };
+        sampleLevel();
+      } catch (levelErr) {
+        console.warn('Could not set up audio level monitoring', levelErr);
+      }
+
+      audioChunksRef.current = [];
+      const recorder = new MediaRecorder(stream);
+      recorder.ondataavailable = (e) => {
+        if (e.data.size > 0) {
+          audioChunksRef.current.push(e.data);
+        }
+      };
+      recorder.onstop = () => {
+        stream.getTracks().forEach((t) => t.stop());
+        if (levelRafRef.current != null) {
+          cancelAnimationFrame(levelRafRef.current);
+          levelRafRef.current = null;
+        }
+        audioContextRef.current?.close().catch(() => {});
+        audioContextRef.current = null;
+
+        // Peak is 0..127 (deviation from the 128 silence midpoint). A few
+        // counts of jitter is still effectively silence.
+        if (peakLevelRef.current <= 2) {
+          props.toasts.toast(
+            'error',
+            'No sound was captured. Check microphone permissions and that the correct input device is selected.',
+          );
+          return;
+        }
+
+        const blob = new Blob(audioChunksRef.current, { type: 'audio/webm' });
+        const file = new File([blob], `recording-${Date.now()}.webm`, {
+          type: 'audio/webm',
+        });
+        handleAudioFile(file);
+      };
+      mediaRecorderRef.current = recorder;
+      recorder.start();
+      setRecording(true);
+    } catch (e) {
+      props.toasts.toast('error', 'Microphone access was denied');
+      console.error(e);
+    }
+  };
+
+  const stopRecording = () => {
+    mediaRecorderRef.current?.stop();
+    mediaRecorderRef.current = null;
+    setRecording(false);
+  };
+
   const handleSystemMessage = (message) => {
     const openSessionEventMessage = 'new session opened';
     const failoverTurnOnMessage = 'provider failed, failover enabled';
@@ -765,7 +1055,8 @@ const Chat = (props: ChatProps) => {
     }
 
     setIsSpinning(true);
-    call(promptInput).finally(() => setIsSpinning(false));
+    const request = modality === 'tts' ? callSpeech(promptInput) : call(promptInput);
+    request.finally(() => setIsSpinning(false));
     setPromptInput('');
   };
 
@@ -970,6 +1261,27 @@ const Chat = (props: ChatProps) => {
               {modelName.toUpperCase()[0]}
             </Avatar>
             <div style={{ marginLeft: '10px' }}>{modelName}</div>
+            {isSecure && (
+              <span
+                title={SECURE_BADGE_TOOLTIP}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '4px',
+                  marginLeft: '10px',
+                  padding: '2px 8px 2px 6px',
+                  fontSize: '1.1rem',
+                  fontWeight: 600,
+                  letterSpacing: '0.3px',
+                  color: 'rgba(173, 211, 255, 0.95)',
+                  background: 'rgba(125, 188, 255, 0.14)',
+                  borderRadius: '6px',
+                  cursor: 'default',
+                }}
+              >
+                <IconShieldLock size={13} stroke={2.2} /> Secure
+              </span>
+            )}
           </ChatAvatar>
           {/* {
                         (selectedBid || isLocal) && <div>
@@ -999,52 +1311,130 @@ const Chat = (props: ChatProps) => {
         <Container>
           {renderChatBlock()}
           <Control>
-            <CustomTextArrea
-              disabled={isDisabled}
-              onKeyPress={(e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault();
-                  handleSubmit();
-                }
-              }}
-              value={promptInput}
-              onChange={(ev) => setPromptInput(ev.target.value)}
-              placeholder={
-                isReadonly
-                  ? 'Session is closed. Chat in ReadOnly Mode'
-                  : 'Ask me anything...'
-              }
-              minRows={1}
-              maxRows={6}
-            />
-            <SendBtnWrapper>
-              {isReadonly ? (
-                <>
-                  <Btn onClick={() => handleReopen(false)}>
-                    {isSpinning ? (
-                      <Spinner animation="border" />
-                    ) : (
-                      <span>Staking</span>
-                    )}
-                  </Btn>
-                  <Btn onClick={() => handleReopen(true)}>
-                    {isSpinning ? (
-                      <Spinner animation="border" />
-                    ) : (
-                      <span>Direct Pay</span>
-                    )}
-                  </Btn>
-                </>
-              ) : (
-                <Btn disabled={isDisabled} onClick={handleSubmit}>
-                  {isSpinning ? (
-                    <Spinner animation="border" />
+            {modality === 'stt' && !isReadonly ? (
+              <AudioInputZone data-disabled={isDisabled}>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="audio/*"
+                  style={{ display: 'none' }}
+                  onChange={(e) => {
+                    handleAudioFile(e.target.files?.[0]);
+                    e.target.value = '';
+                  }}
+                />
+                <AudioActionBtn
+                  type="button"
+                  disabled={isDisabled || isSpinning || recording}
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  <IconUpload size={16} /> Upload audio
+                </AudioActionBtn>
+                <AudioActionBtn
+                  type="button"
+                  data-recording={recording}
+                  disabled={isDisabled || isSpinning}
+                  onClick={() => (recording ? stopRecording() : startRecording())}
+                >
+                  {recording ? (
+                    <>
+                      <IconPlayerStopFilled size={16} /> Stop
+                    </>
                   ) : (
-                    <IconArrowUp size={'26px'}></IconArrowUp>
+                    <>
+                      <IconMicrophone size={16} /> Record
+                    </>
                   )}
-                </Btn>
-              )}
-            </SendBtnWrapper>
+                </AudioActionBtn>
+                {isSpinning && <Spinner animation="border" size="sm" />}
+                <AudioHint>
+                  {recording
+                    ? 'Recording… click Stop to transcribe.'
+                    : 'Upload or record audio to transcribe.'}
+                </AudioHint>
+              </AudioInputZone>
+            ) : (
+              <>
+                {modality === 'tts' && !isReadonly && (
+                  <TtsControlsRow>
+                    <label>
+                      Voice
+                      <input
+                        type="text"
+                        list="tts-voices"
+                        value={ttsVoice}
+                        onChange={(e) => setTtsVoice(e.target.value)}
+                      />
+                      <datalist id="tts-voices">
+                        {TTS_VOICES.map((v) => (
+                          <option key={v} value={v} />
+                        ))}
+                      </datalist>
+                    </label>
+                    <label>
+                      Speed
+                      <input
+                        type="range"
+                        min={0.5}
+                        max={2}
+                        step={0.25}
+                        value={ttsSpeed}
+                        onChange={(e) => setTtsSpeed(Number(e.target.value))}
+                      />
+                      {ttsSpeed}x
+                    </label>
+                  </TtsControlsRow>
+                )}
+                <CustomTextArrea
+                  disabled={isDisabled}
+                  onKeyPress={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      handleSubmit();
+                    }
+                  }}
+                  value={promptInput}
+                  onChange={(ev) => setPromptInput(ev.target.value)}
+                  placeholder={
+                    isReadonly
+                      ? 'Session is closed. Chat in ReadOnly Mode'
+                      : modality === 'tts'
+                        ? 'Enter text to synthesize...'
+                        : 'Ask me anything...'
+                  }
+                  minRows={1}
+                  maxRows={6}
+                />
+                <SendBtnWrapper>
+                  {isReadonly ? (
+                    <>
+                      <Btn onClick={() => handleReopen(false)}>
+                        {isSpinning ? (
+                          <Spinner animation="border" />
+                        ) : (
+                          <span>Staking</span>
+                        )}
+                      </Btn>
+                      <Btn onClick={() => handleReopen(true)}>
+                        {isSpinning ? (
+                          <Spinner animation="border" />
+                        ) : (
+                          <span>Direct Pay</span>
+                        )}
+                      </Btn>
+                    </>
+                  ) : (
+                    <Btn disabled={isDisabled} onClick={handleSubmit}>
+                      {isSpinning ? (
+                        <Spinner animation="border" />
+                      ) : (
+                        <IconArrowUp size={'26px'}></IconArrowUp>
+                      )}
+                    </Btn>
+                  )}
+                </SendBtnWrapper>
+              </>
+            )}
           </Control>
         </Container>
       </View>
@@ -1063,6 +1453,14 @@ const Chat = (props: ChatProps) => {
 };
 
 const renderMessage = (message, onOpenImage) => {
+  if (message.isAudioContent) {
+    return (
+      <MessageBody>
+        <AudioPlayer controls src={message.text} />
+      </MessageBody>
+    );
+  }
+
   if (message.isImageContent) {
     return (
       <MessageBody>

--- a/ui-desktop/src/renderer/src/components/chat/modals/ModelRow.tsx
+++ b/ui-desktop/src/renderer/src/components/chat/modals/ModelRow.tsx
@@ -12,7 +12,7 @@ import {
   IconHome,
   IconShieldLock,
 } from '@tabler/icons-react';
-import { formatSmallNumber } from '../utils';
+import { formatSmallNumber, SECURE_TAG, SECURE_BADGE_TOOLTIP } from '../utils';
 
 type IconCmp = React.ComponentType<any>;
 
@@ -21,8 +21,8 @@ type IconCmp = React.ComponentType<any>;
 const MODALITY: Record<string, { label: string; Icon: IconCmp }> = {
   llm: { label: 'LLM', Icon: IconMessage },
   chat: { label: 'LLM', Icon: IconMessage },
-  tts: { label: 'TTS', Icon: IconHeadphones },
-  stt: { label: 'STT', Icon: IconMicrophone },
+  tts: { label: 'Text-to-Speech', Icon: IconHeadphones },
+  stt: { label: 'Speech-to-Text', Icon: IconMicrophone },
   embeddings: { label: 'Embeddings', Icon: IconVector },
   embedding: { label: 'Embeddings', Icon: IconVector },
   image: { label: 'Image', Icon: IconPhoto },
@@ -222,7 +222,7 @@ function classifyTags(rawTags: string[] = [], modelName: string = '') {
     const lower = tag.toLowerCase().trim();
     if (!lower) continue;
     // TEE is a security attribute, not a family tag — surface separately.
-    if (lower === 'tee') {
+    if (lower === SECURE_TAG) {
       hasTee = true;
       continue;
     }
@@ -329,9 +329,9 @@ function ModelRow(props: {
             </Pill>
           ))}
           {hasTee && (
-            <TeePill title="Runs in a Trusted Execution Environment">
+            <TeePill title={SECURE_BADGE_TOOLTIP}>
               <IconShieldLock size={11} stroke={2.2} />
-              TEE
+              Secure
             </TeePill>
           )}
           {!isLocal && providerCount > 1 && (

--- a/ui-desktop/src/renderer/src/components/chat/modals/ModelSelectionModal.tsx
+++ b/ui-desktop/src/renderer/src/components/chat/modals/ModelSelectionModal.tsx
@@ -11,9 +11,11 @@ import {
   IconHome,
   IconWorld,
   IconShieldLock,
+  IconInfoCircle,
 } from '@tabler/icons-react';
 import Modal from '../../contracts/modals/Modal';
 import ModelRow from './ModelRow';
+import { isSecureModel, SECURE_MODE_INFO } from '../utils';
 
 /* The shared outer modal `Body` (in CreateContractModal.styles) bakes in
    `padding: 5rem` and never sets `overflow: hidden`, so an `auto`-height box
@@ -196,6 +198,43 @@ const SectionHint = styled.span`
   text-transform: none;
 `;
 
+const InfoToggle = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+  padding: 2px 6px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: rgba(173, 211, 255, 0.95);
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: 0.2px;
+  text-transform: none;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(125, 188, 255, 0.12);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(125, 188, 255, 0.5);
+    outline-offset: 2px;
+  }
+`;
+
+const InfoPanel = styled.div`
+  margin-bottom: 0.9rem;
+  padding: 1rem 1.2rem;
+  border: 1px solid rgba(125, 188, 255, 0.25);
+  border-radius: 8px;
+  background: rgba(125, 188, 255, 0.08);
+  color: rgba(214, 232, 255, 0.92);
+  font-size: 1.2rem;
+  line-height: 1.5;
+`;
+
 const EmptyState = styled.div`
   padding: 5rem 2rem;
   text-align: center;
@@ -212,14 +251,13 @@ const FILTERS: { id: FilterId; label: string; modality?: string }[] = [
   { id: 'all', label: 'All' },
   { id: 'llm', label: 'LLM', modality: 'llm' },
   { id: 'embeddings', label: 'Embeddings', modality: 'embeddings' },
-  { id: 'tts', label: 'TTS', modality: 'tts' },
-  { id: 'stt', label: 'STT', modality: 'stt' },
-  { id: 'tee', label: 'TEE' },
+  { id: 'tts', label: 'Text-to-Speech', modality: 'tts' },
+  { id: 'stt', label: 'Speech-to-Text', modality: 'stt' },
+  { id: 'tee', label: 'Secure' },
   { id: 'local', label: 'Local' },
 ];
 
-const isTee = (m: any) =>
-  (m?.Tags || []).some((t: any) => String(t).toLowerCase() === 'tee');
+const isTee = (m: any) => isSecureModel(m);
 
 function hasModality(tags: any[] = [], modality: string) {
   return tags.some((t: any) => String(t).toLowerCase() === modality);
@@ -244,6 +282,7 @@ const ModelSelectionModal = ({
 }: any) => {
   const [search, setSearch] = useState('');
   const [filter, setFilter] = useState<FilterId>('all');
+  const [showTeeInfo, setShowTeeInfo] = useState(false);
 
   // Annotate each model with `isOnline` (true for local, otherwise derived
   // from provider availability checks). Sort online first within each section.
@@ -358,6 +397,7 @@ const ModelSelectionModal = ({
       onClose={() => {
         setSearch('');
         setFilter('all');
+        setShowTeeInfo(false);
         handleClose();
       }}
       bodyProps={bodyProps}
@@ -452,9 +492,18 @@ const ModelSelectionModal = ({
             <Section>
               <SectionLabel>
                 <IconShieldLock size={13} stroke={2} />
-                TEE&nbsp;
+                Secure&nbsp;
                 <SectionHint>(Trusted Execution Environment)</SectionHint>
+                <InfoToggle
+                  type="button"
+                  aria-expanded={showTeeInfo}
+                  onClick={() => setShowTeeInfo((v) => !v)}
+                >
+                  <IconInfoCircle size={13} stroke={2} />
+                  What is this?
+                </InfoToggle>
               </SectionLabel>
+              {showTeeInfo && <InfoPanel>{SECURE_MODE_INFO}</InfoPanel>}
               <SectionList>
                 {teeModels.map((m: any) => (
                   <ModelRow

--- a/ui-desktop/src/renderer/src/components/chat/utils.js
+++ b/ui-desktop/src/renderer/src/components/chat/utils.js
@@ -1,5 +1,42 @@
 export const isClosed = (item) => item.ClosedAt || (new Date().getTime() > item.EndsAt * 1000);
 
+// On-chain tag that marks a model as running inside a Trusted Execution Environment (TEE).
+// Mirrors the backend IsTeeModel() check in proxy-router/internal/blockchainapi/model_tags.go.
+export const SECURE_TAG = 'tee';
+
+export const isSecureModel = (model) =>
+    Array.isArray(model?.Tags) &&
+    model.Tags.some((t) => String(t).toLowerCase().trim() === SECURE_TAG);
+
+// Plain-language copy explaining the TEE feature to non-technical users.
+// Accuracy-checked against docs/concepts/tee-overview.mdx — do not over-claim.
+export const SECURE_BADGE_TOOLTIP =
+    'Secure: this model runs inside a Trusted Execution Environment (TEE) — hardware-isolated, encrypted memory. Your prompts are processed privately and the provider is cryptographically prevented from logging or storing them.';
+
+export const SECURE_MODE_INFO =
+    "Secure models run inside a Trusted Execution Environment (TEE). When you chat with one, your node automatically verifies the provider's software at session open and on every prompt — confirming chat storage is off and prompts can't be logged. It verifies the software, not the quality of the answer. Models without this label have no such guarantee.";
+
+// Maps on-chain model tags to an interaction modality. Mirrors the backend
+// DetectModelType() synonym lists in proxy-router/internal/blockchainapi/model_tags.go.
+export const MODALITY_TAGS = {
+    stt: ['stt', 'transcribe', 's2t', 'speech', 'speech-to-text', 'speech2text'],
+    tts: ['tts', 'text-to-speech', 'text2speech', 't2s'],
+    embedding: ['embedding', 'embeddings'],
+    llm: ['llm', 'textgeneration', 'text2text', 'text-to-text', 't2t'],
+};
+
+// Returns 'stt' | 'tts' | 'embedding' | 'llm' for a model. LLM is the default
+// when no recognised modality tag is present.
+export const getModelModality = (model) => {
+    const tags = (model?.Tags || []).map((t) => String(t).toLowerCase().trim());
+    for (const k of ['stt', 'tts', 'embedding']) {
+        if (tags.some((t) => MODALITY_TAGS[k].includes(t))) {
+            return k;
+        }
+    }
+    return 'llm';
+};
+
 export const makeId = (length) => {
     let result = '';
     const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';

--- a/ui-desktop/src/renderer/src/components/contracts/modals/Modal.jsx
+++ b/ui-desktop/src/renderer/src/components/contracts/modals/Modal.jsx
@@ -21,10 +21,16 @@ function Modal({ children, onClose, bodyProps }) {
   };
 
   const wrapClose = (e, force) => {
-    if (
-      (!force && ignoreBackdropClickRef.current) ||
-      e.target !== e.currentTarget
-    ) {
+    // `force` is the explicit close button. It must always close, regardless
+    // of the backdrop guards below (the click target is the inner X icon, not
+    // the button itself, so the `e.target !== e.currentTarget` check would
+    // otherwise swallow it).
+    if (force) {
+      ignoreBackdropClickRef.current = false;
+      onClose();
+      return;
+    }
+    if (ignoreBackdropClickRef.current || e.target !== e.currentTarget) {
       ignoreBackdropClickRef.current = false;
       return;
     }


### PR DESCRIPTION
Add audio modality support to the desktop chat and surface TEE models as "Secure" in a more user-friendly way.

- chat: detect model modality (LLM/STT/TTS) from tags and branch the input control accordingly — STT shows file upload + mic recording, TTS shows a textarea with voice/speed controls
- chat: call /v1/audio/transcriptions and /v1/audio/speech, render audio messages, and robustly load mixed LLM/STT/TTS chat history
- model picker: rename STT/TTS to "Speech-to-Text"/"Text-to-Speech", add a "Secure" shield badge and a "What is this?" info panel
- electron: grant the renderer mic/media permissions and request macOS microphone access so getUserMedia() works for STT recording
- macOS: add audio-input/camera entitlements + NSMicrophoneUsageDescription
- fix(modal): always close on the explicit close button click