### PR TITLE
7.5.0: model health telemetry + zombie-sweep CI retry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2126,31 +2126,62 @@ jobs:
           # OPEN rows older than that. release_tag only annotates error_reason.
           PAYLOAD="{\"release_tag\":\"${BUILDTAG}\"}"
 
-          echo "🧹 Invoking ${FUNCTION_NAME} with payload: ${PAYLOAD}"
-          set +e
-          INVOKE_META=$(aws lambda invoke \
-            --function-name "$FUNCTION_NAME" \
-            --cli-binary-format raw-in-base64-out \
-            --payload "$PAYLOAD" \
-            /tmp/sweep_out.json 2>/tmp/sweep_err.txt)
-          INVOKE_RC=$?
-          set -e
+          # This job starts seconds after the C-Node deploy settles, but the
+          # Lambda's cutoff = deployments[0].updatedAt + 90s rehydration + 120s
+          # safety (~210s ahead) and it REFUSES a future cutoff. So the first
+          # invoke almost always lands before the cutoff and no-ops with a 400.
+          # Retry with backoff until the cutoff has passed (or the budget is
+          # exhausted) so the sweep actually runs. Budget: 10 * 30s = ~5 min,
+          # comfortably past the ~210s cutoff. Only the future-cutoff case is
+          # retried; any other status (200 / SWEEP_MAX_ROWS / error) is terminal.
+          MAX_ATTEMPTS=10
+          SLEEP_SECS=30
+          STATUS=""
+          BODY=""
+          FUNCTION_ERROR=""
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            echo "🧹 [attempt ${attempt}/${MAX_ATTEMPTS}] Invoking ${FUNCTION_NAME} with payload: ${PAYLOAD}"
+            set +e
+            INVOKE_META=$(aws lambda invoke \
+              --function-name "$FUNCTION_NAME" \
+              --cli-binary-format raw-in-base64-out \
+              --payload "$PAYLOAD" \
+              /tmp/sweep_out.json 2>/tmp/sweep_err.txt)
+            INVOKE_RC=$?
+            set -e
 
-          if [ $INVOKE_RC -ne 0 ]; then
-            echo "⚠️ lambda invoke call failed (rc=$INVOKE_RC):"
-            cat /tmp/sweep_err.txt || true
-            echo "ℹ️ Deploy already succeeded; the API Gateway self-heals zombies within ~30 min. Not failing the pipeline."
-            exit 0
-          fi
+            if [ $INVOKE_RC -ne 0 ]; then
+              echo "⚠️ lambda invoke call failed (rc=$INVOKE_RC):"
+              cat /tmp/sweep_err.txt || true
+              echo "ℹ️ Deploy already succeeded; the API Gateway self-heals zombies within ~30 min. Not failing the pipeline."
+              exit 0
+            fi
 
-          echo "📡 Invoke metadata: $INVOKE_META"
-          FUNCTION_ERROR=$(echo "$INVOKE_META" | jq -r '.FunctionError // empty')
-          RESPONSE=$(cat /tmp/sweep_out.json)
-          echo "📦 Lambda response: $RESPONSE"
+            echo "📡 Invoke metadata: $INVOKE_META"
+            FUNCTION_ERROR=$(echo "$INVOKE_META" | jq -r '.FunctionError // empty')
+            RESPONSE=$(cat /tmp/sweep_out.json)
+            echo "📦 Lambda response: $RESPONSE"
 
-          # The handler returns {"statusCode": N, "body": "<json string>"}.
-          STATUS=$(echo "$RESPONSE" | jq -r '.statusCode // empty' 2>/dev/null)
-          BODY=$(echo "$RESPONSE" | jq -r '.body // empty' 2>/dev/null)
+            # The handler returns {"statusCode": N, "body": "<json string>"}.
+            STATUS=$(echo "$RESPONSE" | jq -r '.statusCode // empty' 2>/dev/null)
+            BODY=$(echo "$RESPONSE" | jq -r '.body // empty' 2>/dev/null)
+
+            # An unhandled Lambda error has no statusCode — terminal, don't retry.
+            if [ -n "$FUNCTION_ERROR" ]; then
+              break
+            fi
+
+            # Retry ONLY the "future cutoff" 400 — we just deployed and need to
+            # wait for the cutoff to pass. Everything else is a final result.
+            if [ "$STATUS" = "400" ] && echo "$BODY" | grep -qi "in the future"; then
+              if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+                echo "⏳ Cutoff not reached yet; sleeping ${SLEEP_SECS}s before retry."
+                sleep "$SLEEP_SECS"
+                continue
+              fi
+            fi
+            break
+          done
 
           {
             echo "### 🧹 Routed-sessions zombie sweep"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -102,6 +102,7 @@
               "providers/full/myprovider-gui",
               "providers/full/register-onchain",
               "providers/full/verify-setup",
+              "providers/full/model-health",
               "providers/full/pricing"
             ]
           },

