### PR TITLE
fix(proxy-router): harden TEE backend attestation to fail closed

### DIFF
--- a/proxy-router/internal/attestation/backend_verifier.go
+++ b/proxy-router/internal/attestation/backend_verifier.go
@@ -3,6 +3,7 @@ package attestation
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
@@ -136,30 +137,26 @@ func (bv *BackendVerifier) AttestBackend(ctx context.Context, modelID string, at
 	}
 	bv.log.Infof("backend attestation: TLS binding verified for model %s", modelID)
 
-	// 3a. Workload verification (docker-compose vs attestation quote)
-	var workloadResult *WorkloadResult
-	if bv.artifactRegistry != nil && bv.artifactRegistry.IsLoaded() {
-		dockerCompose, composeErr := bv.fetchDockerCompose(ctx, attestationURL)
-		if composeErr != nil {
-			bv.log.Warnf("backend attestation: could not fetch docker-compose for model %s: %s (workload verification skipped)", modelID, composeErr)
-		} else {
-			result := VerifyWorkload(bv.artifactRegistry, bv.sevRegistry, cpuQuote, dockerCompose, bv.log)
-			workloadResult = &result
-			switch result.Status {
-			case WorkloadAuthentic:
-				bv.log.Infof("backend attestation: workload verified for model %s (template=%s, version=%s, env=%s)", modelID, result.TemplateName, result.ArtifactsVer, result.Env)
-			case WorkloadAuthenticMismatch:
-				bv.storeFailure(modelID, attestationURL, "docker-compose does not match attestation (authentic VM but wrong workload)")
-				return fmt.Errorf("workload verification failed for model %s: docker-compose does not match attestation", modelID)
-			case WorkloadNotAuthentic:
-				bv.storeFailure(modelID, attestationURL, "VM is not an authentic SecretVM (MRTD/RTMR values not in registry)")
-				return fmt.Errorf("workload verification failed for model %s: not an authentic SecretVM", modelID)
-			case WorkloadSkipped:
-				bv.log.Infof("backend attestation: workload verification skipped for model %s (SEV quote, not yet supported)", modelID)
-			}
-		}
-	} else {
-		bv.log.Infof("backend attestation: artifact registry not available, skipping workload verification for model %s", modelID)
+	// 3a. Workload verification (docker-compose vs attestation quote).
+	dockerCompose, composeErr := bv.fetchDockerCompose(ctx, attestationURL)
+	if composeErr != nil {
+		bv.storeFailure(modelID, attestationURL, fmt.Sprintf("could not fetch docker-compose: %s", composeErr))
+		return fmt.Errorf("workload verification failed for model %s: could not fetch docker-compose: %w", modelID, composeErr)
+	}
+
+	workloadResult := VerifyWorkload(bv.artifactRegistry, bv.sevRegistry, cpuQuote, dockerCompose, bv.log)
+	switch workloadResult.Status {
+	case WorkloadAuthentic:
+		bv.log.Infof("backend attestation: workload verified for model %s (template=%s, version=%s, env=%s)", modelID, workloadResult.TemplateName, workloadResult.ArtifactsVer, workloadResult.Env)
+	case WorkloadAuthenticMismatch:
+		bv.storeFailure(modelID, attestationURL, "docker-compose does not match attestation (authentic VM but wrong workload)")
+		return fmt.Errorf("workload verification failed for model %s: docker-compose does not match attestation", modelID)
+	case WorkloadNotAuthentic:
+		bv.storeFailure(modelID, attestationURL, "VM is not an authentic SecretVM (MRTD/RTMR values not in registry)")
+		return fmt.Errorf("workload verification failed for model %s: not an authentic SecretVM", modelID)
+	case ArtifactRegistryNotAvailable:
+		bv.storeFailure(modelID, attestationURL, "artifact registry not available; cannot verify workload")
+		return fmt.Errorf("workload verification unavailable for model %s: artifact registry not loaded", modelID)
 	}
 
 	// 4. Fetch GPU attestation data (JSON with nonce, arch, evidence_list)
@@ -186,15 +183,29 @@ func (bv *BackendVerifier) AttestBackend(ctx context.Context, modelID string, at
 	}
 	bv.log.Infof("backend attestation: CPU-GPU binding verified for model %s", modelID)
 
-	// 7. Verify GPU evidence via NVIDIA Remote Attestation Service (NRAS)
-	// NRAS may be unreachable from some networks (403/timeout). GPU trust is already
-	// established via CPU-GPU nonce binding (step 6), so NRAS failure is non-fatal.
+	// 7. Verify GPU evidence via NVIDIA Remote Attestation Service (NRAS).
+	// NRAS validates the NVIDIA-signed GPU evidence and that it was generated over
+	// the submitted nonce.
 	nrasResult, err := bv.nrasVerifier.VerifyGPU(ctx, gpuData)
 	if err != nil {
-		bv.log.Warnf("backend attestation: NRAS GPU verification failed for model %s (non-fatal): %s", modelID, err)
-	} else {
-		bv.log.Infof("backend attestation: NRAS verified GPU for model %s (%d GPU tokens received)", modelID, len(nrasResult.GPUTokens))
+		bv.storeFailure(modelID, attestationURL, fmt.Sprintf("NRAS GPU verification failed: %s", err))
+		return fmt.Errorf("NRAS GPU verification failed for model %s: %w", modelID, err)
 	}
+	if !nrasResult.OverallResult {
+		bv.storeFailure(modelID, attestationURL, "NRAS reported overall attestation result: failed")
+		return fmt.Errorf("NRAS GPU attestation failed for model %s (x-nvidia-overall-att-result=false)", modelID)
+	}
+	// Bind the NRAS-validated evidence back to the CPU quote: the eat_nonce NRAS
+	// confirmed the evidence was generated over must equal the nonce we submitted
+	// (gpuData.Nonce), which step 6 already proved equals the Intel-signed
+	// CPU-embedded nonce.
+	submittedNonce := strings.ToLower(strings.TrimSpace(gpuData.Nonce))
+	attestedNonce := strings.ToLower(strings.TrimSpace(nrasResult.EATNonce))
+	if attestedNonce == "" || attestedNonce != submittedNonce {
+		bv.storeFailure(modelID, attestationURL, fmt.Sprintf("NRAS eat_nonce mismatch: submitted=%s attested=%s", submittedNonce, attestedNonce))
+		return fmt.Errorf("NRAS eat_nonce does not match CPU-bound nonce for model %s", modelID)
+	}
+	bv.log.Infof("backend attestation: NRAS verified GPU for model %s (%d GPU tokens, nonce bound)", modelID, len(nrasResult.GPUTokens))
 
 	// 8. Golden values comparison (placeholder -- NoopGoldenSource skips this)
 	golden, err := bv.goldenSource.FetchGoldenValues(ctx, modelID, attestationURL)
@@ -230,11 +241,9 @@ func (bv *BackendVerifier) AttestBackend(ctx context.Context, modelID string, at
 		Status:         StatusPassed,
 	}
 
-	if workloadResult != nil {
-		snapshot.WorkloadStatus = string(workloadResult.Status)
-		snapshot.VMTemplateName = workloadResult.TemplateName
-		snapshot.ArtifactsVersion = workloadResult.ArtifactsVer
-	}
+	snapshot.WorkloadStatus = string(workloadResult.Status)
+	snapshot.VMTemplateName = workloadResult.TemplateName
+	snapshot.ArtifactsVersion = workloadResult.ArtifactsVer
 
 	bv.mu.Lock()
 	bv.cache[modelID] = snapshot
@@ -371,19 +380,16 @@ func VerifyCPUGPUBinding(cpuReportData string, gpuReportData string) error {
 		return fmt.Errorf("GPU reportData is empty, cannot verify binding")
 	}
 
-	// Compare the GPU nonce embedded in CPU reportData against GPU's reportData.
-	// Use the shorter of the two for comparison in case of trailing zeros.
-	compareLen := len(gpuNonceFromCPU)
-	if len(gpuReportData) < compareLen {
-		compareLen = len(gpuReportData)
+	// Require an exact match. A prefix/shorter-length comparison would let a GPU
+	// nonce that only matches the first N chars of the CPU-embedded nonce pass,
+	// collapsing the binding's entropy and enabling nonce-collision/replay.
+	if len(gpuNonceFromCPU) != len(gpuReportData) {
+		return fmt.Errorf("CPU-GPU binding length mismatch: cpu_reportdata_suffix=%d chars, gpu_reportdata=%d chars",
+			len(gpuNonceFromCPU), len(gpuReportData))
 	}
-	if compareLen == 0 {
-		return fmt.Errorf("no data available for CPU-GPU binding comparison")
-	}
-
-	if gpuNonceFromCPU[:compareLen] != gpuReportData[:compareLen] {
+	if subtle.ConstantTimeCompare([]byte(gpuNonceFromCPU), []byte(gpuReportData)) != 1 {
 		return fmt.Errorf("CPU-GPU binding mismatch: cpu_reportdata_suffix=%s, gpu_reportdata=%s",
-			gpuNonceFromCPU[:compareLen], gpuReportData[:compareLen])
+			gpuNonceFromCPU, gpuReportData)
 	}
 
 	return nil

--- a/proxy-router/internal/attestation/backend_verifier_test.go
+++ b/proxy-router/internal/attestation/backend_verifier_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -71,6 +72,35 @@ func TestVerifyCPUGPUBinding_Mismatch(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "CPU-GPU binding mismatch") {
 		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func TestVerifyCPUGPUBinding_PrefixDoesNotPass(t *testing.T) {
+	gpuNonce := "aabbccdd11223344556677889900aabbccdd11223344556677889900aabb1122"
+	tlsFingerprint := "0011223344556677889900aabbccddeeff0011223344556677889900aabbccdd"
+	cpuReportData := tlsFingerprint + gpuNonce
+
+	// A GPU reportData that is only a prefix of the expected nonce must be rejected.
+	err := VerifyCPUGPUBinding(cpuReportData, gpuNonce[:1])
+	if err == nil {
+		t.Fatal("expected error for prefix-only GPU reportData")
+	}
+	if !strings.Contains(err.Error(), "length mismatch") {
+		t.Fatalf("expected length mismatch error, got: %s", err)
+	}
+}
+
+func TestVerifyCPUGPUBinding_LongerGPUReportData(t *testing.T) {
+	gpuNonce := "aabbccdd11223344556677889900aabbccdd11223344556677889900aabb1122"
+	tlsFingerprint := "0011223344556677889900aabbccddeeff0011223344556677889900aabbccdd"
+	cpuReportData := tlsFingerprint + gpuNonce
+
+	err := VerifyCPUGPUBinding(cpuReportData, gpuNonce+"deadbeef")
+	if err == nil {
+		t.Fatal("expected error for over-length GPU reportData")
+	}
+	if !strings.Contains(err.Error(), "length mismatch") {
+		t.Fatalf("expected length mismatch error, got: %s", err)
 	}
 }
 
@@ -232,6 +262,7 @@ func TestBackendVerifier_AttestBackend_FullFlow(t *testing.T) {
 
 	gpuNonce := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	cpuReportData := fingerprint + gpuNonce
+	cpuQuote := testTdxQuoteHex()
 
 	gpuJSON := fmt.Sprintf(`{
 		"nonce": "%s",
@@ -241,11 +272,14 @@ func TestBackendVerifier_AttestBackend_FullFlow(t *testing.T) {
 
 	attestMux := http.NewServeMux()
 	attestMux.HandleFunc("/cpu", func(w http.ResponseWriter, _ *http.Request) {
-		fmt.Fprint(w, "deadbeefcpu")
+		fmt.Fprint(w, cpuQuote)
 	})
 	attestMux.HandleFunc("/gpu", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, gpuJSON)
+	})
+	attestMux.HandleFunc("/docker-compose", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "services:\n  llm:\n    image: test\n")
 	})
 	attestServer := httptest.NewTLSServer(attestMux)
 	defer attestServer.Close()
@@ -272,8 +306,12 @@ func TestBackendVerifier_AttestBackend_FullFlow(t *testing.T) {
 	portalServer := httptest.NewServer(portalMux)
 	defer portalServer.Close()
 
-	bv := NewBackendVerifier(portalServer.URL+"/api/quote-parse", nil, nil, nil, testLog())
+	nrasServer := httptest.NewServer(mockNRASHandler(t, true))
+	defer nrasServer.Close()
+
+	bv := NewBackendVerifier(portalServer.URL+"/api/quote-parse", nil, loadedRegistry(), nil, testLog())
 	bv.attestationClient = NewAttestationHTTPClient()
+	bv.nrasVerifier.baseURL = nrasServer.URL
 
 	err := bv.AttestBackend(context.Background(), "test-model", attestServer.URL)
 	if err != nil {
@@ -292,11 +330,94 @@ func TestBackendVerifier_AttestBackend_FullFlow(t *testing.T) {
 	}
 }
 
+// testComposeYAML is the docker-compose served by the orchestration tests. It
+// must match the bytes used to compute the fixture registry entry's RTMR3.
+const testComposeYAML = "services:\n  llm:\n    image: test\n"
+
+// testRootfsData is an arbitrary 48-byte hex rootfs_data for the fixture entry.
+const testRootfsData = "1111111111111111111111111111111111111111111111111111111111111111"
+
+// testTdxRegisters returns deterministic register values for a synthetic TDX
+// quote. RTMR3 is derived from testComposeYAML + testRootfsData so that
+// VerifyTdxWorkload against the fixture registry yields WorkloadAuthentic.
+func testTdxRegisters() (mrtd, rtmr0, rtmr1, rtmr2, rtmr3 [48]byte) {
+	for i := 0; i < 48; i++ {
+		mrtd[i] = 0xa1
+		rtmr0[i] = 0xb2
+		rtmr1[i] = 0xc3
+		rtmr2[i] = 0xd4
+	}
+	rtmr3Hex := CalculateRTMR3([]byte(testComposeYAML), testRootfsData)
+	b, _ := hex.DecodeString(rtmr3Hex)
+	copy(rtmr3[:], b)
+	return
+}
+
+// testTdxQuoteHex builds a minimal synthetic TDX v4 quote carrying the fixture
+// register values, so AttestBackend's mandatory workload verification can run.
+func testTdxQuoteHex() string {
+	mrtd, rtmr0, rtmr1, rtmr2, rtmr3 := testTdxRegisters()
+	raw := make([]byte, 632)
+	binary.LittleEndian.PutUint16(raw[0:2], 4)    // version
+	binary.LittleEndian.PutUint32(raw[4:8], 0x81) // tee type (TDX)
+	copy(raw[184:232], mrtd[:])
+	copy(raw[376:424], rtmr0[:])
+	copy(raw[424:472], rtmr1[:])
+	copy(raw[472:520], rtmr2[:])
+	copy(raw[520:568], rtmr3[:])
+	return hex.EncodeToString(raw)
+}
+
+// loadedRegistry returns an ArtifactRegistry (IsLoaded()==true) containing the
+// entry that matches testTdxQuoteHex + testComposeYAML, so tests exercise
+// AttestBackend's mandatory workload-verification step end to end.
+func loadedRegistry() *ArtifactRegistry {
+	mrtd, rtmr0, rtmr1, rtmr2, _ := testTdxRegisters()
+	r := NewArtifactRegistry("http://unused", 1*time.Hour, testLog())
+	r.mu.Lock()
+	r.entries = []TdxArtifactEntry{{
+		TemplateName: "test-template",
+		VMType:       "tdx",
+		ArtifactsVer: "v1.0.0",
+		MRTD:         hex.EncodeToString(mrtd[:]),
+		RTMR0:        hex.EncodeToString(rtmr0[:]),
+		RTMR1:        hex.EncodeToString(rtmr1[:]),
+		RTMR2:        hex.EncodeToString(rtmr2[:]),
+		RootfsData:   testRootfsData,
+	}}
+	r.lastFetched = time.Now()
+	r.mu.Unlock()
+	return r
+}
+
+// mockNRASHandler returns an NRAS handler that echoes the submitted nonce back
+// as the eat_nonce claim in a JWT-encoded overall EAT token, with the given
+// overall attestation result.
+func mockNRASHandler(t *testing.T, overallResult bool) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req GPUAttestationData
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("NRAS: failed to decode request: %s", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		overall := makeEATToken(t, fmt.Sprintf(`{"eat_nonce":%q,"x-nvidia-overall-att-result":%t}`, req.Nonce, overallResult))
+		resp := []json.RawMessage{
+			[]byte(fmt.Sprintf(`["JWT", %q]`, overall)),
+			[]byte(`{"GPU-0": "eyGPU0Token"}`),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}
+}
+
 func TestBackendVerifier_AttestBackend_WithNRAS(t *testing.T) {
 	cert, fingerprint := selfSignedCert(t)
 
 	gpuNonce := "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 	cpuReportData := fingerprint + gpuNonce
+	cpuQuote := testTdxQuoteHex()
 
 	gpuJSON := fmt.Sprintf(`{
 		"nonce": "%s",
@@ -306,11 +427,14 @@ func TestBackendVerifier_AttestBackend_WithNRAS(t *testing.T) {
 
 	attestMux := http.NewServeMux()
 	attestMux.HandleFunc("/cpu", func(w http.ResponseWriter, _ *http.Request) {
-		fmt.Fprint(w, "deadbeefcpu")
+		fmt.Fprint(w, cpuQuote)
 	})
 	attestMux.HandleFunc("/gpu", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, gpuJSON)
+	})
+	attestMux.HandleFunc("/docker-compose", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "services:\n  llm:\n    image: test\n")
 	})
 	attestServer := httptest.NewTLSServer(attestMux)
 	defer attestServer.Close()
@@ -337,33 +461,10 @@ func TestBackendVerifier_AttestBackend_WithNRAS(t *testing.T) {
 	portalServer := httptest.NewServer(portalMux)
 	defer portalServer.Close()
 
-	// Mock NRAS server
-	nrasMux := http.NewServeMux()
-	nrasMux.HandleFunc("/v4/attest/gpu", func(w http.ResponseWriter, r *http.Request) {
-		var req GPUAttestationData
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Errorf("NRAS: failed to decode request: %s", err)
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		if req.Arch != "HOPPER" {
-			t.Errorf("NRAS: expected arch HOPPER, got %s", req.Arch)
-		}
-		if len(req.EvidenceList) != 1 {
-			t.Errorf("NRAS: expected 1 evidence, got %d", len(req.EvidenceList))
-		}
-
-		resp := []json.RawMessage{
-			[]byte(`["JWT", "eyOverallToken"]`),
-			[]byte(`{"GPU-0": "eyGPU0Token"}`),
-		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
-	})
-	nrasServer := httptest.NewServer(nrasMux)
+	nrasServer := httptest.NewServer(mockNRASHandler(t, true))
 	defer nrasServer.Close()
 
-	bv := NewBackendVerifier(portalServer.URL+"/api/quote-parse", nil, nil, nil, testLog())
+	bv := NewBackendVerifier(portalServer.URL+"/api/quote-parse", nil, loadedRegistry(), nil, testLog())
 	bv.attestationClient = NewAttestationHTTPClient()
 	bv.nrasVerifier.baseURL = nrasServer.URL
 
@@ -378,6 +479,114 @@ func TestBackendVerifier_AttestBackend_WithNRAS(t *testing.T) {
 	}
 	if status.Status != StatusPassed {
 		t.Fatalf("expected StatusPassed, got %s (error: %s)", status.Status, status.Error)
+	}
+}
+
+func TestBackendVerifier_AttestBackend_NRASOverallResultFalse(t *testing.T) {
+	cert, fingerprint := selfSignedCert(t)
+
+	gpuNonce := "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	cpuReportData := fingerprint + gpuNonce
+	cpuQuote := testTdxQuoteHex()
+
+	gpuJSON := fmt.Sprintf(`{
+		"nonce": "%s",
+		"arch": "HOPPER",
+		"evidence_list": [{"certificate": "dGVzdA==", "evidence": "dGVzdA=="}]
+	}`, gpuNonce)
+
+	attestMux := http.NewServeMux()
+	attestMux.HandleFunc("/cpu", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, cpuQuote)
+	})
+	attestMux.HandleFunc("/gpu", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, gpuJSON)
+	})
+	attestMux.HandleFunc("/docker-compose", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "services:\n  llm:\n    image: test\n")
+	})
+	attestServer := httptest.NewTLSServer(attestMux)
+	defer attestServer.Close()
+	attestServer.TLS.Certificates = []tls.Certificate{cert}
+
+	portalMux := http.NewServeMux()
+	portalHandler := func(w http.ResponseWriter, _ *http.Request) {
+		resp := ParseQuoteResponse{
+			Quote:  &QuoteFields{MRTD: "aaaa", RTMR0: "bbbb", RTMR1: "cccc", RTMR2: "dddd", RTMR3: "eeee", ReportData: cpuReportData},
+			Status: &QuoteStatus{AttestationType: "tdx"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}
+	portalMux.HandleFunc("/api/quote-parse", portalHandler)
+	portalMux.HandleFunc("/api/quote-parse-sev", portalHandler)
+	portalServer := httptest.NewServer(portalMux)
+	defer portalServer.Close()
+
+	// NRAS returns a well-formed token but reports overall attestation failure.
+	nrasServer := httptest.NewServer(mockNRASHandler(t, false))
+	defer nrasServer.Close()
+
+	bv := NewBackendVerifier(portalServer.URL+"/api/quote-parse", nil, loadedRegistry(), nil, testLog())
+	bv.attestationClient = NewAttestationHTTPClient()
+	bv.nrasVerifier.baseURL = nrasServer.URL
+
+	err := bv.AttestBackend(context.Background(), "test-model-fail", attestServer.URL)
+	if err == nil {
+		t.Fatal("expected AttestBackend to fail when NRAS overall result is false")
+	}
+	if !strings.Contains(err.Error(), "overall-att-result") {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if status := bv.GetStatus("test-model-fail"); status == nil || status.Status != StatusFailed {
+		t.Fatalf("expected StatusFailed snapshot, got %+v", status)
+	}
+}
+
+func TestBackendVerifier_AttestBackend_RegistryNotLoaded(t *testing.T) {
+	cert, fingerprint := selfSignedCert(t)
+	cpuReportData := fingerprint + "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	cpuQuote := testTdxQuoteHex() // valid TDX quote so workload verification runs
+
+	attestMux := http.NewServeMux()
+	attestMux.HandleFunc("/cpu", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, cpuQuote)
+	})
+	attestMux.HandleFunc("/docker-compose", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, testComposeYAML)
+	})
+	attestServer := httptest.NewTLSServer(attestMux)
+	defer attestServer.Close()
+	attestServer.TLS.Certificates = []tls.Certificate{cert}
+
+	portalMux := http.NewServeMux()
+	portalHandler := func(w http.ResponseWriter, _ *http.Request) {
+		resp := ParseQuoteResponse{
+			Quote:  &QuoteFields{MRTD: "aaaa", RTMR0: "bbbb", RTMR1: "cccc", RTMR2: "dddd", RTMR3: "eeee", ReportData: cpuReportData},
+			Status: &QuoteStatus{AttestationType: "tdx"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}
+	portalMux.HandleFunc("/api/quote-parse", portalHandler)
+	portalMux.HandleFunc("/api/quote-parse-sev", portalHandler)
+	portalServer := httptest.NewServer(portalMux)
+	defer portalServer.Close()
+
+	// nil registry -> workload verification is unavailable -> must fail closed.
+	bv := NewBackendVerifier(portalServer.URL+"/api/quote-parse", nil, nil, nil, testLog())
+	bv.attestationClient = NewAttestationHTTPClient()
+
+	err := bv.AttestBackend(context.Background(), "test-model-noreg", attestServer.URL)
+	if err == nil {
+		t.Fatal("expected AttestBackend to fail closed when artifact registry is not loaded")
+	}
+	if !strings.Contains(err.Error(), "artifact registry not loaded") {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if status := bv.GetStatus("test-model-noreg"); status == nil || status.Status != StatusFailed {
+		t.Fatalf("expected StatusFailed snapshot, got %+v", status)
 	}
 }
 

--- a/proxy-router/internal/attestation/nras_verifier.go
+++ b/proxy-router/internal/attestation/nras_verifier.go
@@ -3,10 +3,12 @@ package attestation
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
 )
@@ -33,6 +35,14 @@ type GPUAttestationData struct {
 type NRASResult struct {
 	OverallToken string
 	GPUTokens    map[string]string
+
+	// EATNonce is the eat_nonce claim from the overall EAT token -- the nonce
+	// NRAS confirmed the GPU evidence was generated over. Empty if the overall
+	// token could not be decoded.
+	EATNonce string
+	// OverallResult is the x-nvidia-overall-att-result claim: NVIDIA's boolean
+	// pass/fail summary across all attested GPUs.
+	OverallResult bool
 }
 
 // NRASVerifier verifies GPU attestation evidence via NVIDIA Remote Attestation Service.
@@ -128,10 +138,51 @@ func parseNRASResponse(body []byte) (*NRASResult, error) {
 		return nil, fmt.Errorf("failed to parse NRAS GPU tokens: %w", err)
 	}
 
-	return &NRASResult{
+	result := &NRASResult{
 		OverallToken: overallPair[1],
 		GPUTokens:    gpuTokens,
-	}, nil
+	}
+
+	// Decode the overall EAT token's claims so callers can enforce the NVIDIA
+	// pass/fail result and bind the attested nonce back to the CPU quote.
+	// Best-effort here: a malformed token leaves the fields zero-valued and is
+	// treated as a hard failure by the caller (AttestBackend).
+	if nonce, overall, err := parseEATClaims(overallPair[1]); err == nil {
+		result.EATNonce = nonce
+		result.OverallResult = overall
+	}
+
+	return result, nil
+}
+
+// eatClaims holds the subset of NVIDIA EAT (Entity Attestation Token) claims we
+// enforce. See https://docs.nvidia.com/attestation/advanced-documentation/latest/claims-guide/gpu_claims.html
+type eatClaims struct {
+	Nonce         string `json:"eat_nonce"`
+	OverallResult bool   `json:"x-nvidia-overall-att-result"`
+}
+
+// parseEATClaims decodes the payload of a JWT-encoded EAT token and extracts the
+// eat_nonce and x-nvidia-overall-att-result claims. It does NOT verify the JWT
+// signature: the token is received directly from NRAS over a TLS-authenticated
+// connection to nras.attestation.nvidia.com, which is the source of trust.
+func parseEATClaims(token string) (nonce string, overallResult bool, err error) {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return "", false, fmt.Errorf("EAT token is not a well-formed JWT (%d segments)", len(parts))
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(parts[1], "="))
+	if err != nil {
+		return "", false, fmt.Errorf("failed to base64url-decode EAT payload: %w", err)
+	}
+
+	var claims eatClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", false, fmt.Errorf("failed to parse EAT claims JSON: %w", err)
+	}
+
+	return claims.Nonce, claims.OverallResult, nil
 }
 
 // ParseGPUAttestationData parses the raw JSON response from the SecretVM /gpu endpoint.

