### PR TITLE
feat(proxy-router): provider model health self-report loop

### DIFF
--- a/docs/providers/full/verify-setup.mdx
+++ b/docs/providers/full/verify-setup.mdx
@@ -22,6 +22,28 @@ Expected:
 { "status": "healthy", "version": "v7.0.0", "uptime": "..." }
 ```
 
+On provider nodes the response also includes a `models` array — the periodic model health self-report. For every model in `models-config.json` that has an active bid from your wallet, the proxy-router sends a small test prompt on a schedule (default hourly, see `MODEL_HEALTH_CHECK_INTERVAL` in [env-proxy-router](/reference/env-proxy-router)) and caches the result:
+
+```json
+{
+  "models": [
+    {
+      "modelId": "0xe086...",
+      "modelType": "LLM",
+      "hasActiveBid": true,
+      "bidId": "0x3f2a...",
+      "status": "healthy",
+      "lastHealthy": 1751871600,
+      "lastChecked": 1751871600,
+      "latencyMs": 412,
+      "promptCorrect": true
+    }
+  ]
+}
+```
+
+`status` is one of `healthy`, `unhealthy` (probe failed — see `errorKind`: `timeout`, `connection`, or `bad_response`), `no_bid` (configured model has no active bid, so it is not probed), or `skipped` (model type other than LLM/embedding). A model showing `unhealthy` here means consumers who open a session will hit the same failure, so fix the backend `apiUrl` before going further.
+
 Logs should show:
 
 ```

--- a/docs/providers/full/verify-setup.mdx
+++ b/docs/providers/full/verify-setup.mdx
@@ -22,7 +22,7 @@ Expected:
 { "status": "healthy", "version": "v7.0.0", "uptime": "..." }
 ```
 
-On provider nodes the response also includes a `models` array — the periodic model health self-report. For every model in `models-config.json` that has an active bid from your wallet, the proxy-router sends a small test prompt on a schedule (default hourly, see `MODEL_HEALTH_CHECK_INTERVAL` in [env-proxy-router](/reference/env-proxy-router)) and caches the result:
+On provider nodes the response also includes a `models` array — the periodic model health self-report covering your **whole ecosystem of configured models and active bids**. For every model in `models-config.json` that has an active bid from your wallet, the proxy-router sends a small test prompt on a schedule (default hourly, see `MODEL_HEALTH_CHECK_INTERVAL` in [env-proxy-router](/reference/env-proxy-router)) and caches the result. Active bids whose model is *missing* from `models-config.json` are also listed, so a bid you're selling but cannot serve doesn't go unnoticed:
 
 ```json
 {
@@ -37,12 +37,28 @@ On provider nodes the response also includes a `models` array — the periodic m
       "lastChecked": 1751871600,
       "latencyMs": 412,
       "promptCorrect": true
+    },
+    {
+      "modelId": "0x85670d...",
+      "modelType": "LLM",
+      "hasActiveBid": true,
+      "bidId": "0x9c41...",
+      "status": "no_model_configured",
+      "lastChecked": 1751871600
     }
   ]
 }
 ```
 
-`status` is one of `healthy`, `unhealthy` (probe failed — see `errorKind`: `timeout`, `connection`, or `bad_response`), `no_bid` (configured model has no active bid, so it is not probed), or `skipped` (model type other than LLM/embedding). A model showing `unhealthy` here means consumers who open a session will hit the same failure, so fix the backend `apiUrl` before going further.
+`status` is one of:
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| `healthy` | Probe succeeded (LLM answer graded via `promptCorrect`) | — |
+| `unhealthy` | Probe failed — see `errorKind`: `timeout`, `connection`, `bad_response` | Fix the backend `apiUrl`; consumers opening a session hit the same failure |
+| `no_bid` | Configured model has no active bid; not probed | Post a bid if you want to sell it |
+| `no_model_configured` | **Active bid exists but the model is missing from `models-config.json`** | Add the model entry or delete the bid — consumers can open sessions against this bid and get errors |
+| `skipped` | Model type other than LLM/embedding; not probed | — |
 
 Logs should show:
 

--- a/docs/proxy-router.all.env
+++ b/docs/proxy-router.all.env
@@ -83,6 +83,8 @@ RATING_CONFIG_PATH=./rating-config.json
 # Provider model health self-checks: periodically probe each configured model
 # that has an active bid from this wallet (LLM: arithmetic test prompt,
 # embedding: embeddings request) and expose sanitized results in GET /healthcheck.
+# Also flags active bids whose model is missing from models-config.json
+# (no_model_configured).
 # Set to true to disable the loop entirely.
 MODEL_HEALTH_CHECK_DISABLED=false
 # How often models are probed; results are cached between runs (default 1h)

--- a/docs/proxy-router.all.env
+++ b/docs/proxy-router.all.env
@@ -80,6 +80,15 @@ MODELS_CONFIG_PATH=./models-config.json
 MODELS_CONFIG_CONTENT='{"$schema":"./internal/config/models-config-schema.json","models":[{"modelId":"0x0000000000000000000000000000000000000000000000000000000000000000","modelName":"llama2","apiType":"openai","apiUrl":"http://localhost:8080/v1"},{"modelId":"0x0000000000000000000000000000000000000000000000000000000000000001","modelName":"inference.sdxl.txt2img.v1","apiType":"prodia-v2","apiUrl":"https://inference.prodia.com/v2","apiKey":"FILL_ME_IN"},{"modelId":"0x0000000000000000000000000000000000000000000000000000000000000002","modelName":"SDXL1.0-base","apiType":"hyperbolic-sd","apiUrl":"https://api.hyperbolic.xyz/v1","apiKey":"FILL_ME_IN","parameters":{"cfg_scale":"5","steps":"30"}},{"modelId":"0x0000000000000000000000000000000000000000000000000000000000000003","modelName":"claude-3-5-sonnet-20241022","apiType":"claudeai","apiUrl":"https://api.anthropic.com/v1","apiKey":"FILL_ME_IN"},{"modelId":"0x0000000000000000000000000000000000000000000000000000000000000004","modelName":"inference.sd15.txt2img.v1","apiType":"prodia-v2","apiUrl":"https://inference.prodia.com/v2","apiKey":"FILL_ME_IN"},{"modelId":"0x0000000000000000000000000000000000000000000000000000000000000005","modelName":"gpt-4o-mini","apiType":"openai","apiUrl":"https://api.openai.com/v1","apiKey":"FILL_ME_IN"}]}'
 # Path to rating configuration file
 RATING_CONFIG_PATH=./rating-config.json
+# Provider model health self-checks: periodically probe each configured model
+# that has an active bid from this wallet (LLM: arithmetic test prompt,
+# embedding: embeddings request) and expose sanitized results in GET /healthcheck.
+# Set to true to disable the loop entirely.
+MODEL_HEALTH_CHECK_DISABLED=false
+# How often models are probed; results are cached between runs (default 1h)
+MODEL_HEALTH_CHECK_INTERVAL=1h
+# Per-model probe timeout (default 60s)
+MODEL_HEALTH_CHECK_TIMEOUT=60s
 
 # System Configurations
 # Enable system-level configuration adjustments

--- a/docs/reference/env-proxy-router.mdx
+++ b/docs/reference/env-proxy-router.mdx
@@ -173,6 +173,16 @@ For TEE images logging is **frozen** to production / JSON / minimal at build tim
 
 For exact defaults check the source of truth ([`config.go`](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/blob/main/proxy-router/internal/config/config.go)) — these can change between releases as we tune the network.
 
+## Model health self-checks (provider)
+
+On provider nodes the proxy-router periodically probes every model from `models-config.json` that has an **active bid from this provider**: LLM models get a small dynamically generated arithmetic prompt (correctness is graded), embedding models get an embeddings request, and other model types are skipped. The cached per-model results (on-chain `modelId`, status, `lastHealthy` epoch, latency, prompt correctness — never the private `modelName`, `apiUrl`, or `apiKey`) are exposed in the `models` field of `GET /healthcheck`.
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `MODEL_HEALTH_CHECK_DISABLED` | `false` | Set `true` to disable the loop (the `models` field disappears from `/healthcheck`) |
+| `MODEL_HEALTH_CHECK_INTERVAL` | `1h` | How often models are probed; results are cached between runs |
+| `MODEL_HEALTH_CHECK_TIMEOUT` | `60s` | Per-model probe timeout |
+
 ## TEE (Phase 1 + Phase 2 attestation)
 
 These are only consulted when at least one model in the marketplace is `tee`-tagged. Otherwise they are unused.

--- a/docs/reference/env-proxy-router.mdx
+++ b/docs/reference/env-proxy-router.mdx
@@ -175,7 +175,7 @@ For exact defaults check the source of truth ([`config.go`](https://github.com/M
 
 ## Model health self-checks (provider)
 
-On provider nodes the proxy-router periodically probes every model from `models-config.json` that has an **active bid from this provider**: LLM models get a small dynamically generated arithmetic prompt (correctness is graded), embedding models get an embeddings request, and other model types are skipped. The cached per-model results (on-chain `modelId`, status, `lastHealthy` epoch, latency, prompt correctness — never the private `modelName`, `apiUrl`, or `apiKey`) are exposed in the `models` field of `GET /healthcheck`.
+On provider nodes the proxy-router periodically probes every model from `models-config.json` that has an **active bid from this provider**: LLM models get a small dynamically generated arithmetic prompt (correctness is graded), embedding models get an embeddings request, and other model types are skipped. The report covers the whole ecosystem of bids and configured models — active bids whose model is missing from `models-config.json` are flagged as `no_model_configured` (capacity being sold with no backend to serve it). The cached per-model results (on-chain `modelId`, `bidId`, status, `lastHealthy` epoch, latency, prompt correctness — never the private `modelName`, `apiUrl`, or `apiKey`) are exposed in the `models` field of `GET /healthcheck`, in the `network.ping` (pong) response on the `:3333` MOR RPC port, and in `POST /proxy/provider/ping`, so consumers can see a provider's model health before opening a session.
 
 | Variable | Default | Notes |
 |----------|---------|-------|

--- a/proxy-router/cmd/main.go
+++ b/proxy-router/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/handlers/httphandlers"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/interfaces"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/modelhealth"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/proxyapi"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/proxyctl"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/repositories/contracts"
@@ -298,7 +299,7 @@ func start() error {
 	proxyRouterApi.SetAttestationVerifier(teeVerifier)
 	if teeVerifier != nil {
 		teeVerifier.SetPingFunc(func(ctx context.Context, providerEndpoint string, providerAddr string) (string, error) {
-			_, version, err := proxyRouterApi.Ping(ctx, providerEndpoint, common.HexToAddress(providerAddr))
+			_, version, _, err := proxyRouterApi.Ping(ctx, providerEndpoint, common.HexToAddress(providerAddr))
 			return version, err
 		})
 	}
@@ -375,7 +376,21 @@ func start() error {
 	proxyController := proxyapi.NewProxyController(proxyRouterApi, aiEngine, chatStorage, *cfg.Proxy.StoreChatContext.Bool, *cfg.Proxy.ForwardChatContext.Bool, *authCfg, ipfsManager, log)
 	proxyController.SetBackendAttestationStatus(backendVerifier)
 	walletController := walletapi.NewWalletController(wallet, *authCfg)
-	systemController := system.NewSystemController(&cfg, wallet, rpcClientStore, sysConfig, appStartTime, chainID, appLog, ethConnectionValidator, *authCfg, storage)
+	var modelHealthChecker *modelhealth.Checker
+	// keep the interface nil when the checker is disabled to avoid a typed-nil
+	// passing the nil check in the healthcheck handler
+	var modelHealthReporter system.ModelHealthReporter
+	if !cfg.Proxy.ModelHealthCheckDisabled {
+		modelHealthChecker = modelhealth.NewChecker(modelhealth.Deps{
+			Adapters:     aiEngine,
+			Bids:         blockchainApi,
+			Tags:         blockchainApi,
+			ModelConfigs: modelConfigLoader,
+		}, cfg.Proxy.ModelHealthCheckInterval, cfg.Proxy.ModelHealthCheckTimeout, appLog)
+		modelHealthReporter = modelHealthChecker
+	}
+
+	systemController := system.NewSystemController(&cfg, wallet, rpcClientStore, sysConfig, appStartTime, chainID, appLog, ethConnectionValidator, *authCfg, storage, modelHealthReporter)
 	authController := authapi.NewAuthController(authCfg, cfg.Environment, appLog)
 
 	apiBus := apibus.NewApiBus(blockchainController, proxyController, walletController, systemController, authController)
@@ -392,7 +407,7 @@ func start() error {
 
 	appLog.Infof("API docs available at %s/swagger/index.html", cfg.Web.PublicUrl)
 
-	proxy := proxyctl.NewProxyCtl(eventListener, wallet, chainID, appLog, tcpLog, cfg.Proxy.Address, sessionStorage, modelConfigLoader, valid, aiEngine, blockchainApi, sessionRepo, sessionExpiryHandler, backendVerifier)
+	proxy := proxyctl.NewProxyCtl(eventListener, wallet, chainID, appLog, tcpLog, cfg.Proxy.Address, sessionStorage, modelConfigLoader, valid, aiEngine, blockchainApi, sessionRepo, sessionExpiryHandler, backendVerifier, modelHealthChecker)
 	err = proxy.Run(ctx)
 
 	cancelServer()

--- a/proxy-router/docs/docs.go
+++ b/proxy-router/docs/docs.go
@@ -3234,9 +3234,6 @@ const docTemplate = `{
                 "error": {
                     "type": "string"
                 },
-                "expiresAt": {
-                    "type": "string"
-                },
                 "modelId": {
                     "type": "string"
                 },
@@ -3262,14 +3259,12 @@ const docTemplate = `{
             "enum": [
                 "passed",
                 "failed",
-                "unknown",
-                "expired"
+                "unknown"
             ],
             "x-enum-varnames": [
                 "StatusPassed",
                 "StatusFailed",
-                "StatusUnknown",
-                "StatusExpired"
+                "StatusUnknown"
             ]
         },
         "attestation.TEEType": {
@@ -4080,6 +4075,12 @@ const docTemplate = `{
         "proxyapi.PingRes": {
             "type": "object",
             "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/system.ModelHealthReport"
+                    }
+                },
                 "ping": {
                     "type": "integer"
                 },
@@ -4767,6 +4768,12 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/system.ModelHealthReport"
+                    }
+                },
                 "status": {
                     "type": "string"
                 },