--- a/docs/providers/full/model-health.mdx
+++ b/docs/providers/full/model-health.mdx
@@ -1,0 +1,133 @@
+---
+title: "Model health self-report"
+description: "How the provider's built-in model health checker works: what it probes, what it costs your backend, how to tune the schedule, and how to read the report to diagnose failing models."
+audience: ["provider-full", "provider-resale"]
+product: ["proxy-router"]
+last_verified: "v7.4.0"
+---
+
+Since v7.4.0 every provider proxy-router continuously verifies that the models it sells actually work, and publishes the result as a `models` array on its `/healthcheck` endpoint. This page is the operational reference for that capability: what runs, what it costs, how to tune it, and how to read the report when something is unhealthy. For the one-time post-setup walkthrough, see [Verify your provider setup](/providers/full/verify-setup).
+
+<Note>
+The `httpStatus` and `modelName` report fields, the `rate_limited` error kind, probe pacing (`MODEL_HEALTH_CHECK_PROBE_DELAY`), and the manual `POST /healthcheck/models/refresh` trigger were added in the release **after** v7.4.0. On v7.4.0 nodes you get the report without those features.
+</Note>
+
+## What actually runs
+
+On a schedule (default hourly, plus one sweep immediately at startup), the proxy-router walks the union of:
+
+- every model in `models-config.json`, **probed only if it has an active on-chain bid from your wallet**, and
+- every active bid whose model is *missing* from `models-config.json` — capacity you are selling but cannot serve, reported as `no_model_configured`.
+
+An LLM probe is a real, tiny chat completion sent **directly to your backend `apiUrl`** — a randomized arithmetic question ("What is 17+34? Reply with only the number."), graded into `promptCorrect`. Embedding models get a one-input embeddings request. Other model types (TTS, image, video) are not probed and report `skipped`. Results are cached in memory between sweeps.
+
+Two consequences worth internalizing:
+
+1. **The probe validates your backend wiring, not your public path.** It goes straight from the proxy-router to the `apiUrl` in `models-config.json` — it does not traverse `:3333`, sessions, or the marketplace. A model can be `healthy` here while your node is unreachable from the internet (check that separately, see [verify-setup](/providers/full/verify-setup)).
+2. **A configured model without a bid is not probed** (`no_bid`). A typo'd `apiUrl` stays invisible until you post a bid — probe-test new models by posting the bid first, or hit the backend manually.
+
+## Configuration and defaults
+
+| Variable | Default | What it controls |
+|----------|---------|------------------|
+| `MODEL_HEALTH_CHECK_DISABLED` | `false` | Set `true` to disable the loop entirely; the `models` field disappears from `/healthcheck` |
+| `MODEL_HEALTH_CHECK_INTERVAL` | `1h` | How often the full sweep runs; results are cached between sweeps |
+| `MODEL_HEALTH_CHECK_TIMEOUT` | `60s` | Per-model probe timeout; slower probes report `errorKind: timeout` |
+| `MODEL_HEALTH_CHECK_PROBE_DELAY` | `2s` | Pause between consecutive probes within a sweep |
+
+Full env reference: [env-proxy-router](/reference/env-proxy-router).
+
+### Impact on your node and your backend
+
+The load on the proxy-router itself is negligible — one lightweight request at a time, sequentially. The cost that matters is **downstream, on your backend**:
+
+- **Every probe is a real completion against your upstream.** With 65 models on an hourly sweep that is ~1,560 tiny (≈10-token) completions per day. Against a metered upstream this is real but usually negligible billing; raise `MODEL_HEALTH_CHECK_INTERVAL` if you care.
+- **Probes share your upstream rate-limit budget with real consumer traffic.** This is why pacing exists: many resale providers fan all models onto a single upstream account (for example a LiteLLM node in front of Venice), and an unpaced sweep of 60+ models fires several requests per second at it — enough to trip a per-minute rate limit, mark your own models `rate_limited`, and throttle paying consumers at the same time. The default 2s delay keeps a 65-model sweep at ~0.5 req/s over roughly 3–5 minutes. If your upstream is particularly strict, raise the delay; you have a whole hour of headroom before it affects the schedule.
+- A sweep takes about `models × (probe latency + probe delay)`. Keep `interval` comfortably larger than that.
+
+## Reading the report
+
+```bash
+curl -s http://localhost:8082/healthcheck | jq '.models'
+```
+
+```json
+{
+  "modelId": "0x0b0b...",
+  "modelName": "gemini-3.1-pro-preview",
+  "modelType": "LLM",
+  "hasActiveBid": true,
+  "bidId": "0x02f5...",
+  "status": "unhealthy",
+  "errorKind": "bad_response",
+  "httpStatus": 402,
+  "latencyMs": 292,
+  "lastHealthy": 1783534671,
+  "lastChecked": 1783536653
+}
+```
+
+`modelName` is the model's **public on-chain registered name** — looked up from the model registry, never your private `modelName` from `models-config.json` (which, like `apiUrl` and `apiKey`, is never exposed).
+
+| Status | Meaning |
+|--------|---------|
+| `healthy` | Probe succeeded; for LLMs `promptCorrect` says whether the answer was right |
+| `unhealthy` | Probe failed — `errorKind` and `httpStatus` say why (see below) |
+| `no_bid` | Configured but no active bid; **not probed** |
+| `no_model_configured` | Active bid but no `models-config.json` entry — consumers can open sessions against this bid and get errors |
+| `skipped` | Model type not probeable (TTS, image, video) |
+
+For `unhealthy` models, the diagnosis is the combination of `errorKind` and `httpStatus`:
+
+| errorKind | httpStatus | Almost always means |
+|-----------|------------|---------------------|
+| `connection` | — | Backend `apiUrl` unreachable: wrong host/port, container down, DNS |
+| `timeout` | — | Backend reachable but slower than `MODEL_HEALTH_CHECK_TIMEOUT` |
+| `rate_limited` | `429` | Backend up and correctly configured, just throttled — often transient; if persistent, your upstream quota is too small for your traffic |
+| `bad_response` | `402` | Upstream account out of credits / payment required — a billing problem, not a node problem |
+| `bad_response` | `400` / `404` | Upstream rejected the request: wrong model name in `models-config.json`, model retired upstream, malformed base URL |
+| `bad_response` | `401` / `403` | Bad or expired `apiKey` |
+| `bad_response` | `5xx` | Upstream itself is failing |
+| `bad_response` | *(absent)* | Backend returned 200 but an empty/invalid completion |
+
+A `healthy` model with `promptCorrect: false` deserves attention too: the backend responds, but the model can't answer 2-digit addition — usually the `apiUrl`/`modelName` pair is wired to the wrong model.
+
+## Diagnosing locally — the tricky parts
+
+**The report is cached — trigger a re-check instead of waiting.** `lastChecked` (unix epoch — `date -r 1783536653` on macOS, `date -d @1783536653` on Linux) tells you how stale each entry is. After fixing a backend, queue an immediate sweep:
+
+```bash
+curl -s -X POST -u 'admin:yourpassword' http://localhost:8082/healthcheck/models/refresh
+# {"status":"refresh queued"}
+```
+
+The call returns `202` immediately and the sweep runs in the background — with probe pacing, a many-model sweep takes a few minutes, so poll `GET /healthcheck` and watch `lastChecked` move. Triggers don't stack: while one manual sweep is queued or running, another `POST` answers `"refresh already pending"` — you cannot hammer your own backend through this endpoint. It requires basic auth (method permission `model_health_refresh`; the admin user's `*` whitelist covers it). On older releases without the endpoint, **restart the proxy-router** instead — a sweep always runs at startup.
+
+**Timestamps carry the history.** `lastHealthy` survives failures: an unhealthy model with a recent `lastHealthy` broke recently (billing, throttling); one with `lastHealthy: 0` has never worked since the router started (misconfiguration).
+
+**The probe result can differ from what consumers experience.** The probe hits the backend directly. If it's `healthy` but consumers report failures, the problem is in front: `:3333` reachability, on-chain endpoint registration, or session handling. Work through [verify-setup](/providers/full/verify-setup) steps 2–5.
+
+**Checking your node from the outside.** `/healthcheck` lives on the `:8082` admin API, which must **not** be exposed publicly. To read a provider's self-report remotely, ask any C-Node to relay it over the Morpheus TCP protocol — the ping RPC returns the same `models` array:
+
+```bash
+curl -s -X POST 'http://<your-c-node>:8082/proxy/provider/ping' \
+  -H 'Content-Type: application/json' \
+  -d '{"providerAddr": "0xYOUR_PROVIDER_WALLET", "providerUrl": "your.node.example:3333"}' | jq '.models'
+```
+
+Use the provider's **own registered wallet and endpoint** exactly as they appear on-chain (`/blockchain/providers`) — a mismatched pair fails signature verification.
+
+**Quick triage one-liner** — group your unhealthy models by cause:
+
+```bash
+curl -s http://localhost:8082/healthcheck \
+  | jq -r '.models[] | select(.status=="unhealthy")
+      | "\(.errorKind)/\(.httpStatus // "-")\t\(.modelName // .modelId)"' \
+  | sort | uniq -c | sort -rn
+```
+
+If most rows share one `errorKind/httpStatus` (say `bad_response/402`), you have one upstream problem, not N model problems.
+
+## Turning it off
+
+Set `MODEL_HEALTH_CHECK_DISABLED=true` only if you genuinely cannot afford the probe traffic. The report is how the network — and your own monitoring — can tell a billing failure from a dead node from a rate limit **before** consumers burn sessions discovering it for you.

