### PR TITLE
fix(ci): retry zombie-sweep Lambda past its future-cutoff guard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2126,31 +2126,62 @@ jobs:
           # OPEN rows older than that. release_tag only annotates error_reason.
           PAYLOAD="{\"release_tag\":\"${BUILDTAG}\"}"
 
-          echo "🧹 Invoking ${FUNCTION_NAME} with payload: ${PAYLOAD}"
-          set +e
-          INVOKE_META=$(aws lambda invoke \
-            --function-name "$FUNCTION_NAME" \
-            --cli-binary-format raw-in-base64-out \
-            --payload "$PAYLOAD" \
-            /tmp/sweep_out.json 2>/tmp/sweep_err.txt)
-          INVOKE_RC=$?
-          set -e
+          # This job starts seconds after the C-Node deploy settles, but the
+          # Lambda's cutoff = deployments[0].updatedAt + 90s rehydration + 120s
+          # safety (~210s ahead) and it REFUSES a future cutoff. So the first
+          # invoke almost always lands before the cutoff and no-ops with a 400.
+          # Retry with backoff until the cutoff has passed (or the budget is
+          # exhausted) so the sweep actually runs. Budget: 10 * 30s = ~5 min,
+          # comfortably past the ~210s cutoff. Only the future-cutoff case is
+          # retried; any other status (200 / SWEEP_MAX_ROWS / error) is terminal.
+          MAX_ATTEMPTS=10
+          SLEEP_SECS=30
+          STATUS=""
+          BODY=""
+          FUNCTION_ERROR=""
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            echo "🧹 [attempt ${attempt}/${MAX_ATTEMPTS}] Invoking ${FUNCTION_NAME} with payload: ${PAYLOAD}"
+            set +e
+            INVOKE_META=$(aws lambda invoke \
+              --function-name "$FUNCTION_NAME" \
+              --cli-binary-format raw-in-base64-out \
+              --payload "$PAYLOAD" \
+              /tmp/sweep_out.json 2>/tmp/sweep_err.txt)
+            INVOKE_RC=$?
+            set -e
 
-          if [ $INVOKE_RC -ne 0 ]; then
-            echo "⚠️ lambda invoke call failed (rc=$INVOKE_RC):"
-            cat /tmp/sweep_err.txt || true
-            echo "ℹ️ Deploy already succeeded; the API Gateway self-heals zombies within ~30 min. Not failing the pipeline."
-            exit 0
-          fi
+            if [ $INVOKE_RC -ne 0 ]; then
+              echo "⚠️ lambda invoke call failed (rc=$INVOKE_RC):"
+              cat /tmp/sweep_err.txt || true
+              echo "ℹ️ Deploy already succeeded; the API Gateway self-heals zombies within ~30 min. Not failing the pipeline."
+              exit 0
+            fi
 
-          echo "📡 Invoke metadata: $INVOKE_META"
-          FUNCTION_ERROR=$(echo "$INVOKE_META" | jq -r '.FunctionError // empty')
-          RESPONSE=$(cat /tmp/sweep_out.json)
-          echo "📦 Lambda response: $RESPONSE"
+            echo "📡 Invoke metadata: $INVOKE_META"
+            FUNCTION_ERROR=$(echo "$INVOKE_META" | jq -r '.FunctionError // empty')
+            RESPONSE=$(cat /tmp/sweep_out.json)
+            echo "📦 Lambda response: $RESPONSE"
 
-          # The handler returns {"statusCode": N, "body": "<json string>"}.
-          STATUS=$(echo "$RESPONSE" | jq -r '.statusCode // empty' 2>/dev/null)
-          BODY=$(echo "$RESPONSE" | jq -r '.body // empty' 2>/dev/null)
+            # The handler returns {"statusCode": N, "body": "<json string>"}.
+            STATUS=$(echo "$RESPONSE" | jq -r '.statusCode // empty' 2>/dev/null)
+            BODY=$(echo "$RESPONSE" | jq -r '.body // empty' 2>/dev/null)
+
+            # An unhandled Lambda error has no statusCode — terminal, don't retry.
+            if [ -n "$FUNCTION_ERROR" ]; then
+              break
+            fi
+
+            # Retry ONLY the "future cutoff" 400 — we just deployed and need to
+            # wait for the cutoff to pass. Everything else is a final result.
+            if [ "$STATUS" = "400" ] && echo "$BODY" | grep -qi "in the future"; then
+              if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+                echo "⏳ Cutoff not reached yet; sleeping ${SLEEP_SECS}s before retry."
+                sleep "$SLEEP_SECS"
+                continue
+              fi
+            fi
+            break
+          done
 
           {
             echo "### 🧹 Routed-sessions zombie sweep"


### PR DESCRIPTION
## Summary
The `Sweep-Zombie-Sessions` job invokes the `<env>-routed-sessions-sweep` Lambda **seconds after** the C-Node deploy settles, but the Lambda derives its cutoff as `deployments[0].updatedAt + 90s rehydration + 120s safety` (~210s ahead) and **refuses a future cutoff**. So the single immediate invoke always landed before the cutoff and no-op'd with a `400` — the post-deploy zombie sweep never actually ran.

Observed on the **v7.4.0 prod roll**: the job reported success but closed 0 rows; 44 zombie `routed_sessions` were left for the ~30-min API-GW self-heal (cleared manually via the runbook).

## Change
- Wrap the Lambda invoke in a **bounded retry** (10 × 30s, ~5 min budget) that retries **only** the future-cutoff `400` until the cutoff passes.
- All other outcomes (`200` / `SWEEP_MAX_ROWS` `409` / unhandled errors) stay terminal, and the job remains **non-fatal** (deploy already succeeded; gateway self-heal is the backstop).

## Companion change (separate repo)
This is one half of the fix. The same Lambda also hits an **explicit deny** reading `<env>-morpheus-api-rds-proxy-credentials` (secret resource policy never whitelisted its role). That is fixed in `Morpheus-Infra` via a new `create_routed_sessions_sweep` flag (dev + prd) and applied with terragrunt. Both must be live for the automated sweep to actually close rows.

## Test plan
- [ ] Merge dev → test; on the next C-Node deploy, confirm the `Sweep-Zombie-Sessions` step logs one or more `⏳ Cutoff not reached yet; sleeping 30s` retries, then a `statusCode 200` with `rows_closed` in the step summary (requires the Infra change applied in dev).
- [ ] Verify the job still completes non-fatally if the sweep errors.

Made with [Cursor](https://cursor.com)