### PR TITLE
fix(docs): emit per-page markdown in static export

### DIFF
--- a/docs/scripts/generate-llms-txt.mjs
+++ b/docs/scripts/generate-llms-txt.mjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 /**
- * Generate llms.txt and llms-full.txt from docs.json navigation + MDX source.
+ * Generate llms.txt, llms-full.txt, and per-page *.md from docs.json + MDX.
  * Usage: SITE_URL=https://nodedocs.mor.org node scripts/generate-llms-txt.mjs [docsDir] [outDir]
+ *
+ * Per-page markdown makes "View as Markdown" / Accept: text/markdown work on the
+ * self-hosted S3 site (Mintlify cloud serves these dynamically; mint export does not).
  */
 import fs from "fs";
 import path from "path";
@@ -56,8 +59,19 @@ function slugToMdxPath(slug) {
   return path.join(docsDir, `${slug}.mdx`);
 }
 
+function writePageMarkdown(slug, title, url, body) {
+  const mdPath =
+    slug === "index"
+      ? path.join(outDir, "index.md")
+      : path.join(outDir, `${slug}.md`);
+  fs.mkdirSync(path.dirname(mdPath), { recursive: true });
+  const md = `# ${title}\n\nSource: ${url}\n\n${body.trim()}\n`;
+  fs.writeFileSync(mdPath, md);
+}
+
 const entries = [];
 const fullSections = [];
+let mdCount = 0;
 
 for (const slug of collectSlugs()) {
   const mdxPath = slugToMdxPath(slug);
@@ -70,6 +84,8 @@ for (const slug of collectSlugs()) {
 
   entries.push({ title, description, url });
   fullSections.push(`# ${title}\n\nSource: ${url}\n\n${body.trim()}\n`);
+  writePageMarkdown(slug, title, url, body);
+  mdCount += 1;
 }
 
 const siteName = docsJson.name ?? "Morpheus Lumerin Node Docs";
@@ -104,4 +120,6 @@ fs.mkdirSync(outDir, { recursive: true });
 fs.writeFileSync(path.join(outDir, "llms.txt"), llmsTxt);
 fs.writeFileSync(path.join(outDir, "llms-full.txt"), llmsFullTxt);
 
-console.log(`Wrote llms.txt (${entries.length} pages) and llms-full.txt to ${outDir}`);
+console.log(
+  `Wrote llms.txt (${entries.length} pages), llms-full.txt, and ${mdCount} *.md files to ${outDir}`
+);

--- a/docs/scripts/postprocess-export.mjs
+++ b/docs/scripts/postprocess-export.mjs
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
 /**
- * Post-process a mint export directory: Pagefind index + navbar search + llms.txt.
+ * Post-process a mint export directory: Pagefind index + navbar search +
+ * llms.txt / llms-full.txt / per-page *.md.
  *
  * Mintlify's built-in search (docs.json "search") targets Mintlify Cloud and prompts
  * for CLI login on self-hosted S3/CloudFront exports. We use Pagefind (static index)
  * in the top navbar instead.
+ *
+ * Per-page *.md and the Fargate MCP at /mcp replace Mintlify cloud agent endpoints
+ * that do not ship with `mint export`.
  *
  * Usage: SITE_URL=https://nodedocs.mor.org node scripts/postprocess-export.mjs <siteDir>
  */
@@ -26,7 +30,7 @@ if (!fs.existsSync(siteDir)) {
 console.log("Running Pagefind index…");
 execSync(`npx pagefind --site "${siteDir}"`, { stdio: "inherit", cwd: docsDir });
 
-console.log("Generating llms.txt…");
+console.log("Generating llms.txt / llms-full.txt / per-page *.md…");
 execSync(
   `node "${path.join(__dirname, "generate-llms-txt.mjs")}" "${docsDir}" "${siteDir}"`,
   { stdio: "inherit", env: { ...process.env, SITE_URL: siteUrl } }


### PR DESCRIPTION
## Summary
- Write per-page `*.md` files during the Mintlify static export postprocess (alongside `llms.txt` / `llms-full.txt`).
- Enables "View as Markdown" and agent-friendly page fetches on the self-hosted S3/CloudFront docs site (Mintlify cloud `.md` alternates are not part of `mint export`).
- Pairs with the self-hosted nodedocs MCP on `nodedocs.dev.mor.org/mcp`.

## Test plan
- [ ] Docs CI validate passes on this PR
- [ ] After merge to `dev`, open promote PR to `test` and confirm deploy to `nodedocs.dev.mor.org` publishes `…/secretvm-quickstart.md` (HTTP 200)
- [ ] Confirm MCP `get_page` / `search_docs` still work (already live via `llms-full.txt`)


Made with [Cursor](https://cursor.com)