--- a/docs/providers/full/verify-setup.mdx
+++ b/docs/providers/full/verify-setup.mdx
@@ -22,13 +22,14 @@ Expected:
 { "status": "healthy", "version": "v7.0.0", "uptime": "..." }
 ```
 
-On provider nodes the response also includes a `models` array — the periodic model health self-report covering your **whole ecosystem of configured models and active bids**. For every model in `models-config.json` that has an active bid from your wallet, the proxy-router sends a small test prompt on a schedule (default hourly, see `MODEL_HEALTH_CHECK_INTERVAL` in [env-proxy-router](/reference/env-proxy-router)) and caches the result. Active bids whose model is *missing* from `models-config.json` are also listed, so a bid you're selling but cannot serve doesn't go unnoticed:
+On provider nodes the response also includes a `models` array — the periodic model health self-report covering your **whole ecosystem of configured models and active bids**. For every model in `models-config.json` that has an active bid from your wallet, the proxy-router sends a small test prompt on a schedule (default hourly, see `MODEL_HEALTH_CHECK_INTERVAL` in [env-proxy-router](/reference/env-proxy-router)) and caches the result. Probes are paced a few seconds apart (`MODEL_HEALTH_CHECK_PROBE_DELAY`, default `2s`) so a provider with many models doesn't burst its own backend into a rate limit. Active bids whose model is *missing* from `models-config.json` are also listed, so a bid you're selling but cannot serve doesn't go unnoticed:
 
 ```json
 {
   "models": [
     {
       "modelId": "0xe086...",
+      "modelName": "llama-3.3-70b",
       "modelType": "LLM",
       "hasActiveBid": true,
       "bidId": "0x3f2a...",
@@ -40,6 +41,7 @@ On provider nodes the response also includes a `models` array — the periodic m
     },
     {
       "modelId": "0x85670d...",
+      "modelName": "mistral-31-24b",
       "modelType": "LLM",
       "hasActiveBid": true,
       "bidId": "0x9c41...",
@@ -50,15 +52,28 @@ On provider nodes the response also includes a `models` array — the periodic m
 }
 ```
 
+`modelName` is the model's public name as registered on-chain (not the private backend model string from `models-config.json`, which is never exposed).
+
 `status` is one of:
 
 | Status | Meaning | Action |
 |--------|---------|--------|
 | `healthy` | Probe succeeded (LLM answer graded via `promptCorrect`) | — |
-| `unhealthy` | Probe failed — see `errorKind`: `timeout`, `connection`, `bad_response` | Fix the backend `apiUrl`; consumers opening a session hit the same failure |
+| `unhealthy` | Probe failed — see `errorKind` and `httpStatus` below | Fix the backend; consumers opening a session hit the same failure |
 | `no_bid` | Configured model has no active bid; not probed | Post a bid if you want to sell it |
 | `no_model_configured` | **Active bid exists but the model is missing from `models-config.json`** | Add the model entry or delete the bid — consumers can open sessions against this bid and get errors |
 | `skipped` | Model type other than LLM/embedding; not probed | — |
+
+The self-report has its own operational reference — schedule, tuning, backend impact, and diagnosis recipes — at [Model health self-report](/providers/full/model-health).
+
+For `unhealthy` models, `errorKind` narrows the failure and, when the backend answered with an HTTP error, `httpStatus` carries the exact upstream status code:
+
+| errorKind | Meaning | Typical `httpStatus` |
+|-----------|---------|----------------------|
+| `timeout` | Probe hit the per-model timeout | — |
+| `connection` | Could not reach the backend `apiUrl` at all | — |
+| `rate_limited` | Backend is up and configured, but throttled the probe | `429` |
+| `bad_response` | Backend answered with an error or empty completion | `402` (billing), `400`/`404` (bad model config), `5xx` |
 
 Logs should show:
 

--- a/docs/reference/env-proxy-router.mdx
+++ b/docs/reference/env-proxy-router.mdx
@@ -175,13 +175,14 @@ For exact defaults check the source of truth ([`config.go`](https://github.com/M
 
 ## Model health self-checks (provider)
 
-On provider nodes the proxy-router periodically probes every model from `models-config.json` that has an **active bid from this provider**: LLM models get a small dynamically generated arithmetic prompt (correctness is graded), embedding models get an embeddings request, and other model types are skipped. The report covers the whole ecosystem of bids and configured models — active bids whose model is missing from `models-config.json` are flagged as `no_model_configured` (capacity being sold with no backend to serve it). The cached per-model results (on-chain `modelId`, `bidId`, status, `lastHealthy` epoch, latency, prompt correctness — never the private `modelName`, `apiUrl`, or `apiKey`) are exposed in the `models` field of `GET /healthcheck`, in the `network.ping` (pong) response on the `:3333` MOR RPC port, and in `POST /proxy/provider/ping`, so consumers can see a provider's model health before opening a session.
+On provider nodes the proxy-router periodically probes every model from `models-config.json` that has an **active bid from this provider**: LLM models get a small dynamically generated arithmetic prompt (correctness is graded), embedding models get an embeddings request, and other model types are skipped. The report covers the whole ecosystem of bids and configured models — active bids whose model is missing from `models-config.json` are flagged as `no_model_configured` (capacity being sold with no backend to serve it). The cached per-model results (on-chain `modelId` and registered model name, `bidId`, status, `errorKind` plus upstream `httpStatus` on failure, `lastHealthy` epoch, latency, prompt correctness — never the private `models-config.json` `modelName`, `apiUrl`, or `apiKey`) are exposed in the `models` field of `GET /healthcheck`, in the `network.ping` (pong) response on the `:3333` MOR RPC port, and in `POST /proxy/provider/ping`, so consumers can see a provider's model health before opening a session. Full operational guide: [Model health self-report](/providers/full/model-health).
 
 | Variable | Default | Notes |
 |----------|---------|-------|
 | `MODEL_HEALTH_CHECK_DISABLED` | `false` | Set `true` to disable the loop (the `models` field disappears from `/healthcheck`) |
 | `MODEL_HEALTH_CHECK_INTERVAL` | `1h` | How often models are probed; results are cached between runs |
 | `MODEL_HEALTH_CHECK_TIMEOUT` | `60s` | Per-model probe timeout |
+| `MODEL_HEALTH_CHECK_PROBE_DELAY` | `2s` | Pause between per-model probes so many-model providers don't burst their upstream into a rate limit |
 
 ## TEE (Phase 1 + Phase 2 attestation)
 

--- a/proxy-router/cmd/main.go
+++ b/proxy-router/cmd/main.go
@@ -384,9 +384,9 @@ func start() error {
 		modelHealthChecker = modelhealth.NewChecker(modelhealth.Deps{
 			Adapters:     aiEngine,
 			Bids:         blockchainApi,
-			Tags:         blockchainApi,
+			Models:       blockchainApi,
 			ModelConfigs: modelConfigLoader,
-		}, cfg.Proxy.ModelHealthCheckInterval, cfg.Proxy.ModelHealthCheckTimeout, appLog)
+		}, cfg.Proxy.ModelHealthCheckInterval, cfg.Proxy.ModelHealthCheckTimeout, cfg.Proxy.ModelHealthCheckProbeDelay, appLog)
 		modelHealthReporter = modelHealthChecker
 	}
 

--- a/proxy-router/docs/docs.go
+++ b/proxy-router/docs/docs.go
@@ -2092,6 +2092,31 @@ const docTemplate = `{
                 }
             }
         },
