### PR TITLE
fix: bump axios to ^1.16.0 in ui-desktop

### DIFF
--- a/ui-desktop/package.json
+++ b/ui-desktop/package.json
@@ -48,7 +48,7 @@
     "@types/tar-stream": "^3.1.3",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
-    "axios": "^1.8.4",
+    "axios": "^1.16.0",
     "bignumber.js": "^9.2.1",
     "bip39": "^3.1.0",
     "bootstrap": "^5.3.3",


### PR DESCRIPTION
Bumps axios from ^1.8.4 to ^1.16.0 in `ui-desktop/package.json`.

Addresses 55 open Dependabot alerts (HIGH severity) in ui-desktop/yarn.lock against CVE-2026 axios advisories.

Fix version: 1.16.0