### PR TITLE
ci: auto-sweep zombie routed_sessions after C-Node deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2075,6 +2075,110 @@ jobs:
             echo "⚠️ Continuing with warning - ECS deployment completed but version verification inconclusive"
           fi
 
+  Sweep-Zombie-Sessions:
+    name: Sweep zombie routed_sessions (post C-Node)
+    # Final tactical step: after the C-Node task swap, a batch of routed_sessions
+    # rows are left state='OPEN' with a provider mapping the new ephemeral BadgerDB
+    # no longer has. The API Gateway self-heals these within ~30 min (failover marks
+    # FAILED; its automation loop expires OPEN-past-expires_at), but this job clears
+    # the whole batch immediately so users don't eat up to ~30 min of intermittent
+    # "provider not found" retries. The Lambda is safe/idempotent (summary-first,
+    # refuses a future cutoff, guarded by SWEEP_MAX_ROWS). See Morpheus-Infra
+    # 02-morpheus_c_node/.terragrunt/06_routed_sessions_sweep.tf.
+    #
+    # Runs only after a successful C-Node deploy; tolerates skipped P-Node jobs the
+    # same way Deploy-to-Morpheus-C-Node does. Never fails the pipeline on a sweep
+    # hiccup - the deploy already succeeded and the gateway self-heals as a backstop.
+    if: |
+      !cancelled() &&
+      github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
+      needs.Deploy-to-Morpheus-C-Node.result == 'success'
+    needs:
+      - Generate-Tag
+      - Deploy-to-Morpheus-C-Node
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.MORPHEUS_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.MORPHEUS_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Invoke routed-sessions zombie sweep Lambda
+        run: |
+          BUILDTAG=${{ needs.Generate-Tag.outputs.tag_name }}
+
+          # Map branch -> environment (same convention as the C-Node deploy).
+          if [ "${{ github.ref_name }}" == "test" ]; then
+            ENV="dev"
+          elif [ "${{ github.ref_name }}" == "main" ]; then
+            ENV="prd"
+          else
+            echo "ℹ️ Branch ${{ github.ref_name }} is not a deploy branch; skipping sweep."
+            exit 0
+          fi
+
+          FUNCTION_NAME="${ENV}-routed-sessions-sweep"
+          # deploy_cutoff mode (default): the Lambda derives cutoff from the C-Node
+          # service deployments[0].updatedAt + rehydration + safety, then closes
+          # OPEN rows older than that. release_tag only annotates error_reason.
+          PAYLOAD="{\"release_tag\":\"${BUILDTAG}\"}"
+
+          echo "🧹 Invoking ${FUNCTION_NAME} with payload: ${PAYLOAD}"
+          set +e
+          INVOKE_META=$(aws lambda invoke \
+            --function-name "$FUNCTION_NAME" \
+            --cli-binary-format raw-in-base64-out \
+            --payload "$PAYLOAD" \
+            /tmp/sweep_out.json 2>/tmp/sweep_err.txt)
+          INVOKE_RC=$?
+          set -e
+
+          if [ $INVOKE_RC -ne 0 ]; then
+            echo "⚠️ lambda invoke call failed (rc=$INVOKE_RC):"
+            cat /tmp/sweep_err.txt || true
+            echo "ℹ️ Deploy already succeeded; the API Gateway self-heals zombies within ~30 min. Not failing the pipeline."
+            exit 0
+          fi
+
+          echo "📡 Invoke metadata: $INVOKE_META"
+          FUNCTION_ERROR=$(echo "$INVOKE_META" | jq -r '.FunctionError // empty')
+          RESPONSE=$(cat /tmp/sweep_out.json)
+          echo "📦 Lambda response: $RESPONSE"
+
+          # The handler returns {"statusCode": N, "body": "<json string>"}.
+          STATUS=$(echo "$RESPONSE" | jq -r '.statusCode // empty' 2>/dev/null)
+          BODY=$(echo "$RESPONSE" | jq -r '.body // empty' 2>/dev/null)
+
+          {
+            echo "### 🧹 Routed-sessions zombie sweep"
+            echo ""
+            echo "- **Function:** \`${FUNCTION_NAME}\`"
+            echo "- **Release tag:** \`${BUILDTAG}\`"
+            echo "- **Handler statusCode:** \`${STATUS:-unknown}\`"
+            if [ -n "$BODY" ]; then
+              echo ""
+              echo "\`\`\`json"
+              echo "$BODY"
+              echo "\`\`\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -n "$FUNCTION_ERROR" ]; then
+            echo "⚠️ Lambda reported FunctionError='$FUNCTION_ERROR'. Check CloudWatch /aws/lambda/${FUNCTION_NAME}."
+            echo "ℹ️ Not failing the pipeline; gateway self-heal is the backstop."
+            exit 0
+          fi
+
+          if [ "$STATUS" = "200" ]; then
+            echo "✅ Sweep completed."
+          else
+            echo "⚠️ Sweep returned non-200 statusCode '${STATUS}' (e.g. future-cutoff or > SWEEP_MAX_ROWS guard)."
+            echo "ℹ️ Review the response above and run the runbook sweep manually if needed. Not failing the pipeline."
+          fi
+
   Deploy-to-Morpheus-P-Node:
     name: Deploy to Morpheus Provider via GitHub
     # First half of the one-at-a-time provider roll (P-Node-1, then P-Node-2).


### PR DESCRIPTION
## Summary

Adds a final **`Sweep-Zombie-Sessions`** job to `build.yml` that invokes the
`<env>-routed-sessions-sweep` Lambda after a successful C-Node deploy. It clears
the post-roll batch of `routed_sessions` rows left `state='OPEN'` whose provider
mapping was lost when the ephemeral-BadgerDB C-Node task was replaced.

This implements **action item #3** from the v7.3.0 HA-rollout post-mortem (automate the post-deploy zombie sweep).

## Why

- After a C-Node roll, a batch of sessions go "zombie" → users hit intermittent `provider not found` retries.
- The API Gateway already self-heals these within ~30 min (failover marks `FAILED`; the automation loop expires `OPEN`-past-`expires_at`), so this is a **tactical accelerator** — it clears the whole batch in seconds instead of waiting out the expiry tail.
- Previously this was a manual runbook SQL step after every deploy.

## Behavior / safety

- Runs only after `Deploy-to-Morpheus-C-Node` succeeds (tolerates skipped P-Node jobs, same as the C-Node job); branch → env mapping (`test`→dev, `main`→prd).
- **Non-fatal by design**: a sweep hiccup (or a not-yet-applied IAM grant) only warns — it never fails an otherwise-successful deploy. Gateway self-heal is the backstop.
- The Lambda itself is summary-first, idempotent, refuses a future cutoff, and aborts batches > `SWEEP_MAX_ROWS` unless forced.

## Companion infra (separate repo, already applied on dev + prd)

The Lambda, its least-privilege IAM, and the deploy-user `lambda:InvokeFunction` grant live in **Morpheus-Infra** `02-morpheus_c_node` (`06_routed_sessions_sweep.tf`, `01_iam_role_gh_actions.tf`). These were `terragrunt apply`'d before this PR, so the invoke is authorized.

## Test plan

- [ ] Merge to `dev` → on the next `test`→dev C-Node deploy, confirm the `Sweep-Zombie-Sessions` job runs and the step summary shows the Lambda response (`statusCode`, rows closed).
- [ ] Verify CloudWatch `/aws/lambda/dev-routed-sessions-sweep` shows the summary + sweep result.
- [ ] Confirm a zero-zombie run reports `0 rows` and exits cleanly (idempotent).

Made with [Cursor](https://cursor.com)