### PR TITLE
fix(proxy-router): count reasoning tokens in usage_from_provider/cons…

### DIFF
--- a/proxy-router/internal/chatstorage/genericchatstorage/chat_completion.go
+++ b/proxy-router/internal/chatstorage/genericchatstorage/chat_completion.go
@@ -3,10 +3,32 @@ package genericchatstorage
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
 	"github.com/sashabaranov/go-openai"
 )
+
+// reasoningDetail mirrors one entry of OpenRouter's structured "reasoning_details"
+// array, which is used (alongside or instead of the plain "reasoning" string) for
+// models that emit summaries or encrypted chain-of-thought. Only the textual parts
+// are relevant for token counting.
+type reasoningDetail struct {
+	Text    string `json:"text"`
+	Summary string `json:"summary"`
+	Data    string `json:"data"`
+}
+
+// joinReasoningDetails concatenates the textual fields of a reasoning_details array.
+func joinReasoningDetails(details []reasoningDetail) string {
+	var b strings.Builder
+	for _, d := range details {
+		b.WriteString(d.Text)
+		b.WriteString(d.Summary)
+		b.WriteString(d.Data)
+	}
+	return b.String()
+}
 
 type OpenAICompletionRequestExtra struct {
 	openai.ChatCompletionRequest
@@ -119,6 +141,39 @@ func (c ChatCompletionResponseExtra) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
+// ReasoningContent returns the message reasoning field from the original JSON,
+// if present. Reasoning ("thinking") models return chain-of-thought here
+// separately from the answer content (choices[].message.content). Providers
+// disagree on the field name: Venice/DeepSeek use "reasoning_content" while
+// ollama/gpt-oss use "reasoning".
+func (c *ChatCompletionResponseExtra) ReasoningContent() string {
+	if c.originalJSON == nil {
+		return ""
+	}
+	raw := c.originalJSON["choices"]
+	if raw == nil {
+		return ""
+	}
+	var choices []struct {
+		Message struct {
+			ReasoningContent string            `json:"reasoning_content"`
+			Reasoning        string            `json:"reasoning"`
+			ReasoningDetails []reasoningDetail `json:"reasoning_details"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(raw, &choices); err != nil || len(choices) == 0 {
+		return ""
+	}
+	m := choices[0].Message
+	if m.ReasoningContent != "" {
+		return m.ReasoningContent
+	}
+	if m.Reasoning != "" {
+		return m.Reasoning
+	}
+	return joinReasoningDetails(m.ReasoningDetails)
+}
+
 // SetOriginalJSONUsage updates the usage field in originalJSON
 func (c *ChatCompletionResponseExtra) SetOriginalJSONUsage(usageBytes []byte) {
 	if c.originalJSON == nil {
@@ -224,6 +279,35 @@ func (c *ChatCompletionStreamResponseExtra) OriginalChoicesJSON() json.RawMessag
 		return nil
 	}
 	return c.originalJSON["choices"]
+}
+
+// ReasoningContent returns the delta reasoning field from the original JSON,
+// if present. Reasoning ("thinking") models stream chain-of-thought separately
+// from the answer content. Providers disagree on the field name: Venice/DeepSeek
+// use "reasoning_content" while ollama/gpt-oss use "reasoning".
+func (c *ChatCompletionStreamResponseExtra) ReasoningContent() string {
+	raw := c.OriginalChoicesJSON()
+	if raw == nil {
+		return ""
+	}
+	var choices []struct {
+		Delta struct {
+			ReasoningContent string            `json:"reasoning_content"`
+			Reasoning        string            `json:"reasoning"`
+			ReasoningDetails []reasoningDetail `json:"reasoning_details"`
+		} `json:"delta"`
+	}
+	if err := json.Unmarshal(raw, &choices); err != nil || len(choices) == 0 {
+		return ""
+	}
+	d := choices[0].Delta
+	if d.ReasoningContent != "" {
+		return d.ReasoningContent
+	}
+	if d.Reasoning != "" {
+		return d.Reasoning
+	}
+	return joinReasoningDetails(d.ReasoningDetails)
 }
 
 func (c *ChatCompletionStreamResponseExtra) SetOriginalJSONUsage(usageBytes []byte) {

--- a/proxy-router/internal/chatstorage/genericchatstorage/completion.go
+++ b/proxy-router/internal/chatstorage/genericchatstorage/completion.go
@@ -139,19 +139,7 @@ func (c *ChunkStreaming) ReasoningContent() string {
 	if c.data == nil {
 		return ""
 	}
-	raw := c.data.OriginalChoicesJSON()
-	if raw == nil {
-		return ""
-	}
-	var choices []struct {
-		Delta struct {
-			ReasoningContent string `json:"reasoning_content"`
-		} `json:"delta"`
-	}
-	if err := json.Unmarshal(raw, &choices); err != nil || len(choices) == 0 {
-		return ""
-	}
-	return choices[0].Delta.ReasoningContent
+	return c.data.ReasoningContent()
 }
 
 func (c *ChunkStreaming) Data() interface{} {

--- a/proxy-router/internal/proxyapi/proxy_receiver.go
+++ b/proxy-router/internal/proxyapi/proxy_receiver.go
@@ -181,8 +181,11 @@ func (s *ProxyReceiver) createCompletionCallback(
 	promptTokens int,
 	sendResponse SendResponse,
 ) genericchatstorage.CompletionCallback {
-	// Track accumulated content for streaming responses
+	// Track accumulated content for streaming responses. Reasoning ("thinking")
+	// tokens are accumulated separately and folded into completion_tokens so
+	// they are billed the same as regular output tokens.
 	var accumulatedContent strings.Builder
+	var accumulatedReasoning strings.Builder
 
 	return func(ctx context.Context, completion genericchatstorage.Chunk, aiEngineErrorResponse *genericchatstorage.AiEngineErrorResponse) error {
 		if aiEngineErrorResponse != nil {
@@ -225,6 +228,8 @@ func (s *ProxyReceiver) createCompletionCallback(
 					if len(data.Choices) > 0 {
 						accumulatedContent.WriteString(data.Choices[0].Delta.Content)
 					}
+					// Accumulate reasoning ("thinking") delta, if any
+					accumulatedReasoning.WriteString(streamChunk.ReasoningContent())
 
 					// Check if this is the final chunk (has finish_reason or Usage data)
 					isFinalChunk := false
@@ -235,9 +240,10 @@ func (s *ProxyReceiver) createCompletionCallback(
 						isFinalChunk = true
 					}
 
-					// On final chunk, calculate and update usage
+					// On final chunk, calculate and update usage. Reasoning tokens
+					// are counted as completion tokens.
 					if isFinalChunk {
-						completionTokens := lib.CountTokens(accumulatedContent.String())
+						completionTokens := lib.CountTokens(accumulatedContent.String()) + lib.CountTokens(accumulatedReasoning.String())
 						updateUsageInStreamResponse(data, promptTokens, completionTokens)
 						*inputTokens = promptTokens
 						*outputTokens = completionTokens
@@ -248,12 +254,13 @@ func (s *ProxyReceiver) createCompletionCallback(
 			// Non-streaming: handle full response
 			if textChunk, ok := completion.(*genericchatstorage.ChunkText); ok {
 				if data, ok := textChunk.Data().(*genericchatstorage.ChatCompletionResponseExtra); ok {
-					// Calculate completion tokens from the full response content
+					// Calculate completion tokens from the full response content.
+					// Reasoning ("thinking") tokens are counted as completion tokens.
 					completionContent := ""
 					if len(data.Choices) > 0 {
 						completionContent = data.Choices[0].Message.Content
 					}
-					completionTokens := lib.CountTokens(completionContent)
+					completionTokens := lib.CountTokens(completionContent) + lib.CountTokens(data.ReasoningContent())
 					updateUsageInResponse(data, promptTokens, completionTokens)
 					*inputTokens = promptTokens
 					*outputTokens = completionTokens

--- a/proxy-router/internal/proxyapi/proxy_sender.go
+++ b/proxy-router/internal/proxyapi/proxy_sender.go
@@ -842,8 +842,11 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 
 	retryCount := 0
 
-	// Track accumulated content for streaming token calculation
+	// Track accumulated content for streaming token calculation. Reasoning
+	// ("thinking") tokens are accumulated separately and folded into
+	// completion_tokens so they are billed like regular output tokens.
 	var accumulatedContent strings.Builder
+	var accumulatedReasoning strings.Builder
 
 	for {
 		if ctx.Err() != nil {
@@ -962,7 +965,7 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 		}
 
 		// Process the AI response based on the request type
-		result, tokens, shouldStop, err := p.processAIResponse(requestType, aiResponse, responses, promptTokens, &accumulatedContent)
+		result, tokens, shouldStop, err := p.processAIResponse(requestType, aiResponse, responses, promptTokens, &accumulatedContent, &accumulatedReasoning)
 		if err != nil {
 			return nil, ttftMs, inputTokens, outputTokens, err
 		}
@@ -987,14 +990,14 @@ func (p *ProxyServiceSender) rpcRequestStreamV2(
 }
 
 // processAIResponse handles different response types and returns the appropriate chunk
-func (p *ProxyServiceSender) processAIResponse(requestType string, aiResponse []byte, responses []interface{}, promptTokens int, accumulatedContent *strings.Builder) (gcs.Chunk, int, bool, error) {
+func (p *ProxyServiceSender) processAIResponse(requestType string, aiResponse []byte, responses []interface{}, promptTokens int, accumulatedContent *strings.Builder, accumulatedReasoning *strings.Builder) (gcs.Chunk, int, bool, error) {
 	switch requestType {
 	case "audio_transcription":
 		return p.handleAudioTranscription(aiResponse, responses)
 	case "audio_speech":
 		return p.handleAudioSpeech(aiResponse, responses)
 	case "chat_completion":
-		return p.handleChatCompletion(aiResponse, responses, promptTokens, accumulatedContent)
+		return p.handleChatCompletion(aiResponse, responses, promptTokens, accumulatedContent, accumulatedReasoning)
 	case "embeddings":
 		return p.handleEmbeddings(aiResponse, responses)
 	default:
@@ -1063,7 +1066,7 @@ func (p *ProxyServiceSender) handleAudioSpeech(aiResponse []byte, responses []in
 }
 
 // handleChatCompletion processes chat completion responses
-func (p *ProxyServiceSender) handleChatCompletion(aiResponse []byte, responses []interface{}, promptTokens int, accumulatedContent *strings.Builder) (gcs.Chunk, int, bool, error) {
+func (p *ProxyServiceSender) handleChatCompletion(aiResponse []byte, responses []interface{}, promptTokens int, accumulatedContent *strings.Builder, accumulatedReasoning *strings.Builder) (gcs.Chunk, int, bool, error) {
 	var controlMsg string
 	if err := json.Unmarshal(aiResponse, &controlMsg); err == nil && controlMsg == "[DONE]" {
 		chunk := gcs.NewChunkControl(controlMsg)
@@ -1089,6 +1092,8 @@ func (p *ProxyServiceSender) handleChatCompletion(aiResponse []byte, responses [
 		if hasChoices {
 			accumulatedContent.WriteString(streamResponse.Choices[0].Delta.Content)
 		}
+		// Accumulate reasoning ("thinking") delta, if any
+		accumulatedReasoning.WriteString(streamResponse.ReasoningContent())
 
 		// Check if this is the final chunk (has finish_reason or Usage data)
 		isFinalChunk := false
@@ -1099,10 +1104,11 @@ func (p *ProxyServiceSender) handleChatCompletion(aiResponse []byte, responses [
 			isFinalChunk = true
 		}
 
-		// On final chunk, calculate and add usage_from_consumer
+		// On final chunk, calculate and add usage_from_consumer. Reasoning
+		// tokens are counted as completion tokens.
 		usageTokens := 0
 		if isFinalChunk {
-			completionTokens := lib.CountTokens(accumulatedContent.String())
+			completionTokens := lib.CountTokens(accumulatedContent.String()) + lib.CountTokens(accumulatedReasoning.String())
 			lib.SetUsageFromConsumer(&streamResponse, promptTokens, completionTokens)
 			usageTokens = completionTokens
 		}
@@ -1117,12 +1123,13 @@ func (p *ProxyServiceSender) handleChatCompletion(aiResponse []byte, responses [
 	var chatResponse gcs.ChatCompletionResponseExtra
 	err = json.Unmarshal(aiResponse, &chatResponse)
 	if err == nil && len(chatResponse.Choices) > 0 && chatResponse.Object == "chat.completion" {
-		// Calculate completion tokens from the full response content
+		// Calculate completion tokens from the full response content.
+		// Reasoning ("thinking") tokens are counted as completion tokens.
 		completionContent := ""
 		if len(chatResponse.Choices) > 0 {
 			completionContent = chatResponse.Choices[0].Message.Content
 		}
-		completionTokens := lib.CountTokens(completionContent)
+		completionTokens := lib.CountTokens(completionContent) + lib.CountTokens(chatResponse.ReasoningContent())
 		lib.SetUsageFromConsumer(&chatResponse, promptTokens, completionTokens)
 
 		chunk := gcs.NewChunkText(&chatResponse)


### PR DESCRIPTION
Reasoning ("thinking") models emit chain-of-thought separately from the
answer content, but the proxy-router's local token recount only counted
the visible `content`. As a result reasoning tokens were billed as zero
in both usage_from_provider (receiver) and usage_from_consumer (sender),
so the downstream marketplace billing never charged for thinking output.

Add ReasoningContent() helpers to the streaming and non-streaming
response structs and fold their token count into completion_tokens on
both the sender and receiver paths.

Provider field names vary, so resolution falls back in order:
  reasoning_content (DeepSeek/Venice/vLLM-legacy)
  -> reasoning (ollama/gpt-oss/vLLM-current)
  -> reasoning_details[] (OpenRouter; text+summary+data concatenated)

The plain-string fields take priority so coexisting reasoning +
reasoning_details (OpenRouter) are not double-counted. The upstream
`usage` object is left untouched; only usage_from_* are augmented.