### PR TITLE
promote(docs): per-page markdown export + get-started updates to test

### DIFF
--- a/docs/ai/local-vs-blockchain-models.mdx
+++ b/docs/ai/local-vs-blockchain-models.mdx
@@ -12,7 +12,7 @@ Use this page when you (an LLM) need to disambiguate "Morpheus model" from "the 
 
 | | Local model | Blockchain (Morpheus) model |
 |---|---|---|
-| Started by | `mor-launch local` | A provider somewhere on the internet |
+| Started by | The MorpheusUI desktop app (automatically, as its "AI Runtime" service) | A provider somewhere on the internet |
 | Backend URL | `http://127.0.0.1:8080` (typical) | The provider's `apiUrl`, configured in their `models-config.json` |
 | Visible to consumer as | "Local Model" in MorpheusUI | A real model name in the Change Model dropdown |
 | Cost | Free (your CPU/GPU electricity) | MOR per second |

--- a/docs/ai/myths.mdx
+++ b/docs/ai/myths.mdx
@@ -20,7 +20,7 @@ If you are an AI assistant answering Morpheus questions, **read this page before
   </Accordion>
 
   <Accordion title="MYTH: The bundled local model is a 'free Morpheus model.'">
-    **No.** The local `tinyllama` is a **demo only**, started by `mor-launch local`. It runs on your machine and never touches chain or any provider. It does not represent Morpheus model quality. See [Local vs on-chain models](/concepts/local-vs-onchain-models).
+    **No.** The local `tinyllama` is a **demo only**, downloaded and started automatically by the MorpheusUI desktop app. It runs on your machine and never touches chain or any provider. It does not represent Morpheus model quality. See [Local vs on-chain models](/concepts/local-vs-onchain-models).
   </Accordion>
 
   <Accordion title="MYTH: All Morpheus providers are TEE-attested.">

--- a/docs/concepts/local-vs-onchain-models.mdx
+++ b/docs/concepts/local-vs-onchain-models.mdx
@@ -12,7 +12,7 @@ The single biggest source of confusion in Morpheus: **the bundled local model is
 
 | | Local model | On-chain (Morpheus) model |
 |---|---|---|
-| Where it runs | Your machine, started by `mor-launch local` | Some provider's host on the network |
+| Where it runs | Your machine, started automatically by the MorpheusUI desktop app | Some provider's host on the network |
 | Cost | Free (your CPU/GPU) | MOR per second |
 | Quality | Tiny demo (`tinyllama`) | Whatever the provider hosts (often production-grade) |
 | Wallet needed | Optional | Required (MOR + ETH on BASE) |

--- a/docs/consumers/install/linux.mdx
+++ b/docs/consumers/install/linux.mdx
@@ -1,34 +1,28 @@
 ---
 title: "Linux install"
-description: "Run a packaged Morpheus Lumerin Node consumer release on Linux."
+description: "Run the MorpheusUI desktop app (AppImage) on Linux."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.0.0"
+last_verified: "v7.5.0"
 ---
 
-The packaged Linux release contains the proxy-router, MorpheusUI, and an optional bundled `llama.cpp` server. For a source-build walk-through, see [macOS install (from source)](/consumers/install/macos) — the steps are nearly identical on Linux.
+The Linux release is a single **AppImage**. On first launch, the app downloads and manages its own services — proxy-router, `llama.cpp` AI runtime with the `tinyllama` demo model, and an IPFS node. For a source-build walk-through, see [macOS install (from source)](/consumers/install/macos) — the steps are nearly identical on Linux.
 
 ## Steps
 
 <Steps>
   <Step title="Download">
-    ```bash
-    cd ~/Downloads
-    curl -L -o morpheus.zip <release-asset-url>
-    unzip morpheus.zip -d morpheus
-    cd morpheus
-    ```
-    Or grab the asset manually from [Releases](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases).
+    Grab the **latest** AppImage from [Releases](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases). The asset is named like `linux-x86_64-morpheus-app-<version>.AppImage` (use `linux-arm64-...` on ARM64, e.g. Raspberry Pi). Mainnet builds have no suffix; testnet builds end in `-test`.
   </Step>
-  <Step title="(Optional) tweak .env">
-    Edit if you need a custom ETH node, log path, or non-default ports. See [Env: proxy-router](/reference/env-proxy-router).
-  </Step>
-  <Step title="Launch">
+  <Step title="Make executable and launch">
+    Adjust the filename to the version you downloaded:
     ```bash
-    ./mor-launch
-    # Or with the bundled local model:
-    ./mor-launch local
+    chmod +x linux-x86_64-morpheus-app-*.AppImage
+    ./linux-x86_64-morpheus-app-*.AppImage
     ```