--- a/proxy-router/internal/attestation/nras_verifier_test.go
+++ b/proxy-router/internal/attestation/nras_verifier_test.go
@@ -2,6 +2,7 @@ package attestation
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -63,6 +64,62 @@ func TestParseGPUAttestationData_InvalidJSON(t *testing.T) {
 	_, err := ParseGPUAttestationData("not json")
 	if err == nil {
 		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func makeEATToken(t *testing.T, payloadJSON string) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(payloadJSON))
+	return header + "." + payload + ".c2ln"
+}
+
+func TestParseEATClaims_Valid(t *testing.T) {
+	token := makeEATToken(t, `{"eat_nonce":"aabbccdd1122","x-nvidia-overall-att-result":true}`)
+	nonce, overall, err := parseEATClaims(token)
+	if err != nil {
+		t.Fatalf("expected no error, got: %s", err)
+	}
+	if nonce != "aabbccdd1122" {
+		t.Fatalf("unexpected nonce: %s", nonce)
+	}
+	if !overall {
+		t.Fatal("expected overall result true")
+	}
+}
+
+func TestParseEATClaims_OverallFalse(t *testing.T) {
+	token := makeEATToken(t, `{"eat_nonce":"aabb","x-nvidia-overall-att-result":false}`)
+	_, overall, err := parseEATClaims(token)
+	if err != nil {
+		t.Fatalf("expected no error, got: %s", err)
+	}
+	if overall {
+		t.Fatal("expected overall result false")
+	}
+}
+
+func TestParseEATClaims_Malformed(t *testing.T) {
+	if _, _, err := parseEATClaims("not-a-jwt"); err == nil {
+		t.Fatal("expected error for non-JWT token")
+	}
+	if _, _, err := parseEATClaims("aGVhZGVy.@@@notbase64@@@.sig"); err == nil {
+		t.Fatal("expected error for invalid base64 payload")
+	}
+}
+
+func TestParseNRASResponse_PopulatesEATClaims(t *testing.T) {
+	overall := makeEATToken(t, `{"eat_nonce":"deadbeef","x-nvidia-overall-att-result":true}`)
+	resp := `[["JWT", "` + overall + `"], {"GPU-0": "eyGPU0"}]`
+	result, err := parseNRASResponse([]byte(resp))
+	if err != nil {
+		t.Fatalf("expected no error, got: %s", err)
+	}
+	if result.EATNonce != "deadbeef" {
+		t.Fatalf("unexpected eat_nonce: %s", result.EATNonce)
+	}
+	if !result.OverallResult {
+		t.Fatal("expected overall result true")
 	}
 }
 