+        "/healthcheck/models/refresh": {
+            "post": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "description": "Queue an immediate model health sweep instead of waiting for the next scheduled run (provider nodes only). Returns immediately; the sweep runs in the background — poll GET /healthcheck and watch models[].lastChecked for fresh results. Probes are paced by MODEL_HEALTH_CHECK_PROBE_DELAY, so a full sweep over many models takes minutes.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "Trigger model health re-check",
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/system.StatusRes"
+                        }
+                    }
+                }
+            }
+        },
         "/ipfs/add": {
             "post": {
                 "security": [
@@ -4797,6 +4822,10 @@ const docTemplate = `{
                 "hasActiveBid": {
                     "type": "boolean"
                 },
+                "httpStatus": {
+                    "description": "HttpStatus is the HTTP status code returned by the upstream backend\nwhen the probe failed with a non-200 response (e.g. 402, 429).\nZero when the probe succeeded or never got an HTTP response.",
+                    "type": "integer"
+                },
                 "lastChecked": {
                     "type": "integer"
                 },
@@ -4807,6 +4836,9 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "modelId": {
+                    "type": "string"
+                },
+                "modelName": {
                     "type": "string"
                 },
                 "modelType": {

--- a/proxy-router/docs/swagger.json
+++ b/proxy-router/docs/swagger.json
@@ -2084,6 +2084,31 @@
                 }
             }
         },
+        "/healthcheck/models/refresh": {
+            "post": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "description": "Queue an immediate model health sweep instead of waiting for the next scheduled run (provider nodes only). Returns immediately; the sweep runs in the background — poll GET /healthcheck and watch models[].lastChecked for fresh results. Probes are paced by MODEL_HEALTH_CHECK_PROBE_DELAY, so a full sweep over many models takes minutes.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "Trigger model health re-check",
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/system.StatusRes"
+                        }
+                    }
+                }
+            }
+        },
         "/ipfs/add": {
             "post": {
                 "security": [
@@ -4789,6 +4814,10 @@
                 "hasActiveBid": {
                     "type": "boolean"
                 },
+                "httpStatus": {
+                    "description": "HttpStatus is the HTTP status code returned by the upstream backend\nwhen the probe failed with a non-200 response (e.g. 402, 429).\nZero when the probe succeeded or never got an HTTP response.",
+                    "type": "integer"
+                },
                 "lastChecked": {
                     "type": "integer"
                 },
@@ -4799,6 +4828,9 @@
                     "type": "integer"
                 },
                 "modelId": {
+                    "type": "string"
+                },
+                "modelName": {
                     "type": "string"
                 },
                 "modelType": {

--- a/proxy-router/docs/swagger.yaml
+++ b/proxy-router/docs/swagger.yaml
@@ -1110,6 +1110,12 @@ definitions:
         type: string
       hasActiveBid:
         type: boolean
+      httpStatus:
+        description: |-
+          HttpStatus is the HTTP status code returned by the upstream backend
+          when the probe failed with a non-200 response (e.g. 402, 429).
+          Zero when the probe succeeded or never got an HTTP response.
+        type: integer
       lastChecked:
         type: integer
       lastHealthy:
@@ -1117,6 +1123,8 @@ definitions:
       latencyMs:
         type: integer
       modelId:
+        type: string
+      modelName:
         type: string
       modelType:
         type: string
@@ -2465,6 +2473,25 @@ paths:
           schema:
             $ref: '#/definitions/system.HealthCheckResponse'
       summary: Healthcheck example
+      tags:
+      - system
+  /healthcheck/models/refresh:
+    post:
+      description: Queue an immediate model health sweep instead of waiting for the
+        next scheduled run (provider nodes only). Returns immediately; the sweep runs
+        in the background — poll GET /healthcheck and watch models[].lastChecked for
+        fresh results. Probes are paced by MODEL_HEALTH_CHECK_PROBE_DELAY, so a full
+        sweep over many models takes minutes.
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/system.StatusRes'
+      security:
+      - BasicAuth: []
+      summary: Trigger model health re-check
       tags:
       - system
   /ipfs/add:

--- a/proxy-router/internal/aiengine/claudeai.go
+++ b/proxy-router/internal/aiengine/claudeai.go
@@ -129,7 +129,7 @@ func (a *ClaudeAI) Prompt(ctx context.Context, compl *gcs.OpenAICompletionReques
 	log := a.log.With("request_id", lib.RequestIDFromContext(ctx))
 	log.Infof("AI Model responded with status code: %d", resp.StatusCode)
 	if resp.StatusCode != http.StatusOK {
-		return a.readError(ctx, resp.Body, cb)
+		return a.readError(ctx, resp.StatusCode, resp.Body, cb)
 	}
 
 	if isContentTypeStream(resp.Header) {
@@ -166,13 +166,13 @@ func (a *ClaudeAI) readResponse(ctx context.Context, body io.Reader, cb gcs.Comp
 	return nil
 }
 
-func (a *ClaudeAI) readError(ctx context.Context, body io.Reader, cb gcs.CompletionCallback) error {
+func (a *ClaudeAI) readError(ctx context.Context, statusCode int, body io.Reader, cb gcs.CompletionCallback) error {
 	var aiEngineErrorResponse interface{}
 	if err := json.NewDecoder(body).Decode(&aiEngineErrorResponse); err != nil {
 		return fmt.Errorf("failed to decode response: %v", err)
 	}
 
-	err := cb(ctx, nil, gcs.NewAiEngineErrorResponse(aiEngineErrorResponse))
+	err := cb(ctx, nil, gcs.NewAiEngineErrorResponse(statusCode, aiEngineErrorResponse))
 	if err != nil {
 		return fmt.Errorf("callback failed: %v", err)
 	}

--- a/proxy-router/internal/aiengine/hyperbolic_sd.go
+++ b/proxy-router/internal/aiengine/hyperbolic_sd.go
@@ -97,7 +97,7 @@ func (s *HyperbolicSD) Prompt(ctx context.Context, prompt *gcs.OpenAICompletionR
 			return fmt.Errorf("failed to decode response: %v", err)
 		}
 
-		err := cb(ctx, nil, gcs.NewAiEngineErrorResponse(aiEngineErrorResponse))
+		err := cb(ctx, nil, gcs.NewAiEngineErrorResponse(res.StatusCode, aiEngineErrorResponse))
 		if err != nil {
 			return fmt.Errorf("callback failed: %v", err)
 		}

--- a/proxy-router/internal/aiengine/openai.go
+++ b/proxy-router/internal/aiengine/openai.go
@@ -84,8 +84,8 @@ func (a *OpenAI) Prompt(ctx context.Context, compl *gcs.OpenAICompletionRequestE
 	log.Infof("AI Model responded with status code: %d", resp.StatusCode)
 
 	if resp.StatusCode != http.StatusOK {
-		log.Warnf("AI Model responded with error: %s", resp.StatusCode)
-		return a.readError(ctx, resp.Body, cb)
+		log.Warnf("AI Model responded with error: %d", resp.StatusCode)
+		return a.readError(ctx, resp.StatusCode, resp.Body, cb)
 	}
 
 	if isContentTypeStream(resp.Header) {
@@ -110,7 +110,7 @@ func (a *OpenAI) readResponse(ctx context.Context, body io.Reader, cb gcs.Comple
 	return nil
 }
 
-func (a *OpenAI) readError(ctx context.Context, body io.Reader, cb gcs.CompletionCallback) error {
+func (a *OpenAI) readError(ctx context.Context, statusCode int, body io.Reader, cb gcs.CompletionCallback) error {
 	raw, err := io.ReadAll(body)
 	if err != nil {
 		return fmt.Errorf("failed to read error response body: %v", err)
@@ -127,10 +127,10 @@ func (a *OpenAI) readError(ctx context.Context, body io.Reader, cb gcs.Completio
 				"type":    "upstream_error",
 			},
 		}
-		return cb(ctx, nil, gcs.NewAiEngineErrorResponse(parsed))
+		return cb(ctx, nil, gcs.NewAiEngineErrorResponse(statusCode, parsed))
 	}
 
-	if cbErr := cb(ctx, nil, gcs.NewAiEngineErrorResponse(parsed)); cbErr != nil {
+	if cbErr := cb(ctx, nil, gcs.NewAiEngineErrorResponse(statusCode, parsed)); cbErr != nil {
 		return fmt.Errorf("callback failed: %v", cbErr)
 	}
 	return nil
@@ -255,7 +255,7 @@ func (a *OpenAI) AudioTranscription(ctx context.Context, audioRequest *gcs.Audio
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return a.readError(ctx, resp.Body, cb)
+		return a.readError(ctx, resp.StatusCode, resp.Body, cb)
 	}
 
 	// Check if response is streaming
@@ -386,7 +386,7 @@ func (a *OpenAI) AudioSpeech(ctx context.Context, audioRequest *gcs.AudioSpeechR
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return a.readError(ctx, resp.Body, cb)
+		return a.readError(ctx, resp.StatusCode, resp.Body, cb)
 	}
 
 	// Stream the audio response in chunks
@@ -426,7 +426,7 @@ func (a *OpenAI) Embeddings(ctx context.Context, embedRequest *gcs.EmbeddingsReq
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return a.readError(ctx, resp.Body, cb)
+		return a.readError(ctx, resp.StatusCode, resp.Body, cb)
 	}
 
 	var embResp gcs.EmbeddingsResponse

--- a/proxy-router/internal/aiengine/prodia_v2.go
+++ b/proxy-router/internal/aiengine/prodia_v2.go
@@ -86,7 +86,7 @@ func (s *ProdiaV2) Prompt(ctx context.Context, prompt *gcs.OpenAICompletionReque
 			return fmt.Errorf("failed to decode response: %v", err)
 		}
 
-		err := cb(ctx, nil, gcs.NewAiEngineErrorResponse(aiEngineErrorResponse))
+		err := cb(ctx, nil, gcs.NewAiEngineErrorResponse(res.StatusCode, aiEngineErrorResponse))
 		if err != nil {
 			return fmt.Errorf("callback failed: %v", err)
 		}

--- a/proxy-router/internal/blockchainapi/service.go
+++ b/proxy-router/internal/blockchainapi/service.go
@@ -72,11 +72,11 @@ type BlockchainService struct {
 	minStake            *big.Int
 	attestationVerifier *attestation.Verifier
 
-	supplyBudgetMu   sync.Mutex
-	cachedSupply     *big.Int
-	cachedSupplyAt   time.Time
-	cachedBudget     *big.Int
-	cachedBudgetAt   time.Time
+	supplyBudgetMu sync.Mutex
+	cachedSupply   *big.Int
+	cachedSupplyAt time.Time
+	cachedBudget   *big.Int
+	cachedBudgetAt time.Time
 
 	legacyTx    bool
 	privateKey  i.PrKeyProvider
@@ -609,6 +609,16 @@ func (s *BlockchainService) GetModelTags(ctx context.Context, modelID common.Has
 		return nil, err
 	}
 	return m.Tags, nil
+}
+
+// GetModelNameAndTags returns the public on-chain name and tags of a model
+// in a single registry read.
+func (s *BlockchainService) GetModelNameAndTags(ctx context.Context, modelID common.Hash) (string, []string, error) {
+	m, err := s.modelRegistry.GetModelById(ctx, modelID)
+	if err != nil {
+		return "", nil, err
+	}
+	return m.Name, m.Tags, nil
 }
 
 func (s *BlockchainService) ModelExists(ctx context.Context, modelID common.Hash) (bool, error) {

--- a/proxy-router/internal/chatstorage/genericchatstorage/completion.go
+++ b/proxy-router/internal/chatstorage/genericchatstorage/completion.go
@@ -471,10 +471,14 @@ var _ Chunk = &ChunkEmbedding{}
 
 type AiEngineErrorResponse struct {
 	ProviderModelError interface{} `json:"providerModelError"`
+	// StatusCode is the HTTP status returned by the upstream model backend
+	// (e.g. 402 payment required, 429 rate limited). Zero when unknown.
+	StatusCode int `json:"statusCode,omitempty"`
 }
 
-func NewAiEngineErrorResponse(ProviderModelError interface{}) *AiEngineErrorResponse {
+func NewAiEngineErrorResponse(statusCode int, providerModelError interface{}) *AiEngineErrorResponse {
 	return &AiEngineErrorResponse{
-		ProviderModelError: ProviderModelError,
+		ProviderModelError: providerModelError,
+		StatusCode:         statusCode,
 	}
 }

--- a/proxy-router/internal/config/config.go
+++ b/proxy-router/internal/config/config.go
@@ -58,25 +58,26 @@ type Config struct {
 		LevelStorage string `env:"LOG_LEVEL_STORAGE"     flag:"log-level-storage"     validate:"omitempty,oneof=debug info warn error dpanic panic fatal"`
 	}
 	Proxy struct {
-		Address                   string        `env:"PROXY_ADDRESS" flag:"proxy-address" validate:"required,hostname_port"`
-		StoragePath               string        `env:"PROXY_STORAGE_PATH"    flag:"proxy-storage-path"    validate:"omitempty,dirpath" desc:"enables file storage and sets the folder path"`
-		StoreChatContext          *lib.Bool     `env:"PROXY_STORE_CHAT_CONTEXT" flag:"proxy-store-chat-context" desc:"store chat context in the proxy storage"`
-		ForwardChatContext        *lib.Bool     `env:"PROXY_FORWARD_CHAT_CONTEXT" flag:"proxy-forward-chat-context" desc:"prepend whole stored message history to the prompt"`
-		AgentConfigPath           string        `env:"AGENT_CONFIG_PATH" flag:"agent-config-path" validate:"omitempty"`
-		AgentConfigContent        string        `env:"AGENT_CONFIG_CONTENT" flag:"agent-config-content" validate:"omitempty" desc:"content of the agent config file"`
-		ModelsConfigPath          string        `env:"MODELS_CONFIG_PATH" flag:"models-config-path" validate:"omitempty"`
-		ModelsConfigContent       string        `env:"MODELS_CONFIG_CONTENT" flag:"models-config-content" validate:"omitempty" desc:"content of the models config file"`
-		RatingConfigPath          string        `env:"RATING_CONFIG_PATH" flag:"rating-config-path" validate:"omitempty" desc:"path to the rating config file"`
-		CookieFilePath            string        `env:"COOKIE_FILE_PATH" flag:"cookie-file-path" validate:"omitempty" desc:"path to the cookie file"`
-		CookieContent             string        `env:"COOKIE_CONTENT" flag:"cookie-content" validate:"omitempty" desc:"content of the cookie file"`
-		AuthConfigFilePath        string        `env:"AUTH_CONFIG_FILE_PATH" flag:"auth-config-file-path" validate:"omitempty"`
-		LLMTimeout                time.Duration `env:"LLM_TIMEOUT" flag:"llm-timeout" validate:"omitempty" desc:"timeout for PNode to LLM requests, applies to both streaming and non-streaming"`
-		CNodePNodeTimeout         time.Duration `env:"CNODE_PNODE_TIMEOUT" flag:"cnode-pnode-timeout" validate:"omitempty" desc:"per-attempt timeout for CNode waiting for PNode first response"`
-		CNodePNodeMaxRetries      int           `env:"CNODE_PNODE_MAX_RETRIES" flag:"cnode-pnode-max-retries" validate:"omitempty,gte=0" desc:"max retries for CNode to PNode read timeout (chat/embeddings)"`
-		CNodePNodeAudioMaxRetries int           `env:"CNODE_PNODE_AUDIO_MAX_RETRIES" flag:"cnode-pnode-audio-max-retries" validate:"omitempty,gte=0" desc:"max retries for CNode to PNode read timeout (audio transcription/speech)"`
-		ModelHealthCheckDisabled  bool          `env:"MODEL_HEALTH_CHECK_DISABLED" flag:"model-health-check-disabled" desc:"disable periodic model health self-checks on provider"`
-		ModelHealthCheckInterval  time.Duration `env:"MODEL_HEALTH_CHECK_INTERVAL" flag:"model-health-check-interval" validate:"omitempty,duration" desc:"how often to probe configured models with a test prompt, result is cached between runs"`
-		ModelHealthCheckTimeout   time.Duration `env:"MODEL_HEALTH_CHECK_TIMEOUT" flag:"model-health-check-timeout" validate:"omitempty,duration" desc:"per-model health probe timeout"`
+		Address                    string        `env:"PROXY_ADDRESS" flag:"proxy-address" validate:"required,hostname_port"`
+		StoragePath                string        `env:"PROXY_STORAGE_PATH"    flag:"proxy-storage-path"    validate:"omitempty,dirpath" desc:"enables file storage and sets the folder path"`
+		StoreChatContext           *lib.Bool     `env:"PROXY_STORE_CHAT_CONTEXT" flag:"proxy-store-chat-context" desc:"store chat context in the proxy storage"`
+		ForwardChatContext         *lib.Bool     `env:"PROXY_FORWARD_CHAT_CONTEXT" flag:"proxy-forward-chat-context" desc:"prepend whole stored message history to the prompt"`
+		AgentConfigPath            string        `env:"AGENT_CONFIG_PATH" flag:"agent-config-path" validate:"omitempty"`
+		AgentConfigContent         string        `env:"AGENT_CONFIG_CONTENT" flag:"agent-config-content" validate:"omitempty" desc:"content of the agent config file"`
+		ModelsConfigPath           string        `env:"MODELS_CONFIG_PATH" flag:"models-config-path" validate:"omitempty"`
+		ModelsConfigContent        string        `env:"MODELS_CONFIG_CONTENT" flag:"models-config-content" validate:"omitempty" desc:"content of the models config file"`
+		RatingConfigPath           string        `env:"RATING_CONFIG_PATH" flag:"rating-config-path" validate:"omitempty" desc:"path to the rating config file"`
+		CookieFilePath             string        `env:"COOKIE_FILE_PATH" flag:"cookie-file-path" validate:"omitempty" desc:"path to the cookie file"`
+		CookieContent              string        `env:"COOKIE_CONTENT" flag:"cookie-content" validate:"omitempty" desc:"content of the cookie file"`
+		AuthConfigFilePath         string        `env:"AUTH_CONFIG_FILE_PATH" flag:"auth-config-file-path" validate:"omitempty"`
+		LLMTimeout                 time.Duration `env:"LLM_TIMEOUT" flag:"llm-timeout" validate:"omitempty" desc:"timeout for PNode to LLM requests, applies to both streaming and non-streaming"`
+		CNodePNodeTimeout          time.Duration `env:"CNODE_PNODE_TIMEOUT" flag:"cnode-pnode-timeout" validate:"omitempty" desc:"per-attempt timeout for CNode waiting for PNode first response"`
+		CNodePNodeMaxRetries       int           `env:"CNODE_PNODE_MAX_RETRIES" flag:"cnode-pnode-max-retries" validate:"omitempty,gte=0" desc:"max retries for CNode to PNode read timeout (chat/embeddings)"`
+		CNodePNodeAudioMaxRetries  int           `env:"CNODE_PNODE_AUDIO_MAX_RETRIES" flag:"cnode-pnode-audio-max-retries" validate:"omitempty,gte=0" desc:"max retries for CNode to PNode read timeout (audio transcription/speech)"`
+		ModelHealthCheckDisabled   bool          `env:"MODEL_HEALTH_CHECK_DISABLED" flag:"model-health-check-disabled" desc:"disable periodic model health self-checks on provider"`
+		ModelHealthCheckInterval   time.Duration `env:"MODEL_HEALTH_CHECK_INTERVAL" flag:"model-health-check-interval" validate:"omitempty,duration" desc:"how often to probe configured models with a test prompt, result is cached between runs"`
+		ModelHealthCheckTimeout    time.Duration `env:"MODEL_HEALTH_CHECK_TIMEOUT" flag:"model-health-check-timeout" validate:"omitempty,duration" desc:"per-model health probe timeout"`
+		ModelHealthCheckProbeDelay time.Duration `env:"MODEL_HEALTH_CHECK_PROBE_DELAY" flag:"model-health-check-probe-delay" validate:"omitempty,duration" desc:"pause between per-model health probes so many-model providers don't burst their upstream and trip rate limits"`
 	}
 	System struct {
 		Enable           bool   `env:"SYS_ENABLE"              flag:"sys-enable" desc:"enable system level configuration adjustments"`
@@ -218,6 +219,9 @@ func (cfg *Config) SetDefaults() {
 	if cfg.Proxy.ModelHealthCheckTimeout == 0 {
 		cfg.Proxy.ModelHealthCheckTimeout = 60 * time.Second
 	}
+	if cfg.Proxy.ModelHealthCheckProbeDelay == 0 {
+		cfg.Proxy.ModelHealthCheckProbeDelay = 2 * time.Second
+	}
 
 	// IPFS
 	if cfg.IPFS.Address == "" {
@@ -278,6 +282,7 @@ func (cfg *Config) GetSanitized() interface{} {
 	publicCfg.Proxy.ModelHealthCheckDisabled = cfg.Proxy.ModelHealthCheckDisabled
 	publicCfg.Proxy.ModelHealthCheckInterval = cfg.Proxy.ModelHealthCheckInterval
 	publicCfg.Proxy.ModelHealthCheckTimeout = cfg.Proxy.ModelHealthCheckTimeout
+	publicCfg.Proxy.ModelHealthCheckProbeDelay = cfg.Proxy.ModelHealthCheckProbeDelay
 
 	publicCfg.System.Enable = cfg.System.Enable
 	publicCfg.System.LocalPortRange = cfg.System.LocalPortRange

--- a/proxy-router/internal/modelhealth/checker.go
+++ b/proxy-router/internal/modelhealth/checker.go
@@ -2,7 +2,9 @@
 // models-config.json that have an active on-chain bid from this provider
 // actually respond to inference requests. Results are cached in memory and
 // exposed through the public /healthcheck endpoint, deliberately excluding
-// private config fields (modelName, apiUrl, apiKey).
+// private config fields (the models-config modelName, apiUrl, apiKey). The
+// report's modelName is the public name registered on-chain, which anyone
+// can already derive from the model ID.
 package modelhealth
 
 import (
@@ -12,6 +14,7 @@ import (
 	"math/big"
 	"math/rand"
 	"net"
+	"net/http"
 	"regexp"
 	"sort"
 	"strings"
@@ -45,41 +48,55 @@ type BidProvider interface {
 	GetActiveBidsByProvider(ctx context.Context, provider common.Address, offset *big.Int, limit uint8, order registries.Order) ([]*structs.Bid, error)
 }
 
-type ModelTagsProvider interface {
-	GetModelTags(ctx context.Context, modelID common.Hash) ([]string, error)
+type ModelMetaProvider interface {
+	GetModelNameAndTags(ctx context.Context, modelID common.Hash) (string, []string, error)
 }
 
 type ModelConfigProvider interface {
 	GetAll() ([]common.Hash, []config.ModelConfig)
 }
 
-type Checker struct {
-	deps     Deps
-	interval time.Duration
-	timeout  time.Duration
-	log      lib.ILogger
+// modelMeta caches the public on-chain facts about a model so each sweep
+// only pays one registry call per previously unseen model.
+type modelMeta struct {
+	name      string
+	modelType structs.ModelType
+}
 
-	mu         sync.RWMutex
-	reports    map[string]system.ModelHealthReport
-	modelTypes map[string]structs.ModelType
+type Checker struct {
+	deps       Deps
+	interval   time.Duration
+	timeout    time.Duration
+	probeDelay time.Duration
+	log        lib.ILogger
+
+	mu        sync.RWMutex
+	reports   map[string]system.ModelHealthReport
+	modelMeta map[string]modelMeta
+
+	// triggerCh carries manual re-check requests into the Run loop; buffered
+	// at 1 so triggers queue at most one extra sweep and can never overlap.
+	triggerCh chan struct{}
 }
 
 // Deps groups the external dependencies of the checker.
 type Deps struct {
 	Adapters     AdapterProvider
 	Bids         BidProvider
-	Tags         ModelTagsProvider
+	Models       ModelMetaProvider
 	ModelConfigs ModelConfigProvider
 }
 
-func NewChecker(deps Deps, interval, timeout time.Duration, log lib.ILogger) *Checker {
+func NewChecker(deps Deps, interval, timeout, probeDelay time.Duration, log lib.ILogger) *Checker {
 	return &Checker{
 		deps:       deps,
 		interval:   interval,
 		timeout:    timeout,
+		probeDelay: probeDelay,
 		log:        log.Named("MODEL_HEALTH"),
 		reports:    make(map[string]system.ModelHealthReport),
-		modelTypes: make(map[string]structs.ModelType),
+		modelMeta:  make(map[string]modelMeta),
+		triggerCh:  make(chan struct{}, 1),
 	}
 }
 
@@ -98,7 +115,26 @@ func (c *Checker) Run(ctx context.Context, walletAddr common.Address) error {
 			return ctx.Err()
 		case <-ticker.C:
 			c.checkAll(ctx, walletAddr)
+		case <-c.triggerCh:
+			c.log.Info("manual model health re-check triggered")
+			c.checkAll(ctx, walletAddr)
+			// restart the scheduled cadence relative to the manual sweep so
+			// a trigger isn't immediately followed by a scheduled sweep
+			ticker.Reset(c.interval)
 		}
+	}
+}
+
+// TriggerNow queues an immediate re-check sweep on the Run loop and reports
+// whether it was accepted. It returns false when a manual sweep is already
+// queued; the sweep itself runs asynchronously — callers observe progress
+// through the lastChecked timestamps in the reports.
+func (c *Checker) TriggerNow() bool {
+	select {
+	case c.triggerCh <- struct{}{}:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -130,6 +166,7 @@ func (c *Checker) checkAll(ctx context.Context, walletAddr common.Address) {
 
 	seen := make(map[string]bool, len(modelIDs)+len(bidsByModel))
 
+	probed := false
 	for _, modelID := range modelIDs {
 		select {
 		case <-ctx.Done():
@@ -137,7 +174,17 @@ func (c *Checker) checkAll(ctx context.Context, walletAddr common.Address) {
 		default:
 		}
 		bidID, hasBid := bidsByModel[modelID]
+		// Pace backend probes so a provider with many models doesn't burst
+		// its upstream (often a single account behind all models) and
+		// self-inflict rate-limit failures. Only probed models (those with
+		// an active bid) hit the backend, so only they are paced.
+		if hasBid && probed && !c.sleep(ctx, c.probeDelay) {
+			return
+		}
 		c.checkModel(ctx, modelID, bidID, hasBid)
+		if hasBid {
+			probed = true
+		}
 		seen[modelID.Hex()] = true
 	}
 
@@ -171,11 +218,28 @@ func (c *Checker) reportUnconfigured(ctx context.Context, modelID common.Hash, b
 
 	c.log.Warnf("active bid %s for model %s has no entry in models config", lib.Short(bidID), lib.Short(modelID))
 
-	if modelType, err := c.modelType(ctx, modelID); err == nil {
-		report.ModelType = string(modelType)
+	if meta, err := c.modelMetaFor(ctx, modelID); err == nil {
+		report.ModelName = meta.name
+		report.ModelType = string(meta.modelType)
 	}
 
 	c.setReport(report)
+}
+
+// sleep blocks for d unless the context is cancelled first; it reports
+// whether the full delay elapsed.
+func (c *Checker) sleep(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return true
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 // prune drops cached reports for models that are no longer configured and no
@@ -243,18 +307,19 @@ func (c *Checker) checkModel(ctx context.Context, modelID common.Hash, bidID com
 		return
 	}
 
-	modelType, err := c.modelType(ctx, modelID)
+	meta, err := c.modelMetaFor(ctx, modelID)
 	if err != nil {
-		c.log.Warnf("model %s: cannot resolve model type: %s", lib.Short(modelID), err)
+		c.log.Warnf("model %s: cannot resolve model metadata: %s", lib.Short(modelID), err)
 		report.Status = system.ModelHealthStatusSkipped
 		report.ErrorKind = system.ModelHealthErrorTypeLookup
 		c.setReport(report)
 		return
 	}
-	report.ModelType = string(modelType)
+	report.ModelName = meta.name
+	report.ModelType = string(meta.modelType)
 
 	var probe func(ctx context.Context, adapter aiengine.AIEngineStream, report *system.ModelHealthReport) error
-	switch modelType {
+	switch meta.modelType {
 	case structs.ModelTypeLLM:
 		probe = c.probeLLM
 	case structs.ModelTypeEMBEDDING:
@@ -284,7 +349,14 @@ func (c *Checker) checkModel(ctx context.Context, modelID common.Hash, bidID com
 	if err != nil {
 		c.log.Warnf("model %s: probe failed: %s", lib.Short(modelID), err)
 		report.Status = system.ModelHealthStatusUnhealthy
-		report.ErrorKind = classifyError(err)
+		// 429 means the backend is up and correctly configured, just
+		// throttled right now — a materially different signal than a
+		// billing (402) or configuration (404) failure.
+		if report.HttpStatus == http.StatusTooManyRequests {
+			report.ErrorKind = system.ModelHealthErrorRateLimited
+		} else {
+			report.ErrorKind = classifyError(err)
+		}
 	} else {
 		report.Status = system.ModelHealthStatusHealthy
 		report.LastHealthy = time.Now().Unix()
@@ -309,6 +381,7 @@ func (c *Checker) probeLLM(ctx context.Context, adapter aiengine.AIEngineStream,
 	var engineErr error
 	err := adapter.Prompt(ctx, req, func(ctx context.Context, chunk gcs.Chunk, aiEngineErr *gcs.AiEngineErrorResponse) error {
 		if aiEngineErr != nil {
+			report.HttpStatus = aiEngineErr.StatusCode
 			engineErr = errors.New("model backend returned an error response")
 			return nil
 		}
@@ -340,6 +413,7 @@ func (c *Checker) probeEmbeddings(ctx context.Context, adapter aiengine.AIEngine
 	var gotVector bool
 	err := adapter.Embeddings(ctx, req, func(ctx context.Context, chunk gcs.Chunk, aiEngineErr *gcs.AiEngineErrorResponse) error {
 		if aiEngineErr != nil {
+			report.HttpStatus = aiEngineErr.StatusCode
 			return nil
 		}
 		resp, ok := chunk.Data().(gcs.EmbeddingsResponse)
@@ -360,25 +434,27 @@ func (c *Checker) probeEmbeddings(ctx context.Context, adapter aiengine.AIEngine
 	return nil
 }
 
-func (c *Checker) modelType(ctx context.Context, modelID common.Hash) (structs.ModelType, error) {
+// modelMetaFor resolves the public on-chain name and type of a model,
+// caching the result. Both come from a single registry read.
+func (c *Checker) modelMetaFor(ctx context.Context, modelID common.Hash) (modelMeta, error) {
 	c.mu.RLock()
-	cached, ok := c.modelTypes[modelID.Hex()]
+	cached, ok := c.modelMeta[modelID.Hex()]
 	c.mu.RUnlock()
 	if ok {
 		return cached, nil
 	}
 
-	tags, err := c.deps.Tags.GetModelTags(ctx, modelID)
+	name, tags, err := c.deps.Models.GetModelNameAndTags(ctx, modelID)
 	if err != nil {
-		return structs.ModelTypeUnknown, err
+		return modelMeta{}, err
 	}
 
-	modelType := blockchainapi.DetectModelType(tags)
+	meta := modelMeta{name: name, modelType: blockchainapi.DetectModelType(tags)}
 
 	c.mu.Lock()
-	c.modelTypes[modelID.Hex()] = modelType
+	c.modelMeta[modelID.Hex()] = meta
 	c.mu.Unlock()
-	return modelType, nil
+	return meta, nil
 }
 
 func (c *Checker) getReport(modelID string) (system.ModelHealthReport, bool) {

--- a/proxy-router/internal/modelhealth/checker_test.go
+++ b/proxy-router/internal/modelhealth/checker_test.go
@@ -67,6 +67,7 @@ type mockDeps struct {
 	bids       []*structs.Bid
 	bidsErr    error
 	tags       map[common.Hash][]string
+	names      map[common.Hash]string
 	modelIDs   []common.Hash
 	adapter    aiengine.AIEngineStream
 	adapterErr error
@@ -87,12 +88,12 @@ func (m *mockDeps) GetActiveBidsByProvider(ctx context.Context, provider common.
 	return m.bids[from:to], nil
 }
 
-func (m *mockDeps) GetModelTags(ctx context.Context, modelID common.Hash) ([]string, error) {
+func (m *mockDeps) GetModelNameAndTags(ctx context.Context, modelID common.Hash) (string, []string, error) {
 	tags, ok := m.tags[modelID]
 	if !ok {
-		return nil, errors.New("model not found")
+		return "", nil, errors.New("model not found")
 	}
-	return tags, nil
+	return m.names[modelID], tags, nil
 }
 
 func (m *mockDeps) GetAll() ([]common.Hash, []config.ModelConfig) {
@@ -152,9 +153,9 @@ func newTestChecker(deps *mockDeps) *Checker {
 	return NewChecker(Deps{
 		Adapters:     deps,
 		Bids:         deps,
-		Tags:         deps,
+		Models:       deps,
 		ModelConfigs: deps,
-	}, time.Hour, time.Second, lib.NewTestLogger())
+	}, time.Hour, time.Second, 0, lib.NewTestLogger())
 }
 
 func reportByID(t *testing.T, reports []system.ModelHealthReport, modelID common.Hash) system.ModelHealthReport {
@@ -188,6 +189,7 @@ func TestCheckAllStatuses(t *testing.T) {
 			modelTTS:          {"tts"},
 			modelUnconfigured: {"llm"},
 		},
+		names:    map[common.Hash]string{modelLLM: "test-llm"},
 		modelIDs: []common.Hash{modelLLM, modelEmbedding, modelNoBid, modelTTS},
 		adapter:  &mathSolvingAdapter{},
 	}
@@ -203,6 +205,8 @@ func TestCheckAllStatuses(t *testing.T) {
 	require.True(t, llm.HasActiveBid)
 	require.Equal(t, bidIDFor(modelLLM).Hex(), llm.BidID)
 	require.Equal(t, string(structs.ModelTypeLLM), llm.ModelType)
+	require.Equal(t, "test-llm", llm.ModelName)
+	require.Zero(t, llm.HttpStatus)
 	require.NotNil(t, llm.PromptCorrect)
 	require.True(t, *llm.PromptCorrect)
 	require.NotZero(t, llm.LastHealthy)
@@ -266,6 +270,65 @@ func TestCheckAllBidsOnlyNoConfig(t *testing.T) {
 	reports := checker.GetReports()
 	require.Len(t, reports, 1)
 	require.Equal(t, system.ModelHealthStatusNoModel, reports[0].Status)
+}
+
+// errorRespondingAdapter simulates an upstream backend that answers every
+// request with an HTTP error status (e.g. 402 payment required, 429 rate
+// limited) instead of a completion.
+type errorRespondingAdapter struct {
+	statusCode int
+}
+
+func (a *errorRespondingAdapter) Prompt(ctx context.Context, compl *gcs.OpenAICompletionRequestExtra, cb gcs.CompletionCallback) error {
+	return cb(ctx, nil, gcs.NewAiEngineErrorResponse(a.statusCode, map[string]interface{}{"error": "upstream error"}))
+}
+
+func (a *errorRespondingAdapter) Embeddings(ctx context.Context, req *gcs.EmbeddingsRequest, cb gcs.CompletionCallback) error {
+	return cb(ctx, nil, gcs.NewAiEngineErrorResponse(a.statusCode, map[string]interface{}{"error": "upstream error"}))
+}
+
+func (a *errorRespondingAdapter) AudioTranscription(ctx context.Context, req *gcs.AudioTranscriptionRequest, cb gcs.CompletionCallback) error {
+	return errors.New("not implemented")
+}
+
+func (a *errorRespondingAdapter) AudioSpeech(ctx context.Context, req *gcs.AudioSpeechRequest, cb gcs.CompletionCallback) error {
+	return errors.New("not implemented")
+}
+
+func (a *errorRespondingAdapter) ApiType() string { return "openai" }
+
+func TestCheckAllUpstreamHTTPError(t *testing.T) {
+	deps := &mockDeps{
+		bids:     []*structs.Bid{bidFor(modelLLM)},
+		tags:     map[common.Hash][]string{modelLLM: {"llm"}},
+		modelIDs: []common.Hash{modelLLM},
+		adapter:  &errorRespondingAdapter{statusCode: 402},
+	}
+
+	checker := newTestChecker(deps)
+	checker.checkAll(context.Background(), common.Address{})
+
+	llm := reportByID(t, checker.GetReports(), modelLLM)
+	require.Equal(t, system.ModelHealthStatusUnhealthy, llm.Status)
+	require.Equal(t, system.ModelHealthErrorBadResponse, llm.ErrorKind)
+	require.Equal(t, 402, llm.HttpStatus)
+}
+
+func TestCheckAllRateLimited(t *testing.T) {
+	deps := &mockDeps{
+		bids:     []*structs.Bid{bidFor(modelLLM)},
+		tags:     map[common.Hash][]string{modelLLM: {"llm"}},
+		modelIDs: []common.Hash{modelLLM},
+		adapter:  &errorRespondingAdapter{statusCode: 429},
+	}
+
+	checker := newTestChecker(deps)
+	checker.checkAll(context.Background(), common.Address{})
+
+	llm := reportByID(t, checker.GetReports(), modelLLM)
+	require.Equal(t, system.ModelHealthStatusUnhealthy, llm.Status)
+	require.Equal(t, system.ModelHealthErrorRateLimited, llm.ErrorKind)
+	require.Equal(t, 429, llm.HttpStatus)
 }
 
 func TestCheckAllProbeFailure(t *testing.T) {
@@ -332,6 +395,32 @@ func TestActiveBidModelsPaginates(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, byModel, len(bids)) // every bid targets a distinct model
 	require.Equal(t, bidIDFor(modelLLM), byModel[modelLLM])
+}
+
+func TestTriggerNowQueuesAtMostOne(t *testing.T) {
+	checker := newTestChecker(&mockDeps{})
+	require.True(t, checker.TriggerNow())
+	require.False(t, checker.TriggerNow(), "second trigger must be rejected while one is queued")
+}
+
+func TestRunConsumesTrigger(t *testing.T) {
+	checker := newTestChecker(&mockDeps{})
+	require.True(t, checker.TriggerNow())
+	require.False(t, checker.TriggerNow())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		_ = checker.Run(ctx, common.Address{})
+		close(done)
+	}()
+
+	// the Run loop must drain the queued trigger, freeing the slot
+	require.Eventually(t, func() bool { return checker.TriggerNow() }, 5*time.Second, 10*time.Millisecond)
+
+	cancel()
+	<-done
 }
 
 func TestCheckAllBidsError(t *testing.T) {

--- a/proxy-router/internal/system/controller.go
+++ b/proxy-router/internal/system/controller.go
@@ -22,9 +22,13 @@ type StorageHealthChecker interface {
 	DBSize() (lsmSize int64, vlogSize int64)
 }
 
-// ModelHealthReporter provides cached per-model health self-reports.
+// ModelHealthReporter provides cached per-model health self-reports and
+// accepts manual re-check triggers.
 type ModelHealthReporter interface {
 	GetReports() []ModelHealthReport
+	// TriggerNow queues an immediate re-check sweep; false means one is
+	// already queued. The sweep runs asynchronously.
+	TriggerNow() bool
 }
 
 type SystemController struct {
@@ -61,6 +65,7 @@ func NewSystemController(config *config.Config, wallet i.Wallet, ethRPC i.RPCEnd
 
 func (s *SystemController) RegisterRoutes(r i.Router) {
 	r.GET("/healthcheck", s.HealthCheck)
+	r.POST("/healthcheck/models/refresh", s.authConfig.CheckAuth("model_health_refresh"), s.RefreshModelHealth)
 	r.GET("/config", s.authConfig.CheckAuth("system_config"), s.GetConfig)
 	r.GET("/files", s.authConfig.CheckAuth("system_config"), s.GetFiles)
 
@@ -111,6 +116,28 @@ func (s *SystemController) HealthCheck(ctx *gin.Context) {
 		Components: components,
 		Models:     models,
 	})
+}
+
+// RefreshModelHealth godoc
+//
+//	@Summary		Trigger model health re-check
+//	@Description	Queue an immediate model health sweep instead of waiting for the next scheduled run (provider nodes only). Returns immediately; the sweep runs in the background — poll GET /healthcheck and watch models[].lastChecked for fresh results. Probes are paced by MODEL_HEALTH_CHECK_PROBE_DELAY, so a full sweep over many models takes minutes.
+//	@Tags			system
+//	@Produce		json
+//	@Success		202	{object}	StatusRes
+//	@Security		BasicAuth
+//	@Router			/healthcheck/models/refresh [post]
+func (s *SystemController) RefreshModelHealth(ctx *gin.Context) {
+	if s.modelHealth == nil {
+		ctx.JSON(http.StatusNotFound, gin.H{"error": "model health checks are disabled on this node"})
+		return
+	}
+
+	if !s.modelHealth.TriggerNow() {
+		ctx.JSON(http.StatusAccepted, StatusRes{Status: "refresh already pending"})
+		return
+	}
+	ctx.JSON(http.StatusAccepted, StatusRes{Status: "refresh queued"})
 }
 
 // GetConfig godoc

--- a/proxy-router/internal/system/structs.go
+++ b/proxy-router/internal/system/structs.go
@@ -34,16 +34,19 @@ const (
 	ModelHealthErrorTimeout     = "timeout"
 	ModelHealthErrorConnection  = "connection"
 	ModelHealthErrorBadResponse = "bad_response"
+	ModelHealthErrorRateLimited = "rate_limited"
 	ModelHealthErrorTypeLookup  = "model_type_lookup"
 )
 
 // ModelHealthReport is the sanitized per-model self-report exposed on the
 // public /healthcheck endpoint. It covers the union of configured models and
-// this provider's active bids, and intentionally carries only the on-chain
-// model ID and derived status — never the private modelName, apiUrl or
-// apiKey from models-config.json.
+// this provider's active bids, and intentionally carries only on-chain data
+// and derived status — never the private modelName, apiUrl or apiKey from
+// models-config.json. The ModelName here is the public name registered
+// on-chain for the model ID, not the private backend model string.
 type ModelHealthReport struct {
 	ModelID       string `json:"modelId"`
+	ModelName     string `json:"modelName,omitempty"`
 	ModelType     string `json:"modelType,omitempty"`
 	HasActiveBid  bool   `json:"hasActiveBid"`
 	BidID         string `json:"bidId,omitempty"`
@@ -53,6 +56,10 @@ type ModelHealthReport struct {
 	LatencyMs     int64  `json:"latencyMs,omitempty"`
 	PromptCorrect *bool  `json:"promptCorrect,omitempty"`
 	ErrorKind     string `json:"errorKind,omitempty"`
+	// HttpStatus is the HTTP status code returned by the upstream backend
+	// when the probe failed with a non-200 response (e.g. 402, 429).
+	// Zero when the probe succeeded or never got an HTTP response.
+	HttpStatus int `json:"httpStatus,omitempty"`
 }
 
 type StatusRes struct {


### PR DESCRIPTION
## Summary

Two changes since the last main release:

**Model health probe telemetry, pacing, and manual re-check (#781)**
- `httpStatus` (upstream HTTP code) and on-chain `modelName` added to the per-model health report; 429s classified as `rate_limited` instead of `bad_response`
- probe pacing: new `MODEL_HEALTH_CHECK_PROBE_DELAY` (default `2s`) so 60+-model sweeps don't burst the shared upstream account and self-inflict rate limits
- `POST /healthcheck/models/refresh` (basic auth, `model_health_refresh` perm) queues an immediate sweep, 202, non-stacking triggers
- log verb fix (`%!s(int=402)` → `402`), new `providers/full/model-health` docs page, swagger updated
- backward compatible: new JSON fields are ignored by older C-Nodes/consumers

**Zombie-sweep Lambda CI retry (#779)**
- the post-deploy `Sweep-Zombie-Sessions` step now retries (10x 30s) when the sweep Lambda returns 400 "cutoff is in the future", which happened when CI invoked it too soon after the C-Node deploy; other errors remain terminal
- pairs with the already-applied Terraform fix (sweep role whitelisted on the RDS proxy credentials secret)

## Validation

- [x] All CI green on `dev` and `test` promotions
- [ ] Test-environment verification in progress: C-Node → P-Node ping should show `modelName`/`httpStatus` in the models report; manual refresh endpoint returns 202
- [ ] Production sweep Lambda expected to run clean on this release's deploy (first full exercise of the retry + IAM fix)

Made with [Cursor](https://cursor.com)