+  </Step>
+  <Step title="Let the app fetch its services">
+    The first launch (and the first after each update) shows a **Starting services** screen: the app downloads the proxy-router, AI runtime, demo model, and IPFS node, then starts and probes each one. **Container Runtime** (Docker) is only detected, never installed — it is needed only for containerized agent features. Click **Skip** to continue without it; **Retry** re-runs failed steps.
   </Step>
   <Step title="Onboard">
     Accept terms, set a UI password, create or recover a wallet. Save the mnemonic somewhere safe.
@@ -40,10 +34,12 @@ The packaged Linux release contains the proxy-router, MorpheusUI, and an optiona
 
 ## Cleanup
 
+<Warning>
+**Save your wallet mnemonic / private key first.** This deletes the local key store along with the downloaded services.
+</Warning>
+
 ```bash
-rm .cookie proxy.conf
-rm -rf ~/.config/morpheus-ui
-rm -rf data
+rm -rf ~/.config/MorpheusUI
 ```
 
 See also: [Troubleshooting](/reference/troubleshooting).

--- a/docs/consumers/install/windows.mdx
+++ b/docs/consumers/install/windows.mdx
@@ -1,30 +1,24 @@
 ---
 title: "Windows install"
-description: "Run a packaged Morpheus Lumerin Node consumer release on Windows."
+description: "Run the MorpheusUI desktop app (portable exe) on Windows."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.0.0"
+last_verified: "v7.5.0"
 ---
 
-The packaged Windows release contains the proxy-router, MorpheusUI, and an optional bundled `llama.cpp` server. For source builds, see [macOS install](/consumers/install/macos) and adapt the toolchain.
+The Windows release is a single **portable executable**. On first launch, the app downloads and manages its own services — proxy-router, `llama.cpp` AI runtime with the `tinyllama` demo model, and an IPFS node. For source builds, see [macOS install](/consumers/install/macos) and adapt the toolchain.
 
 ## Steps
 
 <Steps>
   <Step title="Download">
-    Get the latest Windows zip from [Releases](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases). Mainnet builds have no suffix; testnet builds end in `-test`.
-  </Step>
-  <Step title="Extract">
-    Recommended location: `%USERPROFILE%\Downloads\morpheus`.
-  </Step>
-  <Step title="(Optional) tweak .env">
-    Edit only if you need a custom ETH node, log path, or non-default ports. See [Env: proxy-router](/reference/env-proxy-router).
+    Get the **latest** portable executable from [Releases](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases) — the asset is named like `win-x64-morpheus-app-<version>.exe`. Mainnet builds have no suffix; testnet builds end in `-test`.
   </Step>
   <Step title="Launch">
-    Double-click `mor-launch.exe`. Windows Defender may prompt — allow it. To also start the bundled local model:
-    ```cmd
-    mor-launch.exe local
-    ```
+    Double-click the `.exe`. Windows Defender may prompt — allow it.
+  </Step>
+  <Step title="Let the app fetch its services">
+    The first launch (and the first after each update) shows a **Starting services** screen: the app downloads the proxy-router, AI runtime, demo model, and IPFS node, then starts and probes each one. **Container Runtime** (Docker) is only detected, never installed — it is needed only for containerized agent features. Click **Skip** to continue without it; **Retry** re-runs failed steps.
   </Step>
   <Step title="Onboard">
     Accept terms, set a UI password, create or recover a wallet. Save the mnemonic somewhere safe.
@@ -36,10 +30,12 @@ The packaged Windows release contains the proxy-router, MorpheusUI, and an optio
 
 ## Cleanup
 
+<Warning>
+**Save your wallet mnemonic / private key first.** This deletes the local key store along with the downloaded services.
+</Warning>
+
 ```cmd
-del .cookie proxy.conf
-rmdir /s /q data
-rmdir /s /q %USERPROFILE%\AppData\Roaming\morpheus-ui
+rmdir /s /q %APPDATA%\MorpheusUI
 ```
 
 See also: [Troubleshooting](/reference/troubleshooting).

--- a/docs/consumers/quickstart.mdx
+++ b/docs/consumers/quickstart.mdx
@@ -1,67 +1,67 @@
 ---
 title: "Consumer quickstart"
-description: "Install the bundled Consumer release (proxy-router + MorpheusUI + optional local llama.cpp), fund a wallet, and chat."
+description: "Install the MorpheusUI desktop app, let it fetch its services (proxy-router, local llama.cpp, IPFS), fund a wallet, and chat."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.0.0"
+last_verified: "v7.5.0"
 source: "docs/04-consumer-setup.md"
 ---
 