--- a/proxy-router/internal/attestation/workload_verifier.go
+++ b/proxy-router/internal/attestation/workload_verifier.go
@@ -10,10 +10,10 @@ import (
 type WorkloadStatus string
 
 const (
-	WorkloadAuthentic         WorkloadStatus = "authentic_match"
-	WorkloadAuthenticMismatch WorkloadStatus = "authentic_mismatch"
-	WorkloadNotAuthentic      WorkloadStatus = "not_authentic"
-	WorkloadSkipped           WorkloadStatus = "skipped"
+	WorkloadAuthentic            WorkloadStatus = "authentic_match"
+	WorkloadAuthenticMismatch    WorkloadStatus = "authentic_mismatch"
+	WorkloadNotAuthentic         WorkloadStatus = "not_authentic"
+	ArtifactRegistryNotAvailable WorkloadStatus = "artifact_registry_not_available"
 )
 
 type WorkloadResult struct {
@@ -78,13 +78,19 @@ func VerifyTdxWorkload(registry *ArtifactRegistry, cpuQuoteHex string, dockerCom
 
 func VerifyWorkload(registry *ArtifactRegistry, sevRegistry *SevArtifactRegistry, cpuQuoteData string, dockerComposeYaml string, log lib.ILogger) WorkloadResult {
 	if IsTdxQuote(cpuQuoteData) {
+		if registry == nil || !registry.IsLoaded() {
+			if log != nil {
+				log.Warnf("workload: TDX quote detected but artifact registry not available; cannot verify workload")
+			}
+			return WorkloadResult{Status: ArtifactRegistryNotAvailable}
+		}
 		return VerifyTdxWorkload(registry, cpuQuoteData, dockerComposeYaml, log)
 	}
-	if sevRegistry != nil && sevRegistry.IsLoaded() {
-		return VerifySevWorkload(sevRegistry, cpuQuoteData, dockerComposeYaml, log)
+	if sevRegistry == nil || !sevRegistry.IsLoaded() {
+		if log != nil {
+			log.Warnf("workload: SEV quote detected but SEV registry not available; cannot verify workload")
+		}
+		return WorkloadResult{Status: ArtifactRegistryNotAvailable}
 	}
-	if log != nil {
-		log.Infof("workload: SEV quote detected but SEV registry not available, skipping")
-	}
-	return WorkloadResult{Status: WorkloadSkipped}
+	return VerifySevWorkload(sevRegistry, cpuQuoteData, dockerComposeYaml, log)
 }

--- a/proxy-router/internal/attestation/workload_verifier_test.go
+++ b/proxy-router/internal/attestation/workload_verifier_test.go
@@ -164,10 +164,34 @@ func TestVerifyWorkload_TdxQuote(t *testing.T) {
 	}
 }
 
-func TestVerifyWorkload_NonTdxQuote(t *testing.T) {
+func TestVerifyWorkload_TdxQuoteRegistryNil(t *testing.T) {
+	quoteHex := readTestFixture(t, "tdx_cpu_docker_check_quote.txt")
+	composeYaml := readTestFixture(t, "tdx_cpu_docker_check_compose.yaml")
+
+	// TDX quote but no artifact registry -> must fail closed.
+	result := VerifyWorkload(nil, nil, quoteHex, composeYaml, nil)
+	if result.Status != ArtifactRegistryNotAvailable {
+		t.Fatalf("status = %s, want %s", result.Status, ArtifactRegistryNotAvailable)
+	}
+}
+
+func TestVerifyWorkload_TdxQuoteRegistryNotLoaded(t *testing.T) {
+	quoteHex := readTestFixture(t, "tdx_cpu_docker_check_quote.txt")
+	composeYaml := readTestFixture(t, "tdx_cpu_docker_check_compose.yaml")
+
+	// Registry constructed but never fetched -> IsLoaded()==false -> fail closed.
+	unloaded := NewArtifactRegistry("", 0, &lib.LoggerMock{})
+	result := VerifyWorkload(unloaded, nil, quoteHex, composeYaml, nil)
+	if result.Status != ArtifactRegistryNotAvailable {
+		t.Fatalf("status = %s, want %s", result.Status, ArtifactRegistryNotAvailable)
+	}
+}
+
+func TestVerifyWorkload_NonTdxQuoteNoSevRegistry(t *testing.T) {
 	reg := testRegistry(t)
+	// SEV quote with no SEV registry available must fail closed (registry unavailable).
 	result := VerifyWorkload(reg, nil, "SGVsbG8gV29ybGQ=", "anything", nil)
-	if result.Status != WorkloadSkipped {
-		t.Fatalf("status = %s, want %s", result.Status, WorkloadSkipped)
+	if result.Status != ArtifactRegistryNotAvailable {
+		t.Fatalf("status = %s, want %s", result.Status, ArtifactRegistryNotAvailable)
 	}
 }


### PR DESCRIPTION
## Summary

Hardens the **backend TEE attestation** path (Phase 2: provider P-Node → its own LLM backend) so a `tee`-tagged model is only marked `StatusPassed` when GPU authenticity **and** workload identity are actually proven. Three fail-open gaps are closed; all now fail closed, which propagates to the provider's `FastVerifyBackend` gate and correctly rejects sessions.

All changes are confined to `proxy-router/internal/attestation/`.

## Changes

### 1. CPU↔GPU nonce binding — exact match (`backend_verifier.go`)
`VerifyCPUGPUBinding` used `compareLen = min(len(cpuNonce), len(gpuReportData))` and compared only that prefix. A GPU reportData equal to just the first N chars of the CPU-embedded nonce passed. Now requires an exact length match + `subtle.ConstantTimeCompare`.

### 2. NRAS is fatal and bound to the CPU quote (`backend_verifier.go`, `nras_verifier.go`)
Previously NRAS failure was a non-fatal warning and its result was never checked against the CPU nonce — so the "binding" only proved the backend copied a public value into two plaintext fields. Now step 7:
- fails the attestation if `VerifyGPU` errors,
- requires `x-nvidia-overall-att-result == true`,
- cross-checks the EAT `eat_nonce` claim against the CPU-bound nonce (prevents replay of a valid token for a different nonce).

Adds `parseEATClaims` to decode the overall EAT JWT payload (no signature verification needed — the token arrives over TLS-authenticated `nras.attestation.nvidia.com`, consistent with the existing trust model). Claim names verified against NVIDIA's GPU claims guide.

### 3. Workload verification mandatory / fail closed (`workload_verifier.go`, `backend_verifier.go`)
- Registry unavailable/unloaded or docker-compose unfetchable → hard failure (was: logged + `StatusPassed`).
- Removed the `WorkloadSkipped` status. The registry-availability check moved into `VerifyWorkload`, returning the new `ArtifactRegistryNotAvailable` status (handled fail-closed by `AttestBackend`).
- A non-TDX (SEV) quote with no loaded SEV registry now fails closed instead of silently passing. 

## Post-fix trust chain

A `tee` model attests `passed` only when: Intel-valid CPU TDX quote → TLS-bound → workload measured against a loaded registry → GPU nonce exactly binds to the CPU quote → NRAS confirms genuine NVIDIA-signed GPU evidence over that same nonce. Every step is fail-closed.

## Operational note

NRAS is now on the critical path. Providers on networks that can't reach `nras.attestation.nvidia.com` (403/timeout) will now fail attestation for `tee` models rather than silently passing.