### PR TITLE
ci: independent UI/docs versioning — decouple UI releases from proxy-router rolls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,6 @@ on:
       - ".github/**"
       - "!.github/workflows/docs.yml"
       - "ui-desktop/**"
-      - "ui-core/**"
       - "proxy-router/**"
       - "cli/**"
 
@@ -65,6 +64,84 @@ env:
   TEST_ENV_VAR: "test"
 
 jobs:
+  changes:
+    name: Detect changed components
+    runs-on: ubuntu-latest
+    if: |
+      github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      (
+        (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test' || github.ref == 'refs/heads/dev')) ||
+        (github.event_name == 'workflow_dispatch')
+      )
+    outputs:
+      proxy: ${{ steps.classify.outputs.proxy }}
+      ui: ${{ steps.classify.outputs.ui }}
+      cicd: ${{ steps.classify.outputs.cicd }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Classify changed paths
+        id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          emit() {
+            echo "proxy=$1" >> "$GITHUB_OUTPUT"
+            echo "ui=$2"     >> "$GITHUB_OUTPUT"
+            echo "cicd=$3"   >> "$GITHUB_OUTPUT"
+            {
+              echo "### 🔎 Component change detection"
+              echo ""
+              echo "| Component | Changed |"
+              echo "|-----------|---------|"
+              echo "| proxy-router | \`$1\` |"
+              echo "| ui-desktop / cli | \`$2\` |"
+              echo "| ci-cd (.github) | \`$3\` |"
+            } >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          # Manual dispatch = operator-driven full build. The build_all_os /
+          # create_deployment inputs remain the single source of truth for what
+          # actually runs, so classify every component as changed here.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Manual dispatch → all components treated as changed."
+            emit true true true
+            exit 0
+          fi
+
+          # New branch / first push / force-push with no usable base → fail safe
+          # to a full build (and a minor version bump).
+          if [ -z "${BEFORE_SHA:-}" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            echo "No usable base commit ('${BEFORE_SHA:-}') → all components treated as changed."
+            emit true true true
+            exit 0
+          fi
+
+          CHANGED=$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA")
+          echo "Changed files ($BEFORE_SHA..$AFTER_SHA):"
+          echo "$CHANGED" | sed 's/^/  /'
+
+          PROXY=false
+          UI=false
+          CICD=false
+          # proxy-router (anchor component). Per design, swagger/docs under
+          # proxy-router/ intentionally count as a proxy change.
+          if echo "$CHANGED" | grep -Eq '^proxy-router/'; then PROXY=true; fi
+          # UI components eligible for an independent patch release.
+          if echo "$CHANGED" | grep -Eq '^(ui-desktop|cli)/'; then UI=true; fi
+          # CI/CD changes (excluding the docs workflow, which docs.yml owns).
+          if echo "$CHANGED" | grep -E '^\.github/' | grep -qv '^\.github/workflows/docs\.yml$'; then CICD=true; fi
+
+          emit "$PROXY" "$UI" "$CICD"
+
   Go-Module-Verify:
     name: Verify Go Modules
     if: |
@@ -113,6 +190,8 @@ jobs:
   Generate-Tag:
     runs-on: ubuntu-latest
     name: Generate Tag Name
+    needs:
+      - changes
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
       (
@@ -126,6 +205,12 @@ jobs:
       image_name: ${{ steps.gen_tag_name.outputs.image_name }}
       tee_image_name: ${{ steps.gen_tag_name.outputs.tee_image_name }}
       artifacts_base_url: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ steps.gen_tag_name.outputs.tag_name }}
+      # Proxy-router "anchor" the desktop app downloads its bundled router from.
+      # On main this is always vX.Y.0 (the minor's proxy baseline); on test/dev
+      # it is the current self build (router executables are always built there).
+      anchor_vfull: ${{ steps.gen_tag_name.outputs.anchor_vfull }}
+      anchor_tag: ${{ steps.gen_tag_name.outputs.anchor_tag }}
+      anchor_artifacts_base_url: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ steps.gen_tag_name.outputs.anchor_tag }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v6
@@ -136,6 +221,8 @@ jobs:
       - name: Determine tag name
         id: gen_tag_name
         shell: bash
+        env:
+          PROXY_CHANGED: ${{ needs.changes.outputs.proxy }}
         run: |
           IMAGE_NAME="ghcr.io/morpheusais/morpheus-lumerin-node"
           VMAJ_NEW=7
@@ -159,15 +246,28 @@ jobs:
 
           if [ "$GITHUB_REF_NAME" = "main" ]; then
               if [ "$VMAJ_NEW" -gt "$VMAJ" ]; then
+                  # Forced major floor (e.g. first v7 release).
                   VMAJ=$VMAJ_NEW
                   VMIN=$VMIN_NEW
                   VPAT=$VPAT_NEW
-              else
+                  BUMP="major-floor"
+              elif [ "${PROXY_CHANGED}" = "true" ]; then
+                  # proxy-router changed → MINOR bump, re-anchor (patch resets to 0).
                   VMIN=$((VMIN+1))
                   VPAT=0
+                  BUMP="minor (proxy-router changed)"
+              else
+                  # UI/CLI-only change → PATCH bump on top of the current proxy anchor.
+                  VPAT=$((VPAT+1))
+                  BUMP="patch (UI-only, proxy unchanged)"
               fi
               VFULL=${VMAJ}.${VMIN}.${VPAT}
               VTAG=v$VFULL
+              # On main the desktop app always bundles the minor's proxy baseline
+              # (vX.Y.0). For a minor build this equals self; for a patch build it
+              # points back at the already-published proxy release.
+              ANCHOR_VFULL=${VMAJ}.${VMIN}.0
+              ANCHOR_TAG=v${ANCHOR_VFULL}
           else
               if [ "$VMAJ_NEW" -gt "$VMAJ" ]; then
                   VMAJ=$VMAJ_NEW
@@ -179,15 +279,23 @@ jobs:
               RNAME=${GITHUB_REF_NAME##*/}
               [ "$GITHUB_EVENT_NAME" = "pull_request" ] && RNAME=pr${GITHUB_REF_NAME%/merge}
               VTAG=v${VFULL}-${RNAME}
+              BUMP="prerelease"
+              # test/dev always build their own router executables, so the app
+              # anchors to this same prerelease build (self-contained).
+              ANCHOR_VFULL=${VFULL}
+              ANCHOR_TAG=${VTAG}
           fi
 
           # Output variables for use in subsequent jobs environment
           echo "tag_name=${VTAG}" >> $GITHUB_OUTPUT
           echo "vtag=${VTAG}" >> $GITHUB_OUTPUT
           echo "vfull=${VFULL}" >> $GITHUB_OUTPUT
+          echo "anchor_vfull=${ANCHOR_VFULL}" >> $GITHUB_OUTPUT
+          echo "anchor_tag=${ANCHOR_TAG}" >> $GITHUB_OUTPUT
           echo "image_name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "tee_image_name=${IMAGE_NAME}-tee" >> $GITHUB_OUTPUT
-          echo "✅ New Build Tag: $VTAG" >> $GITHUB_STEP_SUMMARY
+          echo "✅ New Build Tag: $VTAG ($BUMP)" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Proxy Anchor: $ANCHOR_TAG" >> $GITHUB_STEP_SUMMARY
           echo "✅ Docker Image: ${IMAGE_NAME}:${VTAG}" >> $GITHUB_STEP_SUMMARY
           echo "✅ TEE Image: ${IMAGE_NAME}-tee:${VTAG}" >> $GITHUB_STEP_SUMMARY
           echo "❌ Old Major Tag: $VLAST"  >> $GITHUB_STEP_SUMMARY
@@ -196,12 +304,14 @@ jobs:
     name: Test Proxy Router Docker Image
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      !(github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.proxy != 'true') &&
       (
         (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test' || github.ref == 'refs/heads/dev')) ||
         (github.event_name == 'workflow_dispatch') 
       )
     runs-on: ubuntu-latest
     needs:
+      - changes
       - Generate-Tag
       - Go-Module-Verify
     steps:
@@ -241,11 +351,13 @@ jobs:
     name: Build & Push Docker Image
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      !(github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.proxy != 'true') &&
       (
         (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/')|| github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true') 
       )
     needs:
+      - changes
       - Generate-Tag
       - Build-Proxy-Router-Test
     runs-on: ubuntu-latest
@@ -341,11 +453,13 @@ jobs:
     name: Build & Push TEE Docker Image
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      !(github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.proxy != 'true') &&
       (
         (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/')|| github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true') 
       )
     needs:
+      - changes
       - Generate-Tag
       - GHCR-Build-and-Push
     runs-on: ubuntu-latest
@@ -839,8 +953,11 @@ jobs:
 
   Deploy-SecretVM-Test:
     name: Deploy TEE Image to SecretVM (test)
-    if: github.ref == 'refs/heads/test' || startsWith(github.ref, 'refs/heads/cicd/')
+    if: |
+      (github.ref == 'refs/heads/test' || startsWith(github.ref, 'refs/heads/cicd/')) &&
+      (needs.changes.outputs.proxy == 'true' || github.event_name == 'workflow_dispatch')
     needs:
+      - changes
       - Generate-Tag
       - GHCR-Build-and-Push-TEE
     runs-on: ubuntu-latest
@@ -957,11 +1074,13 @@ jobs:
     name: Build Service Executables
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      !(github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.proxy != 'true') &&
       (
         (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true') 
       )
     needs:
+      - changes
       - Generate-Tag
       - Go-Module-Verify
     runs-on: ubuntu-latest
@@ -1095,11 +1214,13 @@ jobs:
     name: Deploy to Titan via GitHub Actions
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      (needs.changes.outputs.proxy == 'true' || github.event_name == 'workflow_dispatch') &&
       (
         (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true' && github.event.inputs.create_deployment == 'true')
       )
     needs:
+      - changes
       - Generate-Tag
       - GHCR-Build-and-Push
     runs-on: ubuntu-latest
@@ -1380,11 +1501,13 @@ jobs:
     name: Drain Morpheus C-Node from NLB
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      (needs.changes.outputs.proxy == 'true' || github.event_name == 'workflow_dispatch') &&
       (
         (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true' && github.event.inputs.create_deployment == 'true')
       )
     needs:
+      - changes
       - Generate-Tag
       - GHCR-Build-and-Push
     runs-on: ubuntu-latest
@@ -1505,6 +1628,7 @@ jobs:
     if: |
       !cancelled() &&
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      (needs.changes.outputs.proxy == 'true' || github.event_name == 'workflow_dispatch') &&
       needs.GHCR-Build-and-Push.result == 'success' &&
       needs.Drain-Morpheus-C-Node.result == 'success' &&
       (needs.Deploy-to-Morpheus-P-Node.result == 'success' || needs.Deploy-to-Morpheus-P-Node.result == 'skipped') &&
@@ -1513,6 +1637,7 @@ jobs:
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true' && github.event.inputs.create_deployment == 'true')
       )
     needs:
+      - changes
       - Generate-Tag
       - GHCR-Build-and-Push
       - Drain-Morpheus-C-Node
@@ -1939,11 +2064,13 @@ jobs:
     # P-Node restarts and takes its hosted models briefly offline.
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      (needs.changes.outputs.proxy == 'true' || github.event_name == 'workflow_dispatch') &&
       (
         (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true' && github.event.inputs.create_deployment == 'true' && github.ref == 'refs/heads/main')
       )
     needs:
+      - changes
       - Generate-Tag
       - GHCR-Build-and-Push
       - Drain-Morpheus-C-Node
@@ -2198,16 +2325,17 @@ jobs:
     name: Build Morpheus UI macOS-arm64 Image
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      (needs.changes.outputs.ui == 'true' || needs.changes.outputs.proxy == 'true') &&
       (
         (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true')
       )
     runs-on: macos-latest
     needs:
+      - changes
       - Generate-Tag
-      - Build-Service-Executables
     env:
-      SERVICE_PROXY_DOWNLOAD_URL_MAC_ARM64: ${{ needs.Generate-Tag.outputs.artifacts_base_url }}/mac-arm64-morpheus-router-${{ needs.Generate-Tag.outputs.vfull }}
+      SERVICE_PROXY_DOWNLOAD_URL_MAC_ARM64: ${{ needs.Generate-Tag.outputs.anchor_artifacts_base_url }}/mac-arm64-morpheus-router-${{ needs.Generate-Tag.outputs.anchor_vfull }}
     steps:
       - name: Clone
         id: checkout
@@ -2262,16 +2390,17 @@ jobs:
     name: Build Morpheus UI Ubuntu x64 Image
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      (needs.changes.outputs.ui == 'true' || needs.changes.outputs.proxy == 'true') &&
       (
         (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true')
       )
     runs-on: ubuntu-22.04
     needs:
+      - changes
       - Generate-Tag
-      - Build-Service-Executables
     env:
-      SERVICE_PROXY_DOWNLOAD_URL_LINUX_X64: ${{ needs.Generate-Tag.outputs.artifacts_base_url }}/linux-x86_64-morpheus-router-${{ needs.Generate-Tag.outputs.vfull }}
+      SERVICE_PROXY_DOWNLOAD_URL_LINUX_X64: ${{ needs.Generate-Tag.outputs.anchor_artifacts_base_url }}/linux-x86_64-morpheus-router-${{ needs.Generate-Tag.outputs.anchor_vfull }}
     steps:
       - name: Clone
         id: checkout
@@ -2325,16 +2454,17 @@ jobs:
     name: Build Morpheus UI Ubuntu arm64 Image
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      (needs.changes.outputs.ui == 'true' || needs.changes.outputs.proxy == 'true') &&
       (
         (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true')
       )
     runs-on: ubuntu-22.04
     needs:
+      - changes
       - Generate-Tag
-      - Build-Service-Executables
     env:
-      SERVICE_PROXY_DOWNLOAD_URL_LINUX_ARM64: ${{ needs.Generate-Tag.outputs.artifacts_base_url }}/linux-arm64-morpheus-router-${{ needs.Generate-Tag.outputs.vfull }}
+      SERVICE_PROXY_DOWNLOAD_URL_LINUX_ARM64: ${{ needs.Generate-Tag.outputs.anchor_artifacts_base_url }}/linux-arm64-morpheus-router-${{ needs.Generate-Tag.outputs.anchor_vfull }}
     steps:
       - name: Clone
         id: checkout
@@ -2388,16 +2518,17 @@ jobs:
     name: Build Morpheus UI macOS-x64 Image
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      (needs.changes.outputs.ui == 'true' || needs.changes.outputs.proxy == 'true') &&
       (
         (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true')
       )
     runs-on: macos-15-intel
     needs:
+      - changes
       - Generate-Tag
-      - Build-Service-Executables
     env:
-      SERVICE_PROXY_DOWNLOAD_URL_MAC_X64: ${{ needs.Generate-Tag.outputs.artifacts_base_url }}/mac-x64-morpheus-router-${{ needs.Generate-Tag.outputs.vfull }}
+      SERVICE_PROXY_DOWNLOAD_URL_MAC_X64: ${{ needs.Generate-Tag.outputs.anchor_artifacts_base_url }}/mac-x64-morpheus-router-${{ needs.Generate-Tag.outputs.anchor_vfull }}
     steps:
       - name: Clone
         id: checkout
@@ -2452,16 +2583,17 @@ jobs:
     name: Build Morpheus UI Windows Image
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      (needs.changes.outputs.ui == 'true' || needs.changes.outputs.proxy == 'true') &&
       (
         (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true')
       )
     runs-on: windows-latest
     needs:
+      - changes
       - Generate-Tag
-      - Build-Service-Executables
     env:
-      SERVICE_PROXY_DOWNLOAD_URL_WINDOWS_X64: ${{ needs.Generate-Tag.outputs.artifacts_base_url }}/win-x64-morpheus-router-${{ needs.Generate-Tag.outputs.vfull }}.exe
+      SERVICE_PROXY_DOWNLOAD_URL_WINDOWS_X64: ${{ needs.Generate-Tag.outputs.anchor_artifacts_base_url }}/win-x64-morpheus-router-${{ needs.Generate-Tag.outputs.anchor_vfull }}.exe
     steps:
       - name: Clone
         id: checkout
@@ -2535,14 +2667,30 @@ jobs:
 
   UI-Release:
     name: Upload UI-Desktop Release
+    # On a UI-only release the router/docker/TEE jobs are intentionally skipped,
+    # so we cannot rely on the implicit success() gate (it fails on any skipped
+    # need). Require the UI builds to have succeeded and tolerate skipped
+    # router/TEE/executables jobs (same pattern as Deploy-to-Morpheus-C-Node).
     if: |
+      !cancelled() &&
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      needs.Generate-Tag.result == 'success' &&
+      (needs.changes.outputs.ui == 'true' || needs.changes.outputs.proxy == 'true') &&
+      needs.UI-macOS-latest-arm64.result == 'success' &&
+      needs.UI-macOS-15-intel-x64.result == 'success' &&
+      needs.UI-Ubuntu-22-x64.result == 'success' &&
+      needs.UI-Ubuntu-22-arm64.result == 'success' &&
+      needs.UI-Windows-avx2-x64.result == 'success' &&
+      (needs.GHCR-Build-and-Push-TEE.result == 'success' || needs.GHCR-Build-and-Push-TEE.result == 'skipped') &&
+      (needs.Build-Service-Executables.result == 'success' || needs.Build-Service-Executables.result == 'skipped') &&
       (
         (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'true')
       )
     needs:
+      - changes
       - Generate-Tag
+      - Build-Service-Executables
       - GHCR-Build-and-Push-TEE
       - UI-macOS-latest-arm64
       - UI-macOS-15-intel-x64
@@ -2571,8 +2719,25 @@ jobs:
           echo "🔍 Contents of ./artifact:"
           ls -lh ./artifact
 
+      - name: Determine release mode
+        id: mode
+        run: |
+          # "full" = router/docker/TEE/executables were built in this run and are
+          # attached to THIS release. "ui-only" = a UI/CLI patch on main where the
+          # router stays at the anchor (vX.Y.0) and is NOT re-attached here.
+          if [ "${{ github.ref }}" != "refs/heads/main" ] || \
+             [ "${{ needs.changes.outputs.proxy }}" = "true" ] || \
+             [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "full=true" >> "$GITHUB_OUTPUT"
+            echo "Release mode: FULL"
+          else
+            echo "full=false" >> "$GITHUB_OUTPUT"
+            echo "Release mode: UI-ONLY (router anchored to ${{ needs.Generate-Tag.outputs.anchor_tag }})"
+          fi
+
       - name: Generate release notes
         id: release_notes
+        if: steps.mode.outputs.full == 'true'
         run: |
           VERSION=${{ needs.Generate-Tag.outputs.vfull }}
           TAG=${{ needs.Generate-Tag.outputs.tag_name }}
@@ -2715,7 +2880,53 @@ jobs:
           # Output for GitHub Actions
           echo "Generated release notes:"
           cat release_notes.md
-        
+
+      - name: Generate UI-only release notes
+        if: steps.mode.outputs.full != 'true'
+        env:
+          VERSION: ${{ needs.Generate-Tag.outputs.vfull }}
+          TAG: ${{ needs.Generate-Tag.outputs.tag_name }}
+          ANCHOR_VERSION: ${{ needs.Generate-Tag.outputs.anchor_vfull }}
+          ANCHOR_TAG: ${{ needs.Generate-Tag.outputs.anchor_tag }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          # Desktop-app-only release. The proxy-router, CLI, and Docker images are
+          # unchanged from the anchor release and are NOT re-published here; the app
+          # bundles the anchor router automatically.
+          cat > release_notes.md <<EOF
+          ## 🖥️ Desktop Application Update ($VERSION)
+
+          This is a **desktop-app-only** release. It bundles the unchanged
+          proxy-router from anchor release [\`$ANCHOR_TAG\`]($REPO_URL/releases/tag/$ANCHOR_TAG)
+          — **node operators do not need to update**; only the desktop app changed.
+
+          ### Download
+
+          | Platform | Download |
+          |----------|----------|
+          | **Windows** (x64) | [\`win-x64-morpheus-app-$VERSION.exe\`]($REPO_URL/releases/download/$TAG/win-x64-morpheus-app-$VERSION.exe) |
+          | **macOS** (Apple Silicon) | [\`mac-arm64-morpheus-app-$VERSION.dmg\`]($REPO_URL/releases/download/$TAG/mac-arm64-morpheus-app-$VERSION.dmg) |
+          | **macOS** (Intel) | [\`mac-x64-morpheus-app-$VERSION.dmg\`]($REPO_URL/releases/download/$TAG/mac-x64-morpheus-app-$VERSION.dmg) |
+          | **Linux** (x64) | [\`linux-x86_64-morpheus-app-$VERSION.AppImage\`]($REPO_URL/releases/download/$TAG/linux-x86_64-morpheus-app-$VERSION.AppImage) |
+          | **Linux** (ARM64/Raspberry Pi) | [\`linux-arm64-morpheus-app-$VERSION.AppImage\`]($REPO_URL/releases/download/$TAG/linux-arm64-morpheus-app-$VERSION.AppImage) |
+
+          > 🔧 Proxy-router, CLI, and Docker images for this version are provided by
+          > the anchor release **[$ANCHOR_TAG]($REPO_URL/releases/tag/$ANCHOR_TAG)**.
+          EOF
+
+          # Append the commit/PR body (same as full release notes).
+          {
+            echo ""
+            echo "---"
+            echo ""
+            echo "## 📝 Release Notes"
+            echo ""
+            git log -1 --pretty=format:"%B" ${{ github.sha }}
+          } >> release_notes.md
+
+          echo "Generated UI-only release notes:"
+          cat release_notes.md
+
       - name: Create release and upload assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Lets us ship **UI/CLI-only desktop releases without rolling the hosted nodes** or re-publishing the proxy-router, while keeping a unified SemVer that's anchored to the proxy-router. Docs-only changes already flow independently via `docs.yml`; this does the same for the desktop/UI side.

Adds a `changes` detection job (inline `git diff`, no new action dependency) and gates the existing jobs off it.

### Versioning (on `main`)
| Change | Bump | Result |
|--------|------|--------|
| `proxy-router/**` changed | **minor** | `vX.Y.0` — re-anchors everything (today's behavior) |
| `ui-desktop/**` / `cli/**` only | **patch** | `vX.Y.Z` on top of the current proxy anchor `vX.Y.0` |
| `docs/**` only | none | handled by `docs.yml` (unchanged) |

So `v7.2.0` (proxy) → `v7.2.1`, `v7.2.2` (UI ticks) → next proxy change → `v7.3.0`.

### What gets skipped on a `main` UI-only push
- `Build-Proxy-Router-Test`, `GHCR-Build-and-Push` (+ TEE), `Build-Service-Executables`
- All hosted deploys: `Deploy-SecretVM-Test`, `Drain-C-Node`, `Deploy-C-Node`, `Deploy-P-Node`, `Deploy-to-Titan`
- Result: docker `latest` and the running nodes **stay put**; only the desktop app is rebuilt + released.

### Anchor coupling (per the chosen design)
The desktop app's `SERVICE_PROXY_DOWNLOAD_URL_*` now points at the **anchor** proxy-router (`vX.Y.0` on `main`; the self prerelease on `test`/`dev`). New `Generate-Tag` outputs: `anchor_vfull`, `anchor_tag`, `anchor_artifacts_base_url`.

### Robustness
- `UI-Release` no longer relies on implicit `success()` (which fails on skipped needs); it explicitly requires the 5 UI builds to succeed and tolerates skipped router/TEE/executables jobs — same pattern already used by `Deploy-to-Morpheus-C-Node`.
- New **UI-only release notes** path: points router/CLI/docker users at the anchor release instead of producing 404 links.
- `workflow_dispatch` stays a full-power escape hatch (builds/deploys everything).
- `changes` fails safe to a full build + minor bump on first-push / no-base / force-push.

### Scope / unchanged behavior
- **`test`/`dev` are unchanged**: they still full-build and self-anchor; only the dev hosted deploys are skipped for UI-only (no node roll).
- **`main` proxy/minor builds are byte-for-byte unchanged** (anchor == self when patch is 0). The only new code path is `main` + UI-only.
- Scope is `ui-desktop` + `cli`. `launcher/` is intentionally left out (it's currently outside the pipeline entirely — separate effort).
- Swagger (`proxy-router/docs/swagger.yaml`) intentionally still counts as a proxy change (per decision).

### Known/accepted edges
- A UI-only build anchors to the **published** `vX.Y.0` router. If a proxy change is sitting on `test` but not yet on `main`, a UI-only build on top would rehearse against the prod router, not the in-flight one (normal promote ordering avoids this).
- Pure ci-cd/config-only pushes (no `ui`/`proxy` change) no longer trigger UI builds — use a real component change or `workflow_dispatch`.

## Test plan
- [ ] Merge to `dev`; confirm `changes` job classifies correctly in the run summary.
- [ ] Promote `dev → test`; confirm a UI-only delta still full-builds on `test` but **skips** the dev hosted deploys.
- [ ] Promote to `main` once with a proxy change → confirm `vX.Y.0` minor + full deploy (unchanged behavior).
- [ ] Then a UI-only change to `main` → confirm `vX.Y.(Z+1)` patch, desktop-only release, docker `latest` + nodes untouched, app downloads router from `vX.Y.0`.

Made with [Cursor](https://cursor.com)