@@ -4774,6 +4781,41 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "system.ModelHealthReport": {
+            "type": "object",
+            "properties": {
+                "bidId": {
+                    "type": "string"
+                },
+                "errorKind": {
+                    "type": "string"
+                },
+                "hasActiveBid": {
+                    "type": "boolean"
+                },
+                "lastChecked": {
+                    "type": "integer"
+                },
+                "lastHealthy": {
+                    "type": "integer"
+                },
+                "latencyMs": {
+                    "type": "integer"
+                },
+                "modelId": {
+                    "type": "string"
+                },
+                "modelType": {
+                    "type": "string"
+                },
+                "promptCorrect": {
+                    "type": "boolean"
+                },
+                "status": {
                     "type": "string"
                 }
             }

--- a/proxy-router/docs/swagger.json
+++ b/proxy-router/docs/swagger.json
@@ -3226,9 +3226,6 @@
                 "error": {
                     "type": "string"
                 },
-                "expiresAt": {
-                    "type": "string"
-                },
                 "modelId": {
                     "type": "string"
                 },
@@ -3254,14 +3251,12 @@
             "enum": [
                 "passed",
                 "failed",
-                "unknown",
-                "expired"
+                "unknown"
             ],
             "x-enum-varnames": [
                 "StatusPassed",
                 "StatusFailed",
-                "StatusUnknown",
-                "StatusExpired"
+                "StatusUnknown"
             ]
         },
         "attestation.TEEType": {
@@ -4072,6 +4067,12 @@
         "proxyapi.PingRes": {
             "type": "object",
             "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/system.ModelHealthReport"
+                    }
+                },
                 "ping": {
                     "type": "integer"
                 },
@@ -4759,6 +4760,12 @@
                         "type": "string"
                     }
                 },
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/system.ModelHealthReport"
+                    }
+                },
                 "status": {
                     "type": "string"
                 },
@@ -4766,6 +4773,41 @@
                     "type": "string"
                 },
                 "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "system.ModelHealthReport": {
+            "type": "object",
+            "properties": {
+                "bidId": {
+                    "type": "string"
+                },
+                "errorKind": {
+                    "type": "string"
+                },
+                "hasActiveBid": {
+                    "type": "boolean"
+                },
+                "lastChecked": {
+                    "type": "integer"
+                },
+                "lastHealthy": {
+                    "type": "integer"
+                },
+                "latencyMs": {
+                    "type": "integer"
+                },
+                "modelId": {
+                    "type": "string"
+                },
+                "modelType": {
+                    "type": "string"
+                },
+                "promptCorrect": {
+                    "type": "boolean"
+                },
+                "status": {
                     "type": "string"
                 }
             }

--- a/proxy-router/docs/swagger.yaml
+++ b/proxy-router/docs/swagger.yaml
@@ -65,8 +65,6 @@ definitions:
         type: string
       error:
         type: string
-      expiresAt:
-        type: string
       modelId:
         type: string
       status:
@@ -85,13 +83,11 @@ definitions:
     - passed
     - failed
     - unknown
-    - expired
     type: string
     x-enum-varnames:
     - StatusPassed
     - StatusFailed
     - StatusUnknown
-    - StatusExpired
   attestation.TEEType:
     enum:
     - TDX
@@ -632,6 +628,10 @@ definitions:
     type: object
   proxyapi.PingRes:
     properties:
+      models:
+        items:
+          $ref: '#/definitions/system.ModelHealthReport'
+        type: array
       ping:
         type: integer
       version:
@@ -1091,11 +1091,38 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      models:
+        items:
+          $ref: '#/definitions/system.ModelHealthReport'
+        type: array
       status:
         type: string
       uptime:
         type: string
       version:
+        type: string
+    type: object
+  system.ModelHealthReport:
+    properties:
+      bidId:
+        type: string
+      errorKind:
+        type: string
+      hasActiveBid:
+        type: boolean
+      lastChecked:
+        type: integer
+      lastHealthy:
+        type: integer
+      latencyMs:
+        type: integer
+      modelId:
+        type: string
+      modelType:
+        type: string
+      promptCorrect:
+        type: boolean
+      status:
         type: string
     type: object
   system.SetEthNodeURLReq:

--- a/proxy-router/internal/blockchainapi/service.go
+++ b/proxy-router/internal/blockchainapi/service.go
@@ -1472,7 +1472,7 @@ func (s *BlockchainService) GetMyAddress(ctx context.Context) (common.Address, e
 }
 
 func (s *BlockchainService) CheckConnectivity(ctx context.Context, url string, addr common.Address) (time.Duration, error) {
-	dur, _, err := s.proxyService.Ping(ctx, url, addr)
+	dur, _, _, err := s.proxyService.Ping(ctx, url, addr)
 	return dur, err
 }
 