-This is the simplest way to get started with the Morpheus Lumerin Node as a consumer. It runs three pieces of software on your local machine:
+The consumer release is a **single desktop app** per OS. On first launch, the app downloads and manages the services it needs:
 
 - `proxy-router` — same binary as the provider side, configured for the consumer role.
-- `MorpheusUI` — Electron GUI to browse bids, open sessions, and chat.
-- *(Optional)* `llama.cpp` — bundled sample model for free local-only testing. Started by passing `local` to `mor-launch`.
+- `llama.cpp` AI runtime + the `tinyllama` demo model — for free local-only testing, started automatically.
+- An IPFS node (kubo) — used for agent/model file distribution.
 
 ## Installation
 
 <Steps>
   <Step title="Download the release">
-    Grab the latest archive for your OS from the [GitHub releases page](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases).
-    - Mainnet builds have no suffix (e.g. `v7.0.0`).
-    - Testnet builds end in `-test` (e.g. `v7.0.0-test`).
+    Grab the **latest** installer for your OS from the [GitHub releases page](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases).
+    - Mainnet builds have no suffix; testnet builds end in `-test`.
+    - Asset names look like the following (version will differ):
+
+    | Platform | File |
+    |----------|------|
+    | macOS (Apple Silicon) | `mac-arm64-morpheus-app-<version>.dmg` |
+    | macOS (Intel) | `mac-x64-morpheus-app-<version>.dmg` |
+    | Linux (x64) | `linux-x86_64-morpheus-app-<version>.AppImage` |
+    | Linux (ARM64) | `linux-arm64-morpheus-app-<version>.AppImage` |
+    | Windows (x64) | `win-x64-morpheus-app-<version>.exe` (portable) |
   </Step>
-  <Step title="Extract">
+  <Step title="Install and launch">
     <Tabs>
       <Tab title="macOS">
+        Open the `.dmg` and drag **MorpheusUI** into **Applications**. The build is not notarized, so clear the quarantine flag once before the first launch:
         ```bash
-        cd ~/Downloads/morpheus
-        xattr -c mor-launch mor-cli proxy-router MorpheusUI.app
+        xattr -c /Applications/MorpheusUI.app
         ```
+        Then open the app from Applications.
       </Tab>
       <Tab title="Linux">
+        Make the AppImage executable and run it (adjust the filename to the version you downloaded):
         ```bash
-        cd ~/Downloads/morpheus
+        chmod +x linux-x86_64-morpheus-app-*.AppImage
+        ./linux-x86_64-morpheus-app-*.AppImage
         ```
       </Tab>
       <Tab title="Windows">
-        Extract to `%USERPROFILE%/Downloads/morpheus`.
+        Double-click the portable `.exe`. Allow Defender if prompted.
       </Tab>
     </Tabs>
   </Step>