--- a/proxy-router/internal/config/config.go
+++ b/proxy-router/internal/config/config.go
@@ -74,6 +74,9 @@ type Config struct {
 		CNodePNodeTimeout         time.Duration `env:"CNODE_PNODE_TIMEOUT" flag:"cnode-pnode-timeout" validate:"omitempty" desc:"per-attempt timeout for CNode waiting for PNode first response"`
 		CNodePNodeMaxRetries      int           `env:"CNODE_PNODE_MAX_RETRIES" flag:"cnode-pnode-max-retries" validate:"omitempty,gte=0" desc:"max retries for CNode to PNode read timeout (chat/embeddings)"`
 		CNodePNodeAudioMaxRetries int           `env:"CNODE_PNODE_AUDIO_MAX_RETRIES" flag:"cnode-pnode-audio-max-retries" validate:"omitempty,gte=0" desc:"max retries for CNode to PNode read timeout (audio transcription/speech)"`
+		ModelHealthCheckDisabled  bool          `env:"MODEL_HEALTH_CHECK_DISABLED" flag:"model-health-check-disabled" desc:"disable periodic model health self-checks on provider"`
+		ModelHealthCheckInterval  time.Duration `env:"MODEL_HEALTH_CHECK_INTERVAL" flag:"model-health-check-interval" validate:"omitempty,duration" desc:"how often to probe configured models with a test prompt, result is cached between runs"`
+		ModelHealthCheckTimeout   time.Duration `env:"MODEL_HEALTH_CHECK_TIMEOUT" flag:"model-health-check-timeout" validate:"omitempty,duration" desc:"per-model health probe timeout"`
 	}
 	System struct {
 		Enable           bool   `env:"SYS_ENABLE"              flag:"sys-enable" desc:"enable system level configuration adjustments"`
@@ -209,6 +212,12 @@ func (cfg *Config) SetDefaults() {
 	if cfg.Proxy.CNodePNodeAudioMaxRetries == 0 {
 		cfg.Proxy.CNodePNodeAudioMaxRetries = 20
 	}
+	if cfg.Proxy.ModelHealthCheckInterval == 0 {
+		cfg.Proxy.ModelHealthCheckInterval = 1 * time.Hour
+	}
+	if cfg.Proxy.ModelHealthCheckTimeout == 0 {
+		cfg.Proxy.ModelHealthCheckTimeout = 60 * time.Second
+	}
 
 	// IPFS
 	if cfg.IPFS.Address == "" {
@@ -267,6 +276,9 @@ func (cfg *Config) GetSanitized() interface{} {
 	publicCfg.Proxy.CNodePNodeTimeout = cfg.Proxy.CNodePNodeTimeout
 	publicCfg.Proxy.CNodePNodeMaxRetries = cfg.Proxy.CNodePNodeMaxRetries
 	publicCfg.Proxy.CNodePNodeAudioMaxRetries = cfg.Proxy.CNodePNodeAudioMaxRetries
+	publicCfg.Proxy.ModelHealthCheckDisabled = cfg.Proxy.ModelHealthCheckDisabled
+	publicCfg.Proxy.ModelHealthCheckInterval = cfg.Proxy.ModelHealthCheckInterval
+	publicCfg.Proxy.ModelHealthCheckTimeout = cfg.Proxy.ModelHealthCheckTimeout
 
 	publicCfg.System.Enable = cfg.System.Enable
 	publicCfg.System.LocalPortRange = cfg.System.LocalPortRange

--- a/proxy-router/internal/config/config.go
+++ b/proxy-router/internal/config/config.go
@@ -58,19 +58,19 @@ type Config struct {
 		LevelStorage string `env:"LOG_LEVEL_STORAGE"     flag:"log-level-storage"     validate:"omitempty,oneof=debug info warn error dpanic panic fatal"`
 	}
 	Proxy struct {
-		Address             string    `env:"PROXY_ADDRESS" flag:"proxy-address" validate:"required,hostname_port"`
-		StoragePath         string    `env:"PROXY_STORAGE_PATH"    flag:"proxy-storage-path"    validate:"omitempty,dirpath" desc:"enables file storage and sets the folder path"`
-		StoreChatContext    *lib.Bool `env:"PROXY_STORE_CHAT_CONTEXT" flag:"proxy-store-chat-context" desc:"store chat context in the proxy storage"`
-		ForwardChatContext  *lib.Bool `env:"PROXY_FORWARD_CHAT_CONTEXT" flag:"proxy-forward-chat-context" desc:"prepend whole stored message history to the prompt"`
-		AgentConfigPath     string    `env:"AGENT_CONFIG_PATH" flag:"agent-config-path" validate:"omitempty"`
-		AgentConfigContent  string    `env:"AGENT_CONFIG_CONTENT" flag:"agent-config-content" validate:"omitempty" desc:"content of the agent config file"`
-		ModelsConfigPath    string    `env:"MODELS_CONFIG_PATH" flag:"models-config-path" validate:"omitempty"`
-		ModelsConfigContent string    `env:"MODELS_CONFIG_CONTENT" flag:"models-config-content" validate:"omitempty" desc:"content of the models config file"`
-		RatingConfigPath    string    `env:"RATING_CONFIG_PATH" flag:"rating-config-path" validate:"omitempty" desc:"path to the rating config file"`
-		CookieFilePath      string    `env:"COOKIE_FILE_PATH" flag:"cookie-file-path" validate:"omitempty" desc:"path to the cookie file"`
-		CookieContent       string    `env:"COOKIE_CONTENT" flag:"cookie-content" validate:"omitempty" desc:"content of the cookie file"`
-		AuthConfigFilePath   string        `env:"AUTH_CONFIG_FILE_PATH" flag:"auth-config-file-path" validate:"omitempty"`
-		LLMTimeout           time.Duration `env:"LLM_TIMEOUT" flag:"llm-timeout" validate:"omitempty" desc:"timeout for PNode to LLM requests, applies to both streaming and non-streaming"`
+		Address                   string        `env:"PROXY_ADDRESS" flag:"proxy-address" validate:"required,hostname_port"`
+		StoragePath               string        `env:"PROXY_STORAGE_PATH"    flag:"proxy-storage-path"    validate:"omitempty,dirpath" desc:"enables file storage and sets the folder path"`
+		StoreChatContext          *lib.Bool     `env:"PROXY_STORE_CHAT_CONTEXT" flag:"proxy-store-chat-context" desc:"store chat context in the proxy storage"`
+		ForwardChatContext        *lib.Bool     `env:"PROXY_FORWARD_CHAT_CONTEXT" flag:"proxy-forward-chat-context" desc:"prepend whole stored message history to the prompt"`
+		AgentConfigPath           string        `env:"AGENT_CONFIG_PATH" flag:"agent-config-path" validate:"omitempty"`
+		AgentConfigContent        string        `env:"AGENT_CONFIG_CONTENT" flag:"agent-config-content" validate:"omitempty" desc:"content of the agent config file"`
+		ModelsConfigPath          string        `env:"MODELS_CONFIG_PATH" flag:"models-config-path" validate:"omitempty"`
+		ModelsConfigContent       string        `env:"MODELS_CONFIG_CONTENT" flag:"models-config-content" validate:"omitempty" desc:"content of the models config file"`
+		RatingConfigPath          string        `env:"RATING_CONFIG_PATH" flag:"rating-config-path" validate:"omitempty" desc:"path to the rating config file"`
+		CookieFilePath            string        `env:"COOKIE_FILE_PATH" flag:"cookie-file-path" validate:"omitempty" desc:"path to the cookie file"`
+		CookieContent             string        `env:"COOKIE_CONTENT" flag:"cookie-content" validate:"omitempty" desc:"content of the cookie file"`
+		AuthConfigFilePath        string        `env:"AUTH_CONFIG_FILE_PATH" flag:"auth-config-file-path" validate:"omitempty"`
+		LLMTimeout                time.Duration `env:"LLM_TIMEOUT" flag:"llm-timeout" validate:"omitempty" desc:"timeout for PNode to LLM requests, applies to both streaming and non-streaming"`
 		CNodePNodeTimeout         time.Duration `env:"CNODE_PNODE_TIMEOUT" flag:"cnode-pnode-timeout" validate:"omitempty" desc:"per-attempt timeout for CNode waiting for PNode first response"`
 		CNodePNodeMaxRetries      int           `env:"CNODE_PNODE_MAX_RETRIES" flag:"cnode-pnode-max-retries" validate:"omitempty,gte=0" desc:"max retries for CNode to PNode read timeout (chat/embeddings)"`
 		CNodePNodeAudioMaxRetries int           `env:"CNODE_PNODE_AUDIO_MAX_RETRIES" flag:"cnode-pnode-audio-max-retries" validate:"omitempty,gte=0" desc:"max retries for CNode to PNode read timeout (audio transcription/speech)"`
@@ -88,8 +88,8 @@ type Config struct {
 		TcpMaxSynBacklog string `env:"SYS_TCP_MAX_SYN_BACKLOG" flag:"sys-tcp-max-syn-backlog" desc:""`
 	}
 	TEE struct {
-		PortalURL                  string        `env:"TEE_PORTAL_URL"  flag:"tee-portal-url"  validate:"omitempty,url" desc:"SecretAI Portal API URL for TEE attestation quote parsing"`
-		ImageRepo                  string        `env:"TEE_IMAGE_REPO"  flag:"tee-image-repo"  validate:"omitempty"     desc:"GHCR image repo for cosign attestation verification (e.g. ghcr.io/morpheusais/morpheus-lumerin-node-tee)"`
+		PortalURL                       string        `env:"TEE_PORTAL_URL"  flag:"tee-portal-url"  validate:"omitempty,url" desc:"SecretAI Portal API URL for TEE attestation quote parsing"`
+		ImageRepo                       string        `env:"TEE_IMAGE_REPO"  flag:"tee-image-repo"  validate:"omitempty"     desc:"GHCR image repo for cosign attestation verification (e.g. ghcr.io/morpheusais/morpheus-lumerin-node-tee)"`
 		ArtifactRegistryURL             string        `env:"ARTIFACT_REGISTRY_URL" flag:"artifact-registry-url" validate:"omitempty,url" desc:"URL for SecretVM TDX artifact registry CSV"`
 		SevArtifactRegistryURL          string        `env:"SEV_ARTIFACT_REGISTRY_URL" flag:"sev-artifact-registry-url" validate:"omitempty,url" desc:"URL for SecretVM SEV-SNP artifact registry JSON"`
 		ArtifactRegistryRefreshInterval time.Duration `env:"ARTIFACT_REGISTRY_REFRESH_INTERVAL" flag:"artifact-registry-refresh-interval" validate:"omitempty" desc:"how often to refresh the artifact registry"`
@@ -231,7 +231,6 @@ func (cfg *Config) SetDefaults() {
 	if cfg.TEE.ImageRepo == "" {
 		cfg.TEE.ImageRepo = "ghcr.io/morpheusais/morpheus-lumerin-node-tee"
 	}
-
 
 	cfg.Log.FolderPath = filepath.FromSlash(cfg.Log.FolderPath)
 	cfg.Proxy.StoragePath = filepath.FromSlash(cfg.Proxy.StoragePath)

--- a/proxy-router/internal/modelhealth/checker.go
+++ b/proxy-router/internal/modelhealth/checker.go
@@ -1,0 +1,363 @@
+// Package modelhealth periodically verifies that the models from
+// models-config.json that have an active on-chain bid from this provider
+// actually respond to inference requests. Results are cached in memory and
+// exposed through the public /healthcheck endpoint, deliberately excluding
+// private config fields (modelName, apiUrl, apiKey).
+package modelhealth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"net"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/aiengine"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/blockchainapi"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/blockchainapi/structs"
+	gcs "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/chatstorage/genericchatstorage"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/config"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/repositories/registries"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/system"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sashabaranov/go-openai"
+)
+
+const bidsPageLimit = 100
+
+type AdapterProvider interface {
+	GetAdapter(ctx context.Context, chatID, modelID, sessionID common.Hash, storeChatContext, forwardChatContext bool) (aiengine.AIEngineStream, error)
+}
+
+type BidProvider interface {
+	GetActiveBidsByProvider(ctx context.Context, provider common.Address, offset *big.Int, limit uint8, order registries.Order) ([]*structs.Bid, error)
+}
+
+type ModelTagsProvider interface {
+	GetModelTags(ctx context.Context, modelID common.Hash) ([]string, error)
+}
+
+type ModelConfigProvider interface {
+	GetAll() ([]common.Hash, []config.ModelConfig)
+}
+
+type Checker struct {
+	deps     Deps
+	interval time.Duration
+	timeout  time.Duration
+	log      lib.ILogger
+
+	mu         sync.RWMutex
+	reports    map[string]system.ModelHealthReport
+	modelTypes map[string]structs.ModelType
+}
+
+// Deps groups the external dependencies of the checker.
+type Deps struct {
+	Adapters     AdapterProvider
+	Bids         BidProvider
+	Tags         ModelTagsProvider
+	ModelConfigs ModelConfigProvider
+}
+
+func NewChecker(deps Deps, interval, timeout time.Duration, log lib.ILogger) *Checker {
+	return &Checker{
+		deps:       deps,
+		interval:   interval,
+		timeout:    timeout,
+		log:        log.Named("MODEL_HEALTH"),
+		reports:    make(map[string]system.ModelHealthReport),
+		modelTypes: make(map[string]structs.ModelType),
+	}
+}
+
+// Run probes all configured models immediately and then on every interval
+// tick until the context is cancelled. It never returns a non-context error
+// so a probe failure cannot bring down the provider errgroup.
+func (c *Checker) Run(ctx context.Context, walletAddr common.Address) error {
+	c.checkAll(ctx, walletAddr)
+
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			c.checkAll(ctx, walletAddr)
+		}
+	}
+}
+
+// GetReports returns a snapshot of the latest per-model reports sorted by model ID.
+func (c *Checker) GetReports() []system.ModelHealthReport {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	reports := make([]system.ModelHealthReport, 0, len(c.reports))
+	for _, r := range c.reports {
+		reports = append(reports, r)
+	}
+	sort.Slice(reports, func(i, j int) bool { return reports[i].ModelID < reports[j].ModelID })
+	return reports
+}
+
+func (c *Checker) checkAll(ctx context.Context, walletAddr common.Address) {
+	modelIDs, _ := c.deps.ModelConfigs.GetAll()
+	if len(modelIDs) == 0 {
+		return
+	}
+
+	bidsByModel, err := c.activeBidModels(ctx, walletAddr)
+	if err != nil {
+		c.log.Warnf("cannot get active bids by provider %s: %s", walletAddr, err)
+		return
+	}
+
+	for _, modelID := range modelIDs {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		bidID, hasBid := bidsByModel[modelID]
+		c.checkModel(ctx, modelID, bidID, hasBid)
+	}
+}
+
+// activeBidModels maps each model with an active bid from this provider to
+// its most recent bid ID (bids are fetched newest-first).
+func (c *Checker) activeBidModels(ctx context.Context, walletAddr common.Address) (map[common.Hash]common.Hash, error) {
+	bids, err := c.deps.Bids.GetActiveBidsByProvider(ctx, walletAddr, big.NewInt(0), bidsPageLimit, registries.OrderDESC)
+	if err != nil {
+		return nil, err
+	}
+
+	byModel := make(map[common.Hash]common.Hash, len(bids))
+	for _, bid := range bids {
+		if _, ok := byModel[bid.ModelAgentId]; !ok {
+			byModel[bid.ModelAgentId] = bid.Id
+		}
+	}
+	return byModel, nil
+}
+
+func (c *Checker) checkModel(ctx context.Context, modelID common.Hash, bidID common.Hash, hasBid bool) {
+	report := system.ModelHealthReport{
+		ModelID:      modelID.Hex(),
+		HasActiveBid: hasBid,
+		LastChecked:  time.Now().Unix(),
+	}
+
+	if hasBid {
+		report.BidID = bidID.Hex()
+	}
+
+	if prev, ok := c.getReport(modelID.Hex()); ok {
+		report.LastHealthy = prev.LastHealthy
+	}
+
+	if !hasBid {
+		report.Status = system.ModelHealthStatusNoBid
+		c.setReport(report)
+		return
+	}
+
+	modelType, err := c.modelType(ctx, modelID)
+	if err != nil {
+		c.log.Warnf("model %s: cannot resolve model type: %s", lib.Short(modelID), err)
+		report.Status = system.ModelHealthStatusSkipped
+		report.ErrorKind = system.ModelHealthErrorTypeLookup
+		c.setReport(report)
+		return
+	}
+	report.ModelType = string(modelType)
+
+	var probe func(ctx context.Context, adapter aiengine.AIEngineStream, report *system.ModelHealthReport) error
+	switch modelType {
+	case structs.ModelTypeLLM:
+		probe = c.probeLLM
+	case structs.ModelTypeEMBEDDING:
+		probe = c.probeEmbeddings
+	default:
+		report.Status = system.ModelHealthStatusSkipped
+		c.setReport(report)
+		return
+	}
+
+	adapter, err := c.deps.Adapters.GetAdapter(ctx, common.Hash{}, modelID, common.Hash{}, false, false)
+	if err != nil {
+		c.log.Warnf("model %s: cannot get adapter: %s", lib.Short(modelID), err)
+		report.Status = system.ModelHealthStatusUnhealthy
+		report.ErrorKind = system.ModelHealthErrorBadResponse
+		c.setReport(report)
+		return
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	start := time.Now()
+	err = probe(probeCtx, adapter, &report)
+	report.LatencyMs = time.Since(start).Milliseconds()
+
+	if err != nil {
+		c.log.Warnf("model %s: probe failed: %s", lib.Short(modelID), err)
+		report.Status = system.ModelHealthStatusUnhealthy
+		report.ErrorKind = classifyError(err)
+	} else {
+		report.Status = system.ModelHealthStatusHealthy
+		report.LastHealthy = time.Now().Unix()
+	}
+
+	c.setReport(report)
+}
+
+func (c *Checker) probeLLM(ctx context.Context, adapter aiengine.AIEngineStream, report *system.ModelHealthReport) error {
+	a, b, prompt := generateArithmeticPrompt()
+
+	req := &gcs.OpenAICompletionRequestExtra{
+		ChatCompletionRequest: openai.ChatCompletionRequest{
+			Messages: []openai.ChatCompletionMessage{
+				{Role: openai.ChatMessageRoleUser, Content: prompt},
+			},
+			Stream: false,
+		},
+	}
+
+	var response strings.Builder
+	var engineErr error
+	err := adapter.Prompt(ctx, req, func(ctx context.Context, chunk gcs.Chunk, aiEngineErr *gcs.AiEngineErrorResponse) error {
+		if aiEngineErr != nil {
+			engineErr = errors.New("model backend returned an error response")
+			return nil
+		}
+		if chunk != nil {
+			response.WriteString(chunk.String())
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if engineErr != nil {
+		return engineErr
+	}
+	if response.Len() == 0 {
+		return errors.New("empty completion response")
+	}
+
+	correct := verifyArithmeticAnswer(response.String(), a+b)
+	report.PromptCorrect = &correct
+	return nil
+}
+
+func (c *Checker) probeEmbeddings(ctx context.Context, adapter aiengine.AIEngineStream, report *system.ModelHealthReport) error {
+	req := &gcs.EmbeddingsRequest{
+		EmbeddingRequest: openai.EmbeddingRequest{Input: "health check"},
+	}
+
+	var gotVector bool
+	err := adapter.Embeddings(ctx, req, func(ctx context.Context, chunk gcs.Chunk, aiEngineErr *gcs.AiEngineErrorResponse) error {
+		if aiEngineErr != nil {
+			return nil
+		}
+		resp, ok := chunk.Data().(gcs.EmbeddingsResponse)
+		if !ok {
+			return nil
+		}
+		if len(resp.Data) > 0 && len(resp.Data[0].Embedding) > 0 {
+			gotVector = true
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if !gotVector {
+		return errors.New("empty embeddings response")
+	}
+	return nil
+}
+
+func (c *Checker) modelType(ctx context.Context, modelID common.Hash) (structs.ModelType, error) {
+	c.mu.RLock()
+	cached, ok := c.modelTypes[modelID.Hex()]
+	c.mu.RUnlock()
+	if ok {
+		return cached, nil
+	}
+
+	tags, err := c.deps.Tags.GetModelTags(ctx, modelID)
+	if err != nil {
+		return structs.ModelTypeUnknown, err
+	}
+
+	modelType := blockchainapi.DetectModelType(tags)
+
+	c.mu.Lock()
+	c.modelTypes[modelID.Hex()] = modelType
+	c.mu.Unlock()
+	return modelType, nil
+}
+
+func (c *Checker) getReport(modelID string) (system.ModelHealthReport, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	r, ok := c.reports[modelID]
+	return r, ok
+}
+
+func (c *Checker) setReport(report system.ModelHealthReport) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.reports[report.ModelID] = report
+}
+
+// generateArithmeticPrompt returns two random small numbers and a prompt
+// asking for their sum, so cached/replayed answers cannot fake correctness.
+func generateArithmeticPrompt() (int, int, string) {
+	a := rand.Intn(50) + 1
+	b := rand.Intn(50) + 1
+	return a, b, fmt.Sprintf("What is %d+%d? Reply with only the number.", a, b)
+}
+
+func verifyArithmeticAnswer(response string, expected int) bool {
+	re := regexp.MustCompile(fmt.Sprintf(`(^|[^\d])%d($|[^\d])`, expected))
+	return re.MatchString(response)
+}
+
+// classifyError maps a probe error to a coarse category so error details
+// (which may contain the private backend URL) never leak into the report.
+func classifyError(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return system.ModelHealthErrorTimeout
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		if netErr.Timeout() {
+			return system.ModelHealthErrorTimeout
+		}
+		return system.ModelHealthErrorConnection
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return system.ModelHealthErrorConnection
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "connection refused") || strings.Contains(msg, "no such host") || strings.Contains(msg, "failed to send request") {
+		return system.ModelHealthErrorConnection
+	}
+	if strings.Contains(msg, "context deadline exceeded") {
+		return system.ModelHealthErrorTimeout
+	}
+	return system.ModelHealthErrorBadResponse
+}

--- a/proxy-router/internal/modelhealth/checker.go
+++ b/proxy-router/internal/modelhealth/checker.go
@@ -30,7 +30,12 @@ import (
 	"github.com/sashabaranov/go-openai"
 )
 
-const bidsPageLimit = 100
+const (
+	bidsPageLimit = 100
+	// maxBidPages caps pagination (10k bids) as a fail-safe against a
+	// misbehaving RPC that keeps returning full pages.
+	maxBidPages = 100
+)
 
 type AdapterProvider interface {
 	GetAdapter(ctx context.Context, chatID, modelID, sessionID common.Hash, storeChatContext, forwardChatContext bool) (aiengine.AIEngineStream, error)
@@ -110,17 +115,20 @@ func (c *Checker) GetReports() []system.ModelHealthReport {
 	return reports
 }
 
+// checkAll reports on the provider's whole ecosystem: every configured model
+// (probed when it has an active bid) plus every active bid whose model is
+// missing from models-config.json (reported as no_model_configured — the
+// provider is selling capacity it cannot serve).
 func (c *Checker) checkAll(ctx context.Context, walletAddr common.Address) {
 	modelIDs, _ := c.deps.ModelConfigs.GetAll()
-	if len(modelIDs) == 0 {
-		return
-	}
 
 	bidsByModel, err := c.activeBidModels(ctx, walletAddr)
 	if err != nil {
 		c.log.Warnf("cannot get active bids by provider %s: %s", walletAddr, err)
 		return
 	}
+
+	seen := make(map[string]bool, len(modelIDs)+len(bidsByModel))
 
 	for _, modelID := range modelIDs {
 		select {
@@ -130,23 +138,87 @@ func (c *Checker) checkAll(ctx context.Context, walletAddr common.Address) {
 		}
 		bidID, hasBid := bidsByModel[modelID]
 		c.checkModel(ctx, modelID, bidID, hasBid)
+		seen[modelID.Hex()] = true
+	}
+
+	for modelID, bidID := range bidsByModel {
+		if seen[modelID.Hex()] {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		c.reportUnconfigured(ctx, modelID, bidID)
+		seen[modelID.Hex()] = true
+	}
+
+	c.prune(seen)
+}
+
+// reportUnconfigured records a bid whose model has no entry in
+// models-config.json. There is no backend to probe, so only the on-chain
+// facts (bid ID, model type from tags) are reported.
+func (c *Checker) reportUnconfigured(ctx context.Context, modelID common.Hash, bidID common.Hash) {
+	report := system.ModelHealthReport{
+		ModelID:      modelID.Hex(),
+		HasActiveBid: true,
+		BidID:        bidID.Hex(),
+		Status:       system.ModelHealthStatusNoModel,
+		LastChecked:  time.Now().Unix(),
+	}
+
+	c.log.Warnf("active bid %s for model %s has no entry in models config", lib.Short(bidID), lib.Short(modelID))
+
+	if modelType, err := c.modelType(ctx, modelID); err == nil {
+		report.ModelType = string(modelType)
+	}
+
+	c.setReport(report)
+}
+
+// prune drops cached reports for models that are no longer configured and no
+// longer have an active bid, so removed models don't linger in the report.
+func (c *Checker) prune(seen map[string]bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for id := range c.reports {
+		if !seen[id] {
+			delete(c.reports, id)
+		}
 	}
 }
 
 // activeBidModels maps each model with an active bid from this provider to
-// its most recent bid ID (bids are fetched newest-first).
+// its most recent bid ID (bids are fetched newest-first). Pages through all
+// active bids so providers with more than one page are fully covered.
 func (c *Checker) activeBidModels(ctx context.Context, walletAddr common.Address) (map[common.Hash]common.Hash, error) {
-	bids, err := c.deps.Bids.GetActiveBidsByProvider(ctx, walletAddr, big.NewInt(0), bidsPageLimit, registries.OrderDESC)
-	if err != nil {
-		return nil, err
-	}
+	byModel := make(map[common.Hash]common.Hash)
 
-	byModel := make(map[common.Hash]common.Hash, len(bids))
-	for _, bid := range bids {
-		if _, ok := byModel[bid.ModelAgentId]; !ok {
-			byModel[bid.ModelAgentId] = bid.Id
+	for page := 0; ; page++ {
+		if page == maxBidPages {
+			c.log.Warnf("provider %s has more than %d active bids, health report may be incomplete", walletAddr, maxBidPages*bidsPageLimit)
+			break
+		}
+
+		offset := big.NewInt(int64(page) * bidsPageLimit)
+		bids, err := c.deps.Bids.GetActiveBidsByProvider(ctx, walletAddr, offset, bidsPageLimit, registries.OrderDESC)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, bid := range bids {
+			if _, ok := byModel[bid.ModelAgentId]; !ok {
+				byModel[bid.ModelAgentId] = bid.Id
+			}
+		}
+
+		if len(bids) < bidsPageLimit {
+			break
 		}
 	}
+
 	return byModel, nil
 }
 

--- a/proxy-router/internal/modelhealth/checker_test.go
+++ b/proxy-router/internal/modelhealth/checker_test.go
@@ -56,10 +56,11 @@ func TestVerifyArithmeticAnswer(t *testing.T) {
 }
 
 var (
-	modelLLM       = common.HexToHash("0x01")
-	modelEmbedding = common.HexToHash("0x02")
-	modelNoBid     = common.HexToHash("0x03")
-	modelTTS       = common.HexToHash("0x04")
+	modelLLM          = common.HexToHash("0x01")
+	modelEmbedding    = common.HexToHash("0x02")
+	modelNoBid        = common.HexToHash("0x03")
+	modelTTS          = common.HexToHash("0x04")
+	modelUnconfigured = common.HexToHash("0x05")
 )
 
 type mockDeps struct {
@@ -72,7 +73,18 @@ type mockDeps struct {
 }
 
 func (m *mockDeps) GetActiveBidsByProvider(ctx context.Context, provider common.Address, offset *big.Int, limit uint8, order registries.Order) ([]*structs.Bid, error) {
-	return m.bids, m.bidsErr
+	if m.bidsErr != nil {
+		return nil, m.bidsErr
+	}
+	from := int(offset.Int64())
+	if from >= len(m.bids) {
+		return nil, nil
+	}
+	to := from + int(limit)
+	if to > len(m.bids) {
+		to = len(m.bids)
+	}
+	return m.bids[from:to], nil
 }
 
 func (m *mockDeps) GetModelTags(ctx context.Context, modelID common.Hash) ([]string, error) {
@@ -169,11 +181,12 @@ func TestCheckAllStatuses(t *testing.T) {
 	olderLLMBid := &structs.Bid{Id: common.HexToHash("0xdead"), ModelAgentId: modelLLM}
 	deps := &mockDeps{
 		// bids come back newest-first; the older duplicate for modelLLM must be ignored
-		bids: []*structs.Bid{bidFor(modelLLM), bidFor(modelEmbedding), bidFor(modelTTS), olderLLMBid},
+		bids: []*structs.Bid{bidFor(modelLLM), bidFor(modelEmbedding), bidFor(modelTTS), olderLLMBid, bidFor(modelUnconfigured)},
 		tags: map[common.Hash][]string{
-			modelLLM:       {"llm"},
-			modelEmbedding: {"embedding"},
-			modelTTS:       {"tts"},
+			modelLLM:          {"llm"},
+			modelEmbedding:    {"embedding"},
+			modelTTS:          {"tts"},
+			modelUnconfigured: {"llm"},
 		},
 		modelIDs: []common.Hash{modelLLM, modelEmbedding, modelNoBid, modelTTS},
 		adapter:  &mathSolvingAdapter{},
@@ -183,7 +196,7 @@ func TestCheckAllStatuses(t *testing.T) {
 	checker.checkAll(context.Background(), common.Address{})
 
 	reports := checker.GetReports()
-	require.Len(t, reports, 4)
+	require.Len(t, reports, 5)
 
 	llm := reportByID(t, reports, modelLLM)
 	require.Equal(t, system.ModelHealthStatusHealthy, llm.Status)
@@ -207,6 +220,52 @@ func TestCheckAllStatuses(t *testing.T) {
 
 	tts := reportByID(t, reports, modelTTS)
 	require.Equal(t, system.ModelHealthStatusSkipped, tts.Status)
+
+	// bid without a matching models-config entry: reported, not probed
+	unconfigured := reportByID(t, reports, modelUnconfigured)
+	require.Equal(t, system.ModelHealthStatusNoModel, unconfigured.Status)
+	require.True(t, unconfigured.HasActiveBid)
+	require.Equal(t, bidIDFor(modelUnconfigured).Hex(), unconfigured.BidID)
+	require.Equal(t, string(structs.ModelTypeLLM), unconfigured.ModelType)
+	require.Zero(t, unconfigured.LatencyMs)
+	require.Nil(t, unconfigured.PromptCorrect)
+}
+
+func TestCheckAllPrunesRemovedModels(t *testing.T) {
+	deps := &mockDeps{
+		bids:     []*structs.Bid{bidFor(modelLLM), bidFor(modelUnconfigured)},
+		tags:     map[common.Hash][]string{modelLLM: {"llm"}, modelUnconfigured: {"llm"}},
+		modelIDs: []common.Hash{modelLLM, modelNoBid},
+		adapter:  &mathSolvingAdapter{},
+	}
+
+	checker := newTestChecker(deps)
+	checker.checkAll(context.Background(), common.Address{})
+	require.Len(t, checker.GetReports(), 3)
+
+	// model removed from config and bid cancelled: both must disappear
+	deps.modelIDs = []common.Hash{modelLLM}
+	deps.bids = []*structs.Bid{bidFor(modelLLM)}
+	checker.checkAll(context.Background(), common.Address{})
+
+	reports := checker.GetReports()
+	require.Len(t, reports, 1)
+	require.Equal(t, modelLLM.Hex(), reports[0].ModelID)
+}
+
+func TestCheckAllBidsOnlyNoConfig(t *testing.T) {
+	deps := &mockDeps{
+		bids:     []*structs.Bid{bidFor(modelUnconfigured)},
+		tags:     map[common.Hash][]string{modelUnconfigured: {"llm"}},
+		modelIDs: []common.Hash{},
+	}
+
+	checker := newTestChecker(deps)
+	checker.checkAll(context.Background(), common.Address{})
+
+	reports := checker.GetReports()
+	require.Len(t, reports, 1)
+	require.Equal(t, system.ModelHealthStatusNoModel, reports[0].Status)
 }
 
 func TestCheckAllProbeFailure(t *testing.T) {
@@ -249,6 +308,30 @@ func TestCheckAllPreservesLastHealthy(t *testing.T) {
 	require.Equal(t, system.ModelHealthStatusUnhealthy, unhealthy.Status)
 	require.Equal(t, system.ModelHealthErrorTimeout, unhealthy.ErrorKind)
 	require.Equal(t, lastHealthy, unhealthy.LastHealthy)
+}
+
+func TestActiveBidModelsPaginates(t *testing.T) {
+	// 3 full pages plus a partial one; the configured model's bid sits on the
+	// last page and must still be found
+	var bids []*structs.Bid
+	for i := 0; i < 3*bidsPageLimit+5; i++ {
+		id := common.BigToHash(big.NewInt(int64(i + 1000)))
+		bids = append(bids, &structs.Bid{Id: common.BigToHash(big.NewInt(int64(i))), ModelAgentId: id})
+	}
+	bids = append(bids, bidFor(modelLLM))
+
+	deps := &mockDeps{
+		bids:     bids,
+		tags:     map[common.Hash][]string{modelLLM: {"llm"}},
+		modelIDs: []common.Hash{modelLLM},
+		adapter:  &mathSolvingAdapter{},
+	}
+
+	checker := newTestChecker(deps)
+	byModel, err := checker.activeBidModels(context.Background(), common.Address{})
+	require.NoError(t, err)
+	require.Len(t, byModel, len(bids)) // every bid targets a distinct model
+	require.Equal(t, bidIDFor(modelLLM), byModel[modelLLM])
 }
 
 func TestCheckAllBidsError(t *testing.T) {

--- a/proxy-router/internal/modelhealth/checker_test.go
+++ b/proxy-router/internal/modelhealth/checker_test.go
@@ -1,0 +1,266 @@
+package modelhealth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/aiengine"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/blockchainapi/structs"
+	gcs "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/chatstorage/genericchatstorage"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/config"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/repositories/registries"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/system"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sashabaranov/go-openai"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateArithmeticPrompt(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		a, b, prompt := generateArithmeticPrompt()
+		require.GreaterOrEqual(t, a, 1)
+		require.LessOrEqual(t, a, 50)
+		require.GreaterOrEqual(t, b, 1)
+		require.LessOrEqual(t, b, 50)
+		require.Contains(t, prompt, fmt.Sprintf("%d+%d", a, b))
+	}
+}
+
+func TestVerifyArithmeticAnswer(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		expected int
+		want     bool
+	}{
+		{"bare number", "4", 4, true},
+		{"number in sentence", "The answer is 42.", 42, true},
+		{"echoed equation", "2+2=4", 4, true},
+		{"wrong answer", "5", 4, false},
+		{"substring of larger number", "14", 4, false},
+		{"expected contains other digits", "142", 42, false},
+		{"empty", "", 4, false},
+		{"newline wrapped", "\n12\n", 12, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, verifyArithmeticAnswer(tt.response, tt.expected))
+		})
+	}
+}
+
+var (
+	modelLLM       = common.HexToHash("0x01")
+	modelEmbedding = common.HexToHash("0x02")
+	modelNoBid     = common.HexToHash("0x03")
+	modelTTS       = common.HexToHash("0x04")
+)
+
+type mockDeps struct {
+	bids       []*structs.Bid
+	bidsErr    error
+	tags       map[common.Hash][]string
+	modelIDs   []common.Hash
+	adapter    aiengine.AIEngineStream
+	adapterErr error
+}
+
+func (m *mockDeps) GetActiveBidsByProvider(ctx context.Context, provider common.Address, offset *big.Int, limit uint8, order registries.Order) ([]*structs.Bid, error) {
+	return m.bids, m.bidsErr
+}
+
+func (m *mockDeps) GetModelTags(ctx context.Context, modelID common.Hash) ([]string, error) {
+	tags, ok := m.tags[modelID]
+	if !ok {
+		return nil, errors.New("model not found")
+	}
+	return tags, nil
+}
+
+func (m *mockDeps) GetAll() ([]common.Hash, []config.ModelConfig) {
+	configs := make([]config.ModelConfig, len(m.modelIDs))
+	return m.modelIDs, configs
+}
+
+func (m *mockDeps) GetAdapter(ctx context.Context, chatID, modelID, sessionID common.Hash, storeChatContext, forwardChatContext bool) (aiengine.AIEngineStream, error) {
+	return m.adapter, m.adapterErr
+}
+
+// mathSolvingAdapter parses the arithmetic prompt and answers it correctly,
+// and returns a non-empty vector for embeddings probes.
+type mathSolvingAdapter struct {
+	promptErr error
+}
+
+func (a *mathSolvingAdapter) Prompt(ctx context.Context, compl *gcs.OpenAICompletionRequestExtra, cb gcs.CompletionCallback) error {
+	if a.promptErr != nil {
+		return a.promptErr
+	}
+	var x, y int
+	_, err := fmt.Sscanf(compl.Messages[0].Content, "What is %d+%d?", &x, &y)
+	if err != nil {
+		return err
+	}
+	resp := &gcs.ChatCompletionResponseExtra{
+		ChatCompletionResponse: openai.ChatCompletionResponse{
+			Choices: []openai.ChatCompletionChoice{
+				{Message: openai.ChatCompletionMessage{Content: fmt.Sprintf("%d", x+y)}},
+			},
+		},
+	}
+	return cb(ctx, gcs.NewChunkText(resp), nil)
+}
+
+func (a *mathSolvingAdapter) Embeddings(ctx context.Context, req *gcs.EmbeddingsRequest, cb gcs.CompletionCallback) error {
+	resp := gcs.EmbeddingsResponse{
+		EmbeddingResponse: openai.EmbeddingResponse{
+			Data: []openai.Embedding{{Embedding: []float32{0.1, 0.2}}},
+		},
+	}
+	return cb(ctx, gcs.NewChunkEmbedding(resp), nil)
+}
+
+func (a *mathSolvingAdapter) AudioTranscription(ctx context.Context, req *gcs.AudioTranscriptionRequest, cb gcs.CompletionCallback) error {
+	return errors.New("not implemented")
+}
+
+func (a *mathSolvingAdapter) AudioSpeech(ctx context.Context, req *gcs.AudioSpeechRequest, cb gcs.CompletionCallback) error {
+	return errors.New("not implemented")
+}
+
+func (a *mathSolvingAdapter) ApiType() string { return "openai" }
+
+func newTestChecker(deps *mockDeps) *Checker {
+	return NewChecker(Deps{
+		Adapters:     deps,
+		Bids:         deps,
+		Tags:         deps,
+		ModelConfigs: deps,
+	}, time.Hour, time.Second, lib.NewTestLogger())
+}
+
+func reportByID(t *testing.T, reports []system.ModelHealthReport, modelID common.Hash) system.ModelHealthReport {
+	t.Helper()
+	for _, r := range reports {
+		if r.ModelID == modelID.Hex() {
+			return r
+		}
+	}
+	t.Fatalf("report for model %s not found", modelID.Hex())
+	return system.ModelHealthReport{}
+}
+
+func bidFor(modelID common.Hash) *structs.Bid {
+	return &structs.Bid{Id: bidIDFor(modelID), ModelAgentId: modelID}
+}
+
+// bidIDFor derives a deterministic fake bid ID from a model ID for assertions.
+func bidIDFor(modelID common.Hash) common.Hash {
+	return common.BytesToHash(append([]byte{0xbb}, modelID.Bytes()[1:]...))
+}
+
+func TestCheckAllStatuses(t *testing.T) {
+	olderLLMBid := &structs.Bid{Id: common.HexToHash("0xdead"), ModelAgentId: modelLLM}
+	deps := &mockDeps{
+		// bids come back newest-first; the older duplicate for modelLLM must be ignored
+		bids: []*structs.Bid{bidFor(modelLLM), bidFor(modelEmbedding), bidFor(modelTTS), olderLLMBid},
+		tags: map[common.Hash][]string{
+			modelLLM:       {"llm"},
+			modelEmbedding: {"embedding"},
+			modelTTS:       {"tts"},
+		},
+		modelIDs: []common.Hash{modelLLM, modelEmbedding, modelNoBid, modelTTS},
+		adapter:  &mathSolvingAdapter{},
+	}
+
+	checker := newTestChecker(deps)
+	checker.checkAll(context.Background(), common.Address{})
+
+	reports := checker.GetReports()
+	require.Len(t, reports, 4)
+
+	llm := reportByID(t, reports, modelLLM)
+	require.Equal(t, system.ModelHealthStatusHealthy, llm.Status)
+	require.True(t, llm.HasActiveBid)
+	require.Equal(t, bidIDFor(modelLLM).Hex(), llm.BidID)
+	require.Equal(t, string(structs.ModelTypeLLM), llm.ModelType)
+	require.NotNil(t, llm.PromptCorrect)
+	require.True(t, *llm.PromptCorrect)
+	require.NotZero(t, llm.LastHealthy)
+	require.NotZero(t, llm.LastChecked)
+
+	embedding := reportByID(t, reports, modelEmbedding)
+	require.Equal(t, system.ModelHealthStatusHealthy, embedding.Status)
+	require.Nil(t, embedding.PromptCorrect)
+
+	noBid := reportByID(t, reports, modelNoBid)
+	require.Equal(t, system.ModelHealthStatusNoBid, noBid.Status)
+	require.False(t, noBid.HasActiveBid)
+	require.Empty(t, noBid.BidID)
+	require.Zero(t, noBid.LastHealthy)
+
+	tts := reportByID(t, reports, modelTTS)
+	require.Equal(t, system.ModelHealthStatusSkipped, tts.Status)
+}
+
+func TestCheckAllProbeFailure(t *testing.T) {
+	deps := &mockDeps{
+		bids:     []*structs.Bid{bidFor(modelLLM)},
+		tags:     map[common.Hash][]string{modelLLM: {"llm"}},
+		modelIDs: []common.Hash{modelLLM},
+		adapter:  &mathSolvingAdapter{promptErr: errors.New("failed to send request: connection refused")},
+	}
+
+	checker := newTestChecker(deps)
+	checker.checkAll(context.Background(), common.Address{})
+
+	llm := reportByID(t, checker.GetReports(), modelLLM)
+	require.Equal(t, system.ModelHealthStatusUnhealthy, llm.Status)
+	require.Equal(t, system.ModelHealthErrorConnection, llm.ErrorKind)
+	require.Zero(t, llm.LastHealthy)
+}
+
+func TestCheckAllPreservesLastHealthy(t *testing.T) {
+	deps := &mockDeps{
+		bids:     []*structs.Bid{bidFor(modelLLM)},
+		tags:     map[common.Hash][]string{modelLLM: {"llm"}},
+		modelIDs: []common.Hash{modelLLM},
+		adapter:  &mathSolvingAdapter{},
+	}
+
+	checker := newTestChecker(deps)
+	checker.checkAll(context.Background(), common.Address{})
+
+	healthy := reportByID(t, checker.GetReports(), modelLLM)
+	require.Equal(t, system.ModelHealthStatusHealthy, healthy.Status)
+	lastHealthy := healthy.LastHealthy
+	require.NotZero(t, lastHealthy)
+
+	deps.adapter = &mathSolvingAdapter{promptErr: context.DeadlineExceeded}
+	checker.checkAll(context.Background(), common.Address{})
+
+	unhealthy := reportByID(t, checker.GetReports(), modelLLM)
+	require.Equal(t, system.ModelHealthStatusUnhealthy, unhealthy.Status)
+	require.Equal(t, system.ModelHealthErrorTimeout, unhealthy.ErrorKind)
+	require.Equal(t, lastHealthy, unhealthy.LastHealthy)
+}
+
+func TestCheckAllBidsError(t *testing.T) {
+	deps := &mockDeps{
+		bidsErr:  errors.New("rpc unavailable"),
+		modelIDs: []common.Hash{modelLLM},
+	}
+
+	checker := newTestChecker(deps)
+	checker.checkAll(context.Background(), common.Address{})
+
+	// no reports should be written when the bid lookup fails, so stale
+	// results from a previous successful run are preserved
+	require.Empty(t, checker.GetReports())
+}

--- a/proxy-router/internal/proxyapi/controller_http.go
+++ b/proxy-router/internal/proxyapi/controller_http.go
@@ -140,13 +140,13 @@ func (s *ProxyController) Ping(ctx *gin.Context) {
 		return
 	}
 
-	ping, version, err := s.service.Ping(ctx, req.ProviderURL, req.ProviderAddr)
+	ping, version, models, err := s.service.Ping(ctx, req.ProviderURL, req.ProviderAddr)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	ctx.JSON(http.StatusOK, &PingRes{PingMs: ping.Milliseconds(), Version: version})
+	ctx.JSON(http.StatusOK, &PingRes{PingMs: ping.Milliseconds(), Version: version, Models: models})
 }
 
 // InitiateSession godoc

--- a/proxy-router/internal/proxyapi/controller_morrpc.go
+++ b/proxy-router/internal/proxyapi/controller_morrpc.go
@@ -14,6 +14,7 @@ import (
 	msg "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/proxyapi/morrpcmessage"
 	sessionrepo "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/repositories/session"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/storages"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/system"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-playground/validator/v10"
 )
@@ -27,6 +28,7 @@ type MORRPCController struct {
 	prKey          lib.HexString
 	streamManager  *StreamingSessionManager
 	sessionSema    *SessionSemaphore // Limits to 1 concurrent request per session
+	modelHealth    system.ModelHealthReporter
 }
 
 type SendResponse func(*msg.RpcResponse) error
@@ -35,7 +37,7 @@ var (
 	ErrUnknownMethod = fmt.Errorf("unknown method")
 )
 
-func NewMORRPCController(service *ProxyReceiver, validator *validator.Validate, sessionRepo *sessionrepo.SessionRepositoryCached, sessionStorage *storages.SessionStorage, prKey lib.HexString) *MORRPCController {
+func NewMORRPCController(service *ProxyReceiver, validator *validator.Validate, sessionRepo *sessionrepo.SessionRepositoryCached, sessionStorage *storages.SessionStorage, prKey lib.HexString, modelHealth system.ModelHealthReporter) *MORRPCController {
 	c := &MORRPCController{
 		service:        service,
 		validator:      validator,
@@ -45,6 +47,7 @@ func NewMORRPCController(service *ProxyReceiver, validator *validator.Validate, 
 		prKey:          prKey,
 		streamManager:  NewStreamingSessionManager(),
 		sessionSema:    NewSessionSemaphore(),
+		modelHealth:    modelHealth,
 	}
 
 	return c
@@ -93,7 +96,12 @@ func (s *MORRPCController) networkPing(_ context.Context, msg m.RPCMessage, send
 		return lib.WrapError(ErrValidation, err)
 	}
 
-	res, err := s.morRpc.PongResponce(msg.ID, s.prKey, req.Nonce, config.BuildVersion)
+	var models []system.ModelHealthReport
+	if s.modelHealth != nil {
+		models = s.modelHealth.GetReports()
+	}
+
+	res, err := s.morRpc.PongResponce(msg.ID, s.prKey, req.Nonce, config.BuildVersion, models)
 	if err != nil {
 		sourceLog.Error(err)
 		return err

--- a/proxy-router/internal/proxyapi/morrpcmessage/mor_rpc.go
+++ b/proxy-router/internal/proxyapi/morrpcmessage/mor_rpc.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/system"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
@@ -20,7 +21,7 @@ func NewMorRpc() *MORRPCMessage {
 
 // RESPONSES
 
-func (m *MORRPCMessage) PongResponce(requestId string, providerPrKey lib.HexString, nonce lib.HexString, version string) (*RpcResponse, error) {
+func (m *MORRPCMessage) PongResponce(requestId string, providerPrKey lib.HexString, nonce lib.HexString, version string, models []system.ModelHealthReport) (*RpcResponse, error) {
 	params := PongRes{
 		Nonce:   nonce,
 		Version: version,
@@ -30,6 +31,9 @@ func (m *MORRPCMessage) PongResponce(requestId string, providerPrKey lib.HexStri
 		return &RpcResponse{}, err
 	}
 
+	// set after signing so the signed payload stays compatible with older
+	// consumers that don't know the models field (see PongRes)
+	params.Models = models
 	params.Signature = signature
 
 	paramsBytes, err := json.Marshal(params)

--- a/proxy-router/internal/proxyapi/morrpcmessage/mor_rpc_test.go
+++ b/proxy-router/internal/proxyapi/morrpcmessage/mor_rpc_test.go
@@ -2,10 +2,13 @@ package morrpcmesssage
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/system"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -85,4 +88,44 @@ func TestMorRpc_generate(t *testing.T) {
 
 	hexSignature := hex.EncodeToString([]byte(signature))
 	fmt.Println(hexSignature)
+}
+
+// oldPongRes mimics the PongRes struct of consumers built before the models
+// field existed: unknown JSON fields are dropped on unmarshal.
+type oldPongRes struct {
+	Nonce     lib.HexString `json:"nonce"`
+	Version   string        `json:"version,omitempty"`
+	Signature lib.HexString `json:"signature"`
+}
+
+func TestPongResponceModelsExcludedFromSignature(t *testing.T) {
+	prKey, err := crypto.GenerateKey()
+	assert.NoError(t, err)
+	prKeyBytes := crypto.FromECDSA(prKey)
+	addr := crypto.PubkeyToAddress(prKey.PublicKey)
+
+	models := []system.ModelHealthReport{
+		{ModelID: "0x01", ModelType: "LLM", HasActiveBid: true, BidID: "0x02", Status: "healthy"},
+	}
+
+	rpc := NewMorRpc()
+	res, err := rpc.PongResponce("1", prKeyBytes, lib.HexString{0x01, 0x02}, "v1.0.0", models)
+	assert.NoError(t, err)
+
+	// new consumer: zeroes both signature and models before verifying
+	var pong PongRes
+	assert.NoError(t, json.Unmarshal(*res.Result, &pong))
+	assert.Len(t, pong.Models, 1)
+
+	signature := pong.Signature
+	pong.Signature = lib.HexString{}
+	pong.Models = nil
+	assert.True(t, rpc.VerifySignatureAddr(pong, signature, addr, lib.NewTestLogger()))
+
+	// old consumer: models field silently dropped, verification still passes
+	var old oldPongRes
+	assert.NoError(t, json.Unmarshal(*res.Result, &old))
+	oldSignature := old.Signature
+	old.Signature = lib.HexString{}
+	assert.True(t, rpc.VerifySignatureAddr(old, oldSignature, addr, lib.NewTestLogger()))
 }

--- a/proxy-router/internal/proxyapi/morrpcmessage/request.go
+++ b/proxy-router/internal/proxyapi/morrpcmessage/request.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/system"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -129,9 +130,13 @@ type PingReq struct {
 }
 
 type PongRes struct {
-	Nonce     lib.HexString `json:"nonce"     validate:"required,hexadecimal"`
-	Version   string        `json:"version,omitempty"   validate:"omitempty"`
-	Signature lib.HexString `json:"signature" validate:"required,hexadecimal"`
+	Nonce   lib.HexString `json:"nonce"     validate:"required,hexadecimal"`
+	Version string        `json:"version,omitempty"   validate:"omitempty"`
+	// Models is set after signing (like Signature) and excluded from the
+	// signed payload: consumers with an older PongRes struct drop the unknown
+	// field on unmarshal, so signature verification keeps working for them.
+	Models    []system.ModelHealthReport `json:"models,omitempty" validate:"omitempty"`
+	Signature lib.HexString              `json:"signature" validate:"required,hexadecimal"`
 }
 
 // Audio streaming message types

--- a/proxy-router/internal/proxyapi/proxy_sender.go
+++ b/proxy-router/internal/proxyapi/proxy_sender.go
@@ -24,6 +24,7 @@ import (
 	msgs "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/proxyapi/morrpcmessage"
 	sessionrepo "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/repositories/session"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/storages"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/system"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gin-gonic/gin/binding"
 )
@@ -94,10 +95,10 @@ func (p *ProxyServiceSender) SetAttestationVerifier(v *attestation.Verifier) {
 	p.attestationVerifier = v
 }
 
-func (p *ProxyServiceSender) Ping(ctx context.Context, providerURL string, providerAddr common.Address) (time.Duration, string, error) {
+func (p *ProxyServiceSender) Ping(ctx context.Context, providerURL string, providerAddr common.Address) (time.Duration, string, []system.ModelHealthReport, error) {
 	prKey, err := p.privateKey.GetPrivateKey()
 	if err != nil {
-		return 0, "", ErrMissingPrKey
+		return 0, "", nil, ErrMissingPrKey
 	}
 
 	// check if context has timeout set
@@ -110,40 +111,42 @@ func (p *ProxyServiceSender) Ping(ctx context.Context, providerURL string, provi
 	nonce := make([]byte, 8)
 	_, err = rand.Read(nonce)
 	if err != nil {
-		return 0, "", lib.WrapError(ErrCreateReq, err)
+		return 0, "", nil, lib.WrapError(ErrCreateReq, err)
 	}
 
 	msg, err := p.morRPC.PingRequest("0", prKey, nonce)
 	if err != nil {
-		return 0, "", lib.WrapError(ErrCreateReq, err)
+		return 0, "", nil, lib.WrapError(ErrCreateReq, err)
 	}
 
 	reqStartTime := time.Now()
 	res, code, err := p.rpcRequest(providerURL, msg)
 	if err != nil {
-		return 0, "", lib.WrapError(ErrProvider, fmt.Errorf("code: %d, msg: %v, error: %s", code, res, err))
+		return 0, "", nil, lib.WrapError(ErrProvider, fmt.Errorf("code: %d, msg: %v, error: %s", code, res, err))
 	}
 	pingDuration := time.Since(reqStartTime)
 
 	var typedMsg *msgs.PongRes
 	err = json.Unmarshal(*res.Result, &typedMsg)
 	if err != nil {
-		return pingDuration, "", lib.WrapError(ErrInvalidResponse, fmt.Errorf("expected PongRes, got %s", res.Result))
+		return pingDuration, "", nil, lib.WrapError(ErrInvalidResponse, fmt.Errorf("expected PongRes, got %s", res.Result))
 	}
 
 	err = binding.Validator.ValidateStruct(typedMsg)
 	if err != nil {
-		return pingDuration, "", lib.WrapError(ErrInvalidResponse, err)
+		return pingDuration, "", nil, lib.WrapError(ErrInvalidResponse, err)
 	}
 
 	signature := typedMsg.Signature
+	models := typedMsg.Models
 	typedMsg.Signature = lib.HexString{}
+	typedMsg.Models = nil // not part of the signed payload (see PongRes)
 
 	if !p.morRPC.VerifySignatureAddr(typedMsg, signature, providerAddr, p.log) {
-		return pingDuration, "", ErrInvalidSig
+		return pingDuration, "", nil, ErrInvalidSig
 	}
 
-	return pingDuration, typedMsg.Version, nil
+	return pingDuration, typedMsg.Version, models, nil
 }
 
 // EnsureProviderRegistered re-discovers provider URL + public key (via ping) and stores them in session storage.
@@ -191,6 +194,7 @@ func (p *ProxyServiceSender) EnsureProviderRegistered(ctx context.Context, provi
 
 	signature := typedMsg.Signature
 	typedMsg.Signature = lib.HexString{}
+	typedMsg.Models = nil // not part of the signed payload (see PongRes)
 	if !p.morRPC.VerifySignatureAddr(typedMsg, signature, providerAddr, p.log) {
 		return ErrInvalidSig
 	}

--- a/proxy-router/internal/proxyapi/requests.go
+++ b/proxy-router/internal/proxyapi/requests.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/system"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -13,8 +14,9 @@ type PingReq struct {
 }
 
 type PingRes struct {
-	PingMs  int64  `json:"ping,omitempty"`
-	Version string `json:"version,omitempty"`
+	PingMs  int64                      `json:"ping,omitempty"`
+	Version string                     `json:"version,omitempty"`
+	Models  []system.ModelHealthReport `json:"models,omitempty"`
 }
 
 type InitiateSessionReq struct {

--- a/proxy-router/internal/proxyctl/proxyctl.go
+++ b/proxy-router/internal/proxyctl/proxyctl.go
@@ -13,11 +13,13 @@ import (
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/handlers/tcphandlers"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/interfaces"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/modelhealth"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/proxyapi"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/repositories/registries"
 	sessionrepo "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/repositories/session"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/repositories/transport"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/storages"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/system"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-playground/validator/v10"
 	"golang.org/x/sync/errgroup"
@@ -72,6 +74,7 @@ type Proxy struct {
 	blockchainService    *blockchainapi.BlockchainService
 	sessionExpiryHandler *blockchainapi.SessionExpiryHandler
 	backendVerifier      proxyapi.BackendTEEVerifier
+	modelHealthChecker   *modelhealth.Checker
 
 	state         lib.AtomicValue[ProxyState]
 	tsk           *lib.Task
@@ -79,7 +82,7 @@ type Proxy struct {
 }
 
 // NewProxyCtl creates a new Proxy controller instance
-func NewProxyCtl(eventListerer *blockchainapi.EventsListener, wallet interfaces.PrKeyProvider, chainID *big.Int, log lib.ILogger, tcpLog *lib.Logger, proxyAddr string, sessionStorage *storages.SessionStorage, modelConfigLoader *config.ModelConfigLoader, valid *validator.Validate, aiEngine *aiengine.AiEngine, blockchainService *blockchainapi.BlockchainService, sessionRepo *sessionrepo.SessionRepositoryCached, sessionExpiryHandler *blockchainapi.SessionExpiryHandler, backendVerifier proxyapi.BackendTEEVerifier) *Proxy {
+func NewProxyCtl(eventListerer *blockchainapi.EventsListener, wallet interfaces.PrKeyProvider, chainID *big.Int, log lib.ILogger, tcpLog *lib.Logger, proxyAddr string, sessionStorage *storages.SessionStorage, modelConfigLoader *config.ModelConfigLoader, valid *validator.Validate, aiEngine *aiengine.AiEngine, blockchainService *blockchainapi.BlockchainService, sessionRepo *sessionrepo.SessionRepositoryCached, sessionExpiryHandler *blockchainapi.SessionExpiryHandler, backendVerifier proxyapi.BackendTEEVerifier, modelHealthChecker *modelhealth.Checker) *Proxy {
 	return &Proxy{
 		eventListener:        eventListerer,
 		chainID:              chainID,
@@ -95,6 +98,7 @@ func NewProxyCtl(eventListerer *blockchainapi.EventsListener, wallet interfaces.
 		sessionRepo:          sessionRepo,
 		sessionExpiryHandler: sessionExpiryHandler,
 		backendVerifier:      backendVerifier,
+		modelHealthChecker:   modelHealthChecker,
 		serverStarted:        make(chan struct{}),
 	}
 }
@@ -193,7 +197,11 @@ func (p *Proxy) run(ctx context.Context, prKey lib.HexString) error {
 		proxyReceiver.SetBackendVerifier(p.backendVerifier)
 	}
 	proxyReceiver.SetModelTagsProvider(p.blockchainService)
-	morTcpHandler := proxyapi.NewMORRPCController(proxyReceiver, p.validator, p.sessionRepo, p.sessionStorage, prKey)
+	var modelHealthReporter system.ModelHealthReporter
+	if p.modelHealthChecker != nil {
+		modelHealthReporter = p.modelHealthChecker
+	}
+	morTcpHandler := proxyapi.NewMORRPCController(proxyReceiver, p.validator, p.sessionRepo, p.sessionStorage, prKey, modelHealthReporter)
 	tcpHandler := tcphandlers.NewTCPHandler(
 		p.tcpLog, morTcpHandler,
 	)
@@ -216,6 +224,13 @@ func (p *Proxy) run(ctx context.Context, prKey lib.HexString) error {
 	g.Go(func() error {
 		return p.sessionExpiryHandler.Run(errCtx)
 	})
+
+	if p.modelHealthChecker != nil {
+		g.Go(func() error {
+			<-tcpServer.Started()
+			return p.modelHealthChecker.Run(errCtx, walletAddr)
+		})
+	}
 
 	return g.Wait()
 }

--- a/proxy-router/internal/system/controller.go
+++ b/proxy-router/internal/system/controller.go
@@ -22,6 +22,11 @@ type StorageHealthChecker interface {
 	DBSize() (lsmSize int64, vlogSize int64)
 }
 
+// ModelHealthReporter provides cached per-model health self-reports.
+type ModelHealthReporter interface {
+	GetReports() []ModelHealthReport
+}
+
 type SystemController struct {
 	config                 *config.Config
 	wallet                 i.Wallet
@@ -33,9 +38,10 @@ type SystemController struct {
 	ethConnectionValidator IEthConnectionValidator
 	authConfig             HTTPAuthConfig
 	storage                StorageHealthChecker
+	modelHealth            ModelHealthReporter
 }
 
-func NewSystemController(config *config.Config, wallet i.Wallet, ethRPC i.RPCEndpoints, sysConfig *SystemConfigurator, appStartTime time.Time, chainID *big.Int, log lib.ILogger, ethConnectionValidator IEthConnectionValidator, authConfig HTTPAuthConfig, storage StorageHealthChecker) *SystemController {
+func NewSystemController(config *config.Config, wallet i.Wallet, ethRPC i.RPCEndpoints, sysConfig *SystemConfigurator, appStartTime time.Time, chainID *big.Int, log lib.ILogger, ethConnectionValidator IEthConnectionValidator, authConfig HTTPAuthConfig, storage StorageHealthChecker, modelHealth ModelHealthReporter) *SystemController {
 	c := &SystemController{
 		config:                 config,
 		wallet:                 wallet,
@@ -47,6 +53,7 @@ func NewSystemController(config *config.Config, wallet i.Wallet, ethRPC i.RPCEnd
 		ethConnectionValidator: ethConnectionValidator,
 		authConfig:             authConfig,
 		storage:                storage,
+		modelHealth:            modelHealth,
 	}
 
 	return c
@@ -85,6 +92,13 @@ func (s *SystemController) HealthCheck(ctx *gin.Context) {
 		}
 	}
 
+	// model probe failures don't flip the node to 503: bid presence and
+	// backend health are marketplace concerns, not process liveness
+	var models []ModelHealthReport
+	if s.modelHealth != nil {
+		models = s.modelHealth.GetReports()
+	}
+
 	httpStatus := http.StatusOK
 	if status != "healthy" {
 		httpStatus = http.StatusServiceUnavailable
@@ -95,6 +109,7 @@ func (s *SystemController) HealthCheck(ctx *gin.Context) {
 		Version:    config.BuildVersion,
 		Uptime:     time.Since(s.appStartTime).Round(time.Second).String(),
 		Components: components,
+		Models:     models,
 	})
 }
 

--- a/proxy-router/internal/system/structs.go
+++ b/proxy-router/internal/system/structs.go
@@ -17,10 +17,40 @@ type ConfigResponse struct {
 }
 
 type HealthCheckResponse struct {
-	Status     string            `json:"status"`
-	Version    string            `json:"version"`
-	Uptime     string            `json:"uptime"`
-	Components map[string]string `json:"components,omitempty"`
+	Status     string              `json:"status"`
+	Version    string              `json:"version"`
+	Uptime     string              `json:"uptime"`
+	Components map[string]string   `json:"components,omitempty"`
+	Models     []ModelHealthReport `json:"models,omitempty"`
+}
+
+const (
+	ModelHealthStatusHealthy   = "healthy"
+	ModelHealthStatusUnhealthy = "unhealthy"
+	ModelHealthStatusNoBid     = "no_bid"
+	ModelHealthStatusSkipped   = "skipped"
+
+	ModelHealthErrorTimeout     = "timeout"
+	ModelHealthErrorConnection  = "connection"
+	ModelHealthErrorBadResponse = "bad_response"
+	ModelHealthErrorTypeLookup  = "model_type_lookup"
+)
+
+// ModelHealthReport is the sanitized per-model self-report exposed on the
+// public /healthcheck endpoint. It intentionally carries only the on-chain
+// model ID and derived status — never the private modelName, apiUrl or
+// apiKey from models-config.json.
+type ModelHealthReport struct {
+	ModelID       string `json:"modelId"`
+	ModelType     string `json:"modelType,omitempty"`
+	HasActiveBid  bool   `json:"hasActiveBid"`
+	BidID         string `json:"bidId,omitempty"`
+	Status        string `json:"status"`
+	LastHealthy   int64  `json:"lastHealthy,omitempty"`
+	LastChecked   int64  `json:"lastChecked"`
+	LatencyMs     int64  `json:"latencyMs,omitempty"`
+	PromptCorrect *bool  `json:"promptCorrect,omitempty"`
+	ErrorKind     string `json:"errorKind,omitempty"`
 }
 
 type StatusRes struct {

--- a/proxy-router/internal/system/structs.go
+++ b/proxy-router/internal/system/structs.go
@@ -28,6 +28,7 @@ const (
 	ModelHealthStatusHealthy   = "healthy"
 	ModelHealthStatusUnhealthy = "unhealthy"
 	ModelHealthStatusNoBid     = "no_bid"
+	ModelHealthStatusNoModel   = "no_model_configured"
 	ModelHealthStatusSkipped   = "skipped"
 
 	ModelHealthErrorTimeout     = "timeout"
@@ -37,7 +38,8 @@ const (
 )
 
 // ModelHealthReport is the sanitized per-model self-report exposed on the
-// public /healthcheck endpoint. It intentionally carries only the on-chain
+// public /healthcheck endpoint. It covers the union of configured models and
+// this provider's active bids, and intentionally carries only the on-chain
 // model ID and derived status — never the private modelName, apiUrl or
 // apiKey from models-config.json.
 type ModelHealthReport struct {

--- a/proxy-router/mobile/httpserver.go
+++ b/proxy-router/mobile/httpserver.go
@@ -226,5 +226,5 @@ func (n *noopAIEngine) GetAdapter(ctx context.Context, chatID, modelID, sessionI
 
 type noopStorageHealthChecker struct{}
 
-func (n *noopStorageHealthChecker) HealthCheck() error        { return nil }
-func (n *noopStorageHealthChecker) DBSize() (int64, int64)    { return 0, 0 }
+func (n *noopStorageHealthChecker) HealthCheck() error     { return nil }
+func (n *noopStorageHealthChecker) DBSize() (int64, int64) { return 0, 0 }

--- a/proxy-router/mobile/httpserver.go
+++ b/proxy-router/mobile/httpserver.go
@@ -105,6 +105,7 @@ func (s *SDK) StartHTTPServer(address, publicURL, adminUser, adminPass string) e
 		nil,
 		*authCfg,
 		&noopStorageHealthChecker{},
+		nil,
 	)
 
 	// Selective registration: only expose routes whose dependencies are

--- a/proxy-router/mobile/sdk.go
+++ b/proxy-router/mobile/sdk.go
@@ -222,7 +222,7 @@ func NewSDK(cfg Config) (*SDK, error) {
 	proxySender.SetSessionService(blockchainSvc)
 	proxySender.SetAttestationVerifier(teeVerifier)
 	teeVerifier.SetPingFunc(func(ctx context.Context, providerEndpoint string, providerAddr string) (string, error) {
-		_, version, err := proxySender.Ping(ctx, providerEndpoint, common.HexToAddress(providerAddr))
+		_, version, _, err := proxySender.Ping(ctx, providerEndpoint, common.HexToAddress(providerAddr))
 		return version, err
 	})
 


### PR DESCRIPTION
## Summary

1. **Configurable health-check loop on the provider node**: periodically sends a real inference probe to every model from `models-config.json` that has an **active on-chain bid from this provider**, and caches the result.
2. **Whole-ecosystem coverage**: the report is the union of configured models and active bids. Configured models without a bid are `no_bid`; **active bids whose model is missing from `models-config.json` are flagged `no_model_configured`** — capacity being sold with no backend to serve it, which would otherwise surface only as consumer-side session errors. Entries that leave both sets are pruned.
3. **Self-report exposure on three surfaces**: `GET /healthcheck` (admin port), the `network.ping` pong over the `:3333` MOR RPC port, and `POST /proxy/provider/ping` (consumer HTTP API) — so consumers can see a provider's model health and bid IDs **before opening a session**.
4. **Privacy-safe by construction**: the report carries only the on-chain `modelId` and derived status. The private `modelName`, `apiUrl`, and `apiKey` from `models-config.json` are never exposed; probe errors are reduced to a coarse category so backend URLs cannot leak through error strings.

---

## Health-check loop (`internal/modelhealth`)

### Scheduling
- Runs in the provider `errgroup` (`proxyctl.run`) after the TCP server starts; automatically restarts with the correct wallet address on key change.
- Immediate first probe, then every `MODEL_HEALTH_CHECK_INTERVAL` (results cached between runs). Never returns a non-context error, so a probe failure cannot bring down the provider.

### Per-cycle flow
1. `GetActiveBidsByProvider(walletAddr)` → map each model to its **most recent active bid** (bids come back newest-first). **Paginated** (100 per page) so providers with >100 active bids are fully covered, with a 10k fail-safe cap against a misbehaving RPC.
2. Configured models with no active bid → `status: no_bid`, **never probed** (no wasted backend calls for unsold models).
3. Active bids with no `models-config.json` entry → `status: no_model_configured` with the bid ID and on-chain model type; nothing to probe, but the mismatch is loudly visible (also logged as a warning each cycle).
4. Reports for models that are no longer configured **and** no longer have a bid are pruned, so removed models don't linger.
5. Model type resolved from **on-chain tags** (`GetModelTags` → `DetectModelType`), cached per model to avoid repeated chain calls.
6. Probe by type, through the same `aiengine` adapter path used for real sessions:
   - **LLM**: dynamically generated arithmetic prompt (`"What is 17+38? Reply with only the number."`, random operands each cycle so cached/replayed answers can't fake correctness). The answer is graded with a word-boundary match (`"14"` does **not** pass for expected `4`) → `promptCorrect`.
   - **EMBEDDING**: embeddings request; healthy iff a non-empty vector returns.
   - **TTS / STT / image / unknown**: `status: skipped`.
5. Per-probe timeout `MODEL_HEALTH_CHECK_TIMEOUT`; latency recorded; `lastHealthy` preserved across failures so operators can see when a model last worked.

### Report shape (`system.ModelHealthReport`)

```json
[
  {
    "modelId": "0xe086...",
    "modelType": "LLM",
    "hasActiveBid": true,
    "bidId": "0x3f2a...",
    "status": "healthy",
    "lastHealthy": 1751871600,
    "lastChecked": 1751871600,
    "latencyMs": 412,
    "promptCorrect": true
  },
  {
    "modelId": "0x85670d...",
    "modelType": "LLM",
    "hasActiveBid": true,
    "bidId": "0x9c41...",
    "status": "no_model_configured",
    "lastChecked": 1751871600
  }
]
```

`status`: `healthy` | `unhealthy` (see `errorKind`: `timeout` | `connection` | `bad_response`) | `no_bid` (configured, no bid) | `no_model_configured` (bid, not configured) | `skipped` (non-probeable type).

---

## Configuration (`internal/config`)

| Variable | Default | Notes |
|----------|---------|-------|
| `MODEL_HEALTH_CHECK_DISABLED` | `false` | Disables the loop; `models` field disappears from all responses |
| `MODEL_HEALTH_CHECK_INTERVAL` | `1h` | Probe cadence; results cached between runs |
| `MODEL_HEALTH_CHECK_TIMEOUT` | `60s` | Per-model probe timeout |

All three are included in the sanitized `/config` output.

---

## Exposure surfaces

### `GET /healthcheck` (`internal/system`)
- New `models[]` field via a nil-safe `ModelHealthReporter` interface on `SystemController`.
- Model probe failures do **not** flip the node to 503 — bid presence and backend health are marketplace concerns, not process liveness.

### `network.ping` pong (`internal/proxyapi/morrpcmessage`)
- `PongRes` gains `models[]`, set **after** signing (exactly like `Signature` itself).
- **Why**: consumers verify the pong by unmarshalling into their own `PongRes`, zeroing `Signature`, re-marshalling, and checking the signature. If `models` were part of the signed payload, every pre-upgrade consumer (whose struct lacks the field) would re-marshal without it and get `ErrInvalidSig` — breaking pings network-wide. Post-signing injection keeps the signed bytes identical for old consumers; new consumers zero `Models` alongside `Signature` before verifying (`Ping` and `EnsureProviderRegistered`).
- Trade-off: the health info itself is not signature-authenticated — informational, same trust level as the rest of the pre-session handshake.

### `POST /proxy/provider/ping` (`internal/proxyapi`)
- `ProxyServiceSender.Ping` returns the models from the **verified** pong as a fourth return value; `PingRes` gains `models[]`.
- Call sites updated (`CheckConnectivity`, TEE ping closures in `cmd/main.go` and `mobile/sdk.go` ignore the new value).

---

## Docs

- Swagger regenerated (`system.ModelHealthReport`, `proxyapi.PingRes`, healthcheck response).
- `docs/reference/env-proxy-router.mdx`: new "Model health self-checks (provider)" section.
- `docs/providers/full/verify-setup.mdx`: sample `models` response + interpretation guidance in Step 1.
- `docs/proxy-router.all.env`: annotated entries for the three new vars.