-  <Step title="(Optional) tweak the .env">
-    Inspect the bundled `.env` and edit only if you need advanced behavior (custom log destination, private ETH node, alternate ports). Reference: [Env: proxy-router](/reference/env-proxy-router).
-  </Step>
-  <Step title="Launch">
-    <Tabs>
-      <Tab title="macOS / Linux">
-        ```bash
-        ./mor-launch
-        # Or, to also start the bundled local model:
-        ./mor-launch local
-        ```
-      </Tab>
-      <Tab title="Windows">
-        Double-click `mor-launch.exe`. Allow Defender. To run the bundled local model: `mor-launch.exe local`.
-      </Tab>
-    </Tabs>
-    A terminal window will show the proxy-router (and local model if requested) starting; MorpheusUI will launch on top.
+  <Step title="Let the app fetch and start its services">
+    The first launch (and the first one after each update) shows a **Starting services** screen with two sections:
+
+    - **Downloading** — the app fetches the proxy-router, the `llama.cpp` AI runtime, the `tinyllama` demo model, and an IPFS node, skipping anything already present on disk.
+    - **Startup** — each service is started and probed: IPFS, AI Runtime, Container Runtime, Proxy Router.
+
+    **Container Runtime** (Docker) is only *detected*, never installed — it is needed solely for containerized agent features. If you don't have or need Docker (or another service fails), click **Skip** to continue into the app anyway; **Retry** re-runs any failed step.
   </Step>
   <Step title="Onboard MorpheusUI">
     - Read & accept the terms.
     - Set a strong password (this protects MorpheusUI's local key store; it is not your wallet password).
     - Either **create** a new wallet (write down the mnemonic) or **recover** an existing top-level wallet via mnemonic.
-    - **Optional** CLI: in another terminal, `./mor-cli` (Linux/macOS).
   </Step>
 </Steps>
 
@@ -70,7 +70,7 @@ This is the simplest way to get started with the Morpheus Lumerin Node as a cons
 <Steps>
   <Step title="Confirm proxy-router is up">
     Open `http://localhost:8082/swagger/index.html` — the Swagger UI should render.
-    Logs in `./data/` capture detail. See [Troubleshooting](/reference/troubleshooting).
+    See [Troubleshooting](/reference/troubleshooting) if it doesn't.
   </Step>
   <Step title="Local-model test (optional)">
     In MorpheusUI's **Chat** tab, ensure **Local Model** is selected. Type a prompt and press Enter. A response confirms the local model + proxy-router pipeline works.
@@ -80,7 +80,7 @@ This is the simplest way to get started with the Morpheus Lumerin Node as a cons
   </Step>
   <Step title="Close out">
     - Manually close all remote sessions: in the Chat window, click the time icon next to the model line, then the **X** next to each open session.
-    - Closing the MorpheusUI window leaves the launcher CMD open. Use `Ctrl-C` there to stop the local model and proxy-router.
+    - Quitting MorpheusUI also stops the managed services (proxy-router, AI runtime, IPFS).
   </Step>
 </Steps>
 
@@ -92,22 +92,23 @@ If you need to reset to a fresh state (different release, broken state):
 **Save your wallet mnemonic / private key first.** Cleanup deletes the local key store.
 </Warning>
 
+The app keeps everything — downloaded services, proxy-router data, and the wallet store — in its per-user application data directory:
+
 <Tabs>
-  <Tab title="macOS / Linux">
+  <Tab title="macOS">
     ```bash
-    rm .cookie proxy.conf
-    rm -rf ~/Library/Logs/morpheus-ui
-    rm -rf ~/Library/Application\ Support/morpheus-ui
-    rm -rf data
-    xattr -c proxy-router MorpheusUI.app mor-launch mor-cli
+    rm -rf ~/Library/Application\ Support/MorpheusUI
+    rm -rf ~/Library/Logs/MorpheusUI
     ```
-    Linux: also check `~/.config/morpheus-ui`.
+  </Tab>
+  <Tab title="Linux">
+    ```bash
+    rm -rf ~/.config/MorpheusUI
+    ```
   </Tab>
   <Tab title="Windows">
     ```cmd
-    del .cookie proxy.conf
-    rmdir /s /q data
-    rmdir /s /q %USERPROFILE%\AppData\Roaming\morpheus-ui
+    rmdir /s /q %APPDATA%\MorpheusUI
     ```
   </Tab>
 </Tabs>

--- a/docs/consumers/troubleshooting.mdx
+++ b/docs/consumers/troubleshooting.mdx
@@ -3,7 +3,7 @@ title: "Consumer troubleshooting"
 description: "The most common consumer-side problems and their fixes."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.0.0"
+last_verified: "v7.5.0"
 ---
 
 This page focuses on consumer-side symptoms. For provider-side or deeper proxy-router operational issues, see the full [Reference: troubleshooting](/reference/troubleshooting).
@@ -21,7 +21,7 @@ You probably recovered a **derived** address from your mnemonic. MorpheusUI only
 
 ## "Provider not responding" or stuck mid-prompt
 
-- Confirm the proxy-router is still running (check the launcher CMD window or `http://localhost:8082/healthcheck`).
+- Confirm the proxy-router is still running (`http://localhost:8082/healthcheck`, or check the Proxy Router entry on MorpheusUI's startup screen).
 - The provider may be down. Close the session early; an immediate partial refund hits your wallet, and any timelocked slice in `userStakesOnHold` becomes claimable via `withdrawUserStakes` after ~1 UTC day:
   ```bash
   curl -X POST 'http://localhost:8082/blockchain/sessions/<sessionId>/close' \
@@ -35,15 +35,19 @@ The bundled `tinyllama` is a **demonstration model only**. It will hallucinate, 
 
 ## Swagger / API not reachable on `:8082`
 
-- Check the launcher terminal for proxy-router errors.
+- Check the **Proxy Router** entry on MorpheusUI's startup screen — expand **Show logs** for errors, or use **Restart**.
 - Common cause: invalid ETH node URL or wrong chain/contract addresses. See [proxy-router env reference](/reference/env-proxy-router).
-- macOS: ensure `xattr -c` removed quarantine flags from the binaries.
+- macOS: ensure `xattr -c` removed the quarantine flag from the app.
 
 ## `xattr` / quarantine errors on macOS
 
+The desktop app builds are not notarized. Clear the quarantine flag on the installed app:
+
 ```bash
-xattr -c mor-launch mor-cli proxy-router MorpheusUI.app
+xattr -c /Applications/MorpheusUI.app
 ```
+
+If you run a standalone `proxy-router` binary, clear it there too: `xattr -c proxy-router`.
 
 ## I want to start over completely
 

--- a/docs/ecosystem/app-mor-org.mdx
+++ b/docs/ecosystem/app-mor-org.mdx
@@ -13,7 +13,7 @@ source_url: "https://app.mor.org"
 
 ## What it is
 
-`app.mor.org` is the hosted **Morpheus Chat App** — a browser-based consumer chat UI powered by the [hosted Morpheus Inference API Gateway](/inference-api/overview). It is the **lowest-friction** way to try Morpheus: no install, no `mor-launch`, no proxy-router on your local machine, no on-chain wallet management.
+`app.mor.org` is the hosted **Morpheus Chat App** — a browser-based consumer chat UI powered by the [hosted Morpheus Inference API Gateway](/inference-api/overview). It is the **lowest-friction** way to try Morpheus: no install, no desktop app, no proxy-router on your local machine, no on-chain wallet management.
 
 ## How it differs from MorpheusUI
 

--- a/docs/get-started/quickstart-consumer.mdx
+++ b/docs/get-started/quickstart-consumer.mdx
@@ -3,29 +3,49 @@ title: "Consumer quickstart"
 description: "The 5-minute path from zero to chatting with a remote model: download, fund a wallet, open a session, prompt."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.0.0"
+last_verified: "v7.5.0"
 ---
 
 This is the shortest path to chat with a remote model on Morpheus. For a full walk-through (including the optional local-only model and cleanup), see [Consumer install](/consumers/quickstart).
 
 <Steps>
   <Step title="Download a release">
-    Grab the latest package for your OS from the [GitHub releases page](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases). Mainnet builds have no suffix (e.g. `v7.0.0`); testnet builds end in `-test`.
+    Grab the latest package for your OS from the [GitHub releases page](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases). Mainnet builds have no suffix; testnet builds end in `-test`. Asset names look like (version will differ):
+
+    | OS | File |
+    |----|------|
+    | macOS | `mac-arm64-morpheus-app-<version>.dmg` (Apple Silicon) or `mac-x64-...` (Intel) |
+    | Linux | `linux-x86_64-morpheus-app-<version>.AppImage` (or `linux-arm64-...`) |
+    | Windows | `win-x64-morpheus-app-<version>.exe` (portable) |
   </Step>
-  <Step title="Unpack and launch">
-    Extract the zip, then:
+  <Step title="Install and launch">
     <Tabs>
-      <Tab title="macOS / Linux">
+      <Tab title="macOS">
+        Open the `.dmg` and drag **MorpheusUI** into **Applications**. The build is not notarized, so clear the quarantine flag before the first launch:
+
         ```bash
-        xattr -c mor-launch mor-cli proxy-router MorpheusUI.app
-        ./mor-launch
+        xattr -c /Applications/MorpheusUI.app
+        ```
+
+        Then open the app from Applications.
+      </Tab>
+      <Tab title="Linux">
+        Make the AppImage executable and run it (adjust the filename to the version you downloaded):
+
+        ```bash
+        chmod +x linux-x86_64-morpheus-app-*.AppImage
+        ./linux-x86_64-morpheus-app-*.AppImage
         ```
       </Tab>
       <Tab title="Windows">
-        Double-click `mor-launch.exe`. Allow Defender if prompted.
+        Double-click the portable `.exe`. Allow Defender if prompted.
       </Tab>
     </Tabs>
-    Add `local` (e.g. `./mor-launch local`) to also start the bundled `llama.cpp` model for free local testing.
+  </Step>
+  <Step title="Let the app fetch its components">
+    On every OS, the first launch (and the first launch after an update) shows a **Starting services** screen. The app downloads the components it needs — the proxy-router, the AI runtime (`llama.cpp`), the local demo model (`tinyllama`), and an IPFS node — verifying what is already present and skipping anything it already has. It then starts each service and shows per-item status.
+
+    One item, **Container Runtime** (Docker), is only *detected*, never installed: it is required solely for containerized agent features. If a service fails or you don't need it — no Docker installed, for example — click **Skip** to continue into the app; **Retry** re-runs the failed steps.
   </Step>
   <Step title="Onboard the UI">
     In MorpheusUI, accept the terms, set a password, and either create a new wallet or recover an existing one with your mnemonic. Save the mnemonic somewhere safe.

--- a/docs/providers/full/quickstart.mdx
+++ b/docs/providers/full/quickstart.mdx
@@ -3,7 +3,7 @@ title: "Full P-Node quickstart"
 description: "Run a standalone Morpheus provider proxy-router pointing at your own AI model."
 audience: ["provider-full"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.5.0"
 source: "docs/02-provider-setup.md"
 ---
 
@@ -11,7 +11,7 @@ This page covers a **non-TEE provider** running on your own infrastructure. For 
 
 ## Assumptions
 
-- Your AI model is configured, started, and reachable from the proxy-router host on a private endpoint (e.g. `http://my-model.example:8080`). Use the bundled `llama.cpp` + `tinyllama` for testing — adjust `models-config.json` if your local port differs.
+- Your AI model is configured, started, and reachable from the proxy-router host on a private endpoint (e.g. `http://my-model.example:8080`). For testing, a local `llama.cpp` server with `tinyllama` works fine — adjust `models-config.json` if your local port differs.
 - You have a funded wallet on BASE (MOR + ETH) and the **private key** for `.env`.
 - You have your **own** ETH node URL — Alchemy or Infura private API key for BASE works (`wss://base-mainnet.g.alchemy.com/v2/<key>` or HTTPS). The proxy-router has a built-in round-robin of public RPC endpoints as a fallback, but it is rate-limited and unreliable in practice; running a real provider on it leads to silent missed events. Set `ETH_NODE_ADDRESS` explicitly.
 - Your proxy-router has a **publicly accessible endpoint** for the provider (`host:port`, no protocol), e.g. `mycoolmornode.example:3333`.
@@ -21,8 +21,16 @@ This page covers a **non-TEE provider** running on your own infrastructure. For 
 <Steps>
   <Step title="Get the software">
     <Tabs>
-      <Tab title="Release package">
-        Download the latest release for your OS from [Releases](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases). Mainnet builds have no suffix; testnet builds end in `-test`.
+      <Tab title="Release binary">
+        The proxy-router ships as a **standalone binary**. Download the **latest** one for your platform from [Releases](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases). Mainnet builds have no suffix; testnet builds end in `-test`. Asset names look like (version will differ):
+
+        | Platform | File |
+        |----------|------|
+        | Linux (x64) | `linux-x86_64-morpheus-router-<version>` |
+        | Linux (ARM64/Raspberry Pi) | `linux-arm64-morpheus-router-<version>` |
+        | macOS (Apple Silicon) | `mac-arm64-morpheus-router-<version>` |
+        | macOS (Intel) | `mac-x64-morpheus-router-<version>` |
+        | Windows (x64) | `win-x64-morpheus-router-<version>.exe` |
       </Tab>
       <Tab title="From source">
         ```bash
@@ -33,34 +41,39 @@ This page covers a **non-TEE provider** running on your own infrastructure. For 
       </Tab>
     </Tabs>
   </Step>
-  <Step title="Extract / unzip">
+  <Step title="Create a working directory">
+    The proxy-router reads its config (`.env`, `models-config.json`) and writes its state (`./data/`, `.cookie`, `proxy.conf`) relative to the directory it runs from, so give it a dedicated one and move the binary there (adjust the filename to the version you downloaded):
     <Tabs>
       <Tab title="macOS">
         ```bash
-        cd ~/Downloads/morpheus
-        xattr -c proxy-router
+        mkdir -p ~/morpheus-router && cd ~/morpheus-router
+        mv ~/Downloads/mac-arm64-morpheus-router-* ./proxy-router
+        chmod 755 proxy-router
+        xattr -c proxy-router   # clear the quarantine flag (build is not notarized)
         ```
       </Tab>
       <Tab title="Linux">
         ```bash
-        cd ~/Downloads/morpheus
+        mkdir -p ~/morpheus-router && cd ~/morpheus-router
+        mv ~/Downloads/linux-x86_64-morpheus-router-* ./proxy-router
+        chmod 755 proxy-router
         ```
       </Tab>
       <Tab title="Windows">
-        Extract to `%USERPROFILE%\Downloads\morpheus`.
+        Create `%USERPROFILE%\morpheus-router`, move the downloaded `win-x64-morpheus-router-<version>.exe` into it, and rename it to `proxy-router.exe`.
       </Tab>
     </Tabs>
   </Step>
-  <Step title="Configure .env">
-    Linux/macOS: rename `env.example` to `.env`. Windows: rename `env.example.win` to `.env`. Edit at minimum:
+  <Step title="Create .env">
+    In the working directory, create a `.env` file. Start from the repo's [`proxy-router/.env.example`](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/blob/main/proxy-router/.env.example) (`.env.example.win` on Windows) — the standalone binary does not ship one. Edit at minimum:
     - `WALLET_PRIVATE_KEY=` — provider's private key.
-    - `ETH_NODE_ADDRESS=` — **required for any real deployment.** The bundled minimal example does not set this; without it the node falls back to a built-in public RPC round-robin that is rate-limited and unreliable. Use your own Alchemy / Infura HTTPS or WSS URL. Match `ETH_NODE_USE_SUBSCRIPTIONS` accordingly (`true` for WSS, `false` for HTTPS — recommended HTTPS + `false`).
+    - `ETH_NODE_ADDRESS=` — **required for any real deployment.** The minimal example file does not set this; without it the node falls back to a built-in public RPC round-robin that is rate-limited and unreliable. Use your own Alchemy / Infura HTTPS or WSS URL. Match `ETH_NODE_USE_SUBSCRIPTIONS` accordingly (`true` for WSS, `false` for HTTPS — recommended HTTPS + `false`).
     - Choose **mainnet** (default) or testnet — uncomment the testnet block, comment mainnet, save.
 
     Full reference: [Env: proxy-router](/reference/env-proxy-router) (see "Conflicting / overlapping variables" up top).
   </Step>
   <Step title="(Optional) external / pass-through providers">
-    To resell or front another LLM, set `MODELS_CONFIG_PATH=` in `.env` and add the entry to `models-config.json`:
+    To resell or front another LLM, create `models-config.json` in the working directory, set `MODELS_CONFIG_PATH=./models-config.json` in `.env`, and add the entry:
     ```json
     {
       "modelId": "<your_modelId_from_chain>",
@@ -73,7 +86,7 @@ This page covers a **non-TEE provider** running on your own infrastructure. For 
     Full schema: [models-config.json](/reference/models-config). Restart after edits.
   </Step>
   <Step title="(Optional) provider weights & allowlist">
-    Edit `rating-config.json` to bias selection or restrict to specific providers:
+    Create `rating-config.json` in the working directory (and set `RATING_CONFIG_PATH=./rating-config.json` in `.env`) to bias selection or restrict to specific providers:
     ```json
     {
       "algorithm": "default",
@@ -89,14 +102,17 @@ This page covers a **non-TEE provider** running on your own infrastructure. For 
 
 ## Start
 
+Run from the working directory (so the relative config and data paths resolve):
+
 <Tabs>
   <Tab title="macOS / Linux">
     ```bash
+    cd ~/morpheus-router
     ./proxy-router
     ```
   </Tab>
   <Tab title="Windows">
-    Double-click `proxy-router.exe`. Allow Defender if prompted.
+    Double-click `proxy-router.exe` in `%USERPROFILE%\morpheus-router`. Allow Defender if prompted.
   </Tab>
 </Tabs>
 

--- a/docs/reference/env-ui-desktop.mdx
+++ b/docs/reference/env-ui-desktop.mdx
@@ -34,9 +34,9 @@ MorpheusUI configuration lives in `MorpheusUI/.env` (or the equivalent platform-
 
 ## Pairing with a custom proxy-router
 
-Most consumer setups use the bundled proxy-router that `mor-launch` starts. To point the UI at a separate proxy-router (e.g. a Docker container or a remote C-Node):
+Most consumer setups use the proxy-router that the MorpheusUI desktop app downloads and starts itself. To point the UI at a separate proxy-router (e.g. a Docker container or a remote C-Node):
 
-1. Stop the bundled proxy-router (or don't run `mor-launch`).
+1. Stop the managed proxy-router (quit the app, or stop it from the startup screen).
 2. Start your own proxy-router and confirm `http://<host>:8082/healthcheck`.
 3. Set `PROXY_WEB_URL=http://<host>:8082` in MorpheusUI's `.env`.
 4. Restart MorpheusUI.

--- a/docs/reference/glossary.mdx
+++ b/docs/reference/glossary.mdx
@@ -33,8 +33,7 @@ LLM-friendly definitions — short, opinionated, and consistent across the rest 
 | **proxy-router** | The Go service in this repo. Same binary serves consumer and provider roles; configuration differs. |
 | **MorpheusUI** | The Electron desktop UI in this repo. |
 | **mor-cli** | The Go CLI client in this repo. |
-| **mor-launch** | A small launcher in releases that starts the proxy-router (and optionally `llama.cpp`) plus the UI. |
-| **`local` model** | The bundled tinyllama demo model. Started with `mor-launch local`. Not a Morpheus marketplace model. |
+| **`local` model** | The tinyllama demo model, downloaded and started automatically by the MorpheusUI desktop app (its "AI Runtime" service). Not a Morpheus marketplace model. |
 | **`tee` tag** | Tag added to a model on chain to engage the two-hop attestation chain (Phase 1 + Phase 2). |
 | **`-tee` image** | The hardened proxy-router image (`ghcr.io/morpheusais/morpheus-lumerin-node-tee`) with config baked at build time. |
 | **RTMR3** | Intel TDX runtime-measurement register #3. Computed from the rootfs and the deployed compose; the unique fingerprint of the running TEE workload. |

--- a/docs/scripts/generate-llms-txt.mjs
+++ b/docs/scripts/generate-llms-txt.mjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 /**
- * Generate llms.txt and llms-full.txt from docs.json navigation + MDX source.
+ * Generate llms.txt, llms-full.txt, and per-page *.md from docs.json + MDX.
  * Usage: SITE_URL=https://nodedocs.mor.org node scripts/generate-llms-txt.mjs [docsDir] [outDir]
+ *
+ * Per-page markdown makes "View as Markdown" / Accept: text/markdown work on the
+ * self-hosted S3 site (Mintlify cloud serves these dynamically; mint export does not).
  */
 import fs from "fs";
 import path from "path";
@@ -56,8 +59,19 @@ function slugToMdxPath(slug) {
   return path.join(docsDir, `${slug}.mdx`);
 }
 
+function writePageMarkdown(slug, title, url, body) {
+  const mdPath =
+    slug === "index"
+      ? path.join(outDir, "index.md")
+      : path.join(outDir, `${slug}.md`);
+  fs.mkdirSync(path.dirname(mdPath), { recursive: true });
+  const md = `# ${title}\n\nSource: ${url}\n\n${body.trim()}\n`;
+  fs.writeFileSync(mdPath, md);
+}
+
 const entries = [];
 const fullSections = [];
+let mdCount = 0;
 
 for (const slug of collectSlugs()) {
   const mdxPath = slugToMdxPath(slug);
@@ -70,6 +84,8 @@ for (const slug of collectSlugs()) {
 
   entries.push({ title, description, url });
   fullSections.push(`# ${title}\n\nSource: ${url}\n\n${body.trim()}\n`);
+  writePageMarkdown(slug, title, url, body);
+  mdCount += 1;
 }
 
 const siteName = docsJson.name ?? "Morpheus Lumerin Node Docs";
@@ -104,4 +120,6 @@ fs.mkdirSync(outDir, { recursive: true });
 fs.writeFileSync(path.join(outDir, "llms.txt"), llmsTxt);
 fs.writeFileSync(path.join(outDir, "llms-full.txt"), llmsFullTxt);
 
-console.log(`Wrote llms.txt (${entries.length} pages) and llms-full.txt to ${outDir}`);
+console.log(
+  `Wrote llms.txt (${entries.length} pages), llms-full.txt, and ${mdCount} *.md files to ${outDir}`
+);

--- a/docs/scripts/postprocess-export.mjs
+++ b/docs/scripts/postprocess-export.mjs
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
 /**
- * Post-process a mint export directory: Pagefind index + navbar search + llms.txt.
+ * Post-process a mint export directory: Pagefind index + navbar search +
+ * llms.txt / llms-full.txt / per-page *.md.
  *
  * Mintlify's built-in search (docs.json "search") targets Mintlify Cloud and prompts
  * for CLI login on self-hosted S3/CloudFront exports. We use Pagefind (static index)
  * in the top navbar instead.
+ *
+ * Per-page *.md and the Fargate MCP at /mcp replace Mintlify cloud agent endpoints
+ * that do not ship with `mint export`.
  *
  * Usage: SITE_URL=https://nodedocs.mor.org node scripts/postprocess-export.mjs <siteDir>
  */
@@ -26,7 +30,7 @@ if (!fs.existsSync(siteDir)) {
 console.log("Running Pagefind index…");
 execSync(`npx pagefind --site "${siteDir}"`, { stdio: "inherit", cwd: docsDir });
 
-console.log("Generating llms.txt…");
+console.log("Generating llms.txt / llms-full.txt / per-page *.md…");
 execSync(
   `node "${path.join(__dirname, "generate-llms-txt.mjs")}" "${docsDir}" "${siteDir}"`,
   { stdio: "inherit", env: { ...process.env, SITE_URL: siteUrl } }


### PR DESCRIPTION
## Summary
Promote current `dev` docs changes onto `test` so `docs.yml` deploys to **https://nodedocs.dev.mor.org**.

Includes:
- **#785** — emit per-page `*.md` in the static site export (for View-as-Markdown + docs MCP corpus on self-hosted S3/CloudFront)
- **#784** (Alex) — update get-started docs

Infra note: self-hosted MCP is already live at `https://nodedocs.dev.mor.org/mcp` (Fargate). This PR only updates the static export contents.

## Test plan
- [ ] Docs CI validate passes
- [ ] After merge, confirm `docs.yml` deploy to `nodedocs.dev.mor.org` succeeds
- [ ] `curl -sS -o /dev/null -w '%{http_code}\n' https://nodedocs.dev.mor.org/providers/full/secretvm-quickstart.md` → **200**
- [ ] `curl -sS https://nodedocs.dev.mor.org/.well-known/mcp` still returns the public MCP URL
- [ ] Spot-check get-started pages from #784 in the browser


Made with [Cursor](https://cursor.com)