### PR TITLE
docs(providers): prefer active.mor.org lookup + MyProvider

### DIFF
--- a/docs/concepts/tee-overview.mdx
+++ b/docs/concepts/tee-overview.mdx
@@ -53,7 +53,7 @@ Phase 2 runs **entirely inside the provider's P-Node**. For each `tee`-tagged mo
     Use a v6.0.0+ proxy-router. When you open a session against a `tee`-tagged model, attestation runs automatically.
   </Card>
   <Card title="As a provider" icon="server" href="/providers/full/secretvm-quickstart">
-    Deploy the `-tee` image on SecretVM, register your model with the `tee` tag.
+    Deploy the `-tee` image on SecretVM, then register via MyProvider — bid on an existing `tee` model when possible, or mint with the `tee` tag.
   </Card>
   <Card title="Reference (deep)" icon="book" href="/providers/full/tee-reference">
     Cosign verification, RTMR3 recomputation, attestation manifest fields.

--- a/docs/ecosystem/active-status.mdx
+++ b/docs/ecosystem/active-status.mdx
@@ -3,27 +3,41 @@ title: "active.mor.org (live status)"
 description: "Mirror summary of active.mor.org — live status, active models, and active bids on the Morpheus marketplace."
 audience: ["consumer", "prosumer", "provider-full", "provider-resale", "developer"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.5.0"
 source_url: "https://active.mor.org"
 ---
 
 <Note>
-**Mirrored summary.** Live numbers (counts, prices, latencies) live at [active.mor.org](https://active.mor.org). This page describes the **semantics** of those numbers and how to interpret them.
+**Mirrored summary.** Live numbers (counts, prices, latencies) live at [active.mor.org](https://active.mor.org). This page describes the **semantics** of those numbers and how to interpret them. Providers: start here **before** minting a new model — see [Register on chain → Step 0](/providers/full/register-onchain#step-0--look-up-models-before-you-mint).
 </Note>
 
 ## What's there
 
 | Endpoint | What it shows | Useful for |
 |----------|---------------|-----------|
-| [active.mor.org/status](https://active.mor.org/status) | Overall network status | Spotting outages, monitoring uptime |
-| [active.mor.org/active_models](https://active.mor.org/active_models) | Models that have active bids and at least one healthy provider | Choosing what to consume; evaluating competition as a provider |
-| [active.mor.org/active_bids](https://active.mor.org/active_bids) | Currently posted bids across all models | Pricing decisions; reseller competitive analysis |
+| [active.mor.org/status](https://active.mor.org/status) | Human status UI (uptime, min prices, model detail) | Spotting outages; picking a model to join |
+| [active_models.json](https://active.mor.org/active_models.json) | Routable models (healthy/degraded bids) | Choosing what to consume; **finding an existing `Id` to bid on** |
+| [active_bids.json](https://active.mor.org/active_bids.json) | Currently posted bids across all models | Pricing decisions; competitive analysis |
+| [all_models.json](https://active.mor.org/all_models.json) | All non-deleted on-chain models | Lookup when a model has no live healthy provider yet |
+| [status/api.json](https://active.mor.org/status/api.json) | Machine-readable status summary | Monitoring / agents |
+
+HTML list views also exist at `/active_models` and `/active_bids` on the same host.
+
+## Provider tip: join, don't duplicate
+
+The marketplace does not stop two people from registering the same display name as separate models. That creates clutter. If you intend to serve a model that already appears in `active_models.json`, **register as a provider and bid on that model's `Id`** (via [MyProvider](/providers/full/myprovider-gui) or the API). Mint a new model only for genuinely new weights or a required new `tee` listing.
+
+```bash
+curl -sS https://active.mor.org/active_models.json \
+  | jq '.models[] | select(.Name | test("glm-5"; "i")) | {Name, Id, Tags, health}'
+```
 
 ## How to read it
 
-- **A model "active" here means `(at least one bid posted) AND (provider healthcheck passes)`.** A model on chain that has no healthy provider won't show up here even if its `Diamond` record exists.
-- **`pricePerSecond`** values are denominated in MOR. To compare across models with different token economies, multiply by tokens-per-second to get an apples-to-apples cost.
-- **Latency / throughput** numbers are aggregated; a single hot provider can pull averages dramatically up or down.
+- **A model "active" here means `(at least one bid posted) AND (provider healthcheck passes)`.** A model on chain that has no healthy provider won't show up in `active_models.json` even if its Diamond record exists — check `all_models.json` in that case.
+- Snapshot fields use PascalCase (`Id`, `Name`, `ModelName`, `PricePerSecond`, `Provider`, …).
+- **`pricePerSecond`** values are MOR wei per second. Many UIs also show `priceMorPerHour`.
+- Snapshots refresh on a short cron (on the order of minutes); a brand-new bid may take a few minutes to appear.
 
 ## When to cite this page
 
@@ -31,6 +45,8 @@ For an LLM answering "what models are available?" or "what's the going rate?" �
 
 ## Related canonical pages on this site
 
+- [Register on chain](/providers/full/register-onchain)
+- [MyProvider GUI](/providers/full/myprovider-gui)
 - [Architecture](/concepts/architecture)
 - [Pricing a resale bid](/providers/resale/registering-bid)
 - [Buy a bid](/consumers/buy-bid)
@@ -39,3 +55,4 @@ For an LLM answering "what models are available?" or "what's the going rate?" �
 ## Source
 
 - [https://active.mor.org](https://active.mor.org)
+- [https://active.mor.org/status](https://active.mor.org/status)

--- a/docs/ecosystem/myprovider.mdx
+++ b/docs/ecosystem/myprovider.mdx
@@ -1,48 +1,61 @@
 ---
 title: "MyProvider"
-description: "Mirror summary of myprovider.mor.org — hosted operator GUI for managing Morpheus provider nodes."
+description: "Mirror summary of myprovider.mor.org — hosted operator GUI for Morpheus providers (Basic Auth to your proxy-router)."
 audience: ["provider-full", "provider-resale"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.5.0"
 source_url: "https://myprovider.mor.org"
 ---
 
 <Note>
-**Mirrored summary** of [myprovider.mor.org](https://myprovider.mor.org). For current screens and feature behavior, defer to the live site.
+**Mirrored summary** of [myprovider.mor.org](https://myprovider.mor.org). For screens and the latest behavior, defer to the live site and the canonical [MyProvider GUI](/providers/full/myprovider-gui) page on this docs site.
 </Note>
 
 ## What it is
 
-A hosted operator dashboard for Morpheus providers. Lets you manage providers, models, bids, and sessions through a GUI rather than scripting against the proxy-router HTTP API.
+A hosted operator dashboard for Morpheus providers. It connects to **your** proxy-router with HTTP Basic Auth (same credentials as Swagger) and helps you register the provider, bid on models, and sync `models-config` — without scripting every call by hand.
+
+It does **not** replace funding a wallet or running a node: you still create a provider wallet, load MOR + ETH, and run proxy-router (or SecretVM). MyProvider is the graphical control plane for that node.
+
+## Preferred use
+
+1. Look up existing models / prices on [active.mor.org/status](https://active.mor.org/status).
+2. Connect MyProvider to your node and register as a provider.
+3. **Bid on an existing model** when one matches what you serve — avoid minting duplicate marketplace entries.
+4. Sync `models-config` so the on-chain `modelId` points at your backend.
+
+Full steps: [Register on chain](/providers/full/register-onchain) and [MyProvider GUI](/providers/full/myprovider-gui).
 
 ## What it gives you
 
-- **Provider dashboard** — register / update your provider record, view stake, status, and earnings.
-- **Model management** — register, tag (including `tee`), and update models.
-- **Bid management** — post, edit, and retire bids.
-- **Session monitoring** — see active and historical sessions, pending claims, and earnings.
-- **Health pings** — quick visibility into whether your `:3333` and `/healthcheck` are reachable.
+- Provider register / update and `:3333` reachability check
+- Bid on existing models; create model + bid only when needed
+- Model configuration sync (`MODELS_CONFIG_CONTENT` / `models-config.json`)
+- Optional `.env` bootstrap before connect
 
-## How it relates to this site
+Not included today: session/earnings dashboards, built-in active.mor.org search, or browser-wallet connect.
 
-- Conceptually it does the same thing as [Register on chain](/providers/full/register-onchain) and [API endpoints](/reference/api-endpoints).
-- Authenticates against your provider's wallet — connect a wallet that owns the provider record on chain.
-- Read the privacy and TOS on the site directly before connecting any wallet you care about.
+## Auth and HTTPS
+
+- Auth = node Basic Auth, **not** MetaMask.
+- Hosted [myprovider.mor.org](https://myprovider.mor.org) requires an **HTTPS** proxy-router URL (SecretVM fits naturally). HTTP-only nodes: desktop app or local `npm run dev`.
 
 ## When to use MyProvider vs the API
 
 | Task | Best surface |
 |------|--------------|
-| First-time provider registration | MyProvider GUI or Swagger |
+| First-time provider registration | **MyProvider** (or Swagger) |
+| Join existing model (bid only) | **MyProvider** Available Models |
 | Update bids in bulk | API/script |
 | TEE attestation inspection | [SecretVM portal](https://secretai.scrtlabs.com/attestation) + cosign |
-| Day-to-day operator monitoring | MyProvider GUI |
 | Programmatic automation | API ([endpoints reference](/reference/api-endpoints)) |
 
 ## Related canonical pages on this site
 
 - [MyProvider GUI](/providers/full/myprovider-gui)
 - [Register on chain](/providers/full/register-onchain)
+- [SecretVM quickstart](/providers/full/secretvm-quickstart)
+- [active.mor.org](/ecosystem/active-status)
 - [Headless operation](/providers/full/headless)
 - [API endpoints](/reference/api-endpoints)
 

--- a/docs/get-started/introduction.mdx
+++ b/docs/get-started/introduction.mdx
@@ -56,7 +56,7 @@ flowchart LR
     Install the desktop release, fund a wallet, open a session, chat.
   </Card>
   <Card title="Provider quickstart" icon="server" href="/providers/full/quickstart">
-    Stand up a proxy-router, register a model, post a bid.
+    Stand up a proxy-router, look up existing models on active.mor.org, bid (mint only if needed).
   </Card>
   <Card title="TEE provider fast lane" icon="shield-check" href="/providers/full/secretvm-quickstart">
     Deploy a hardened `-tee` image on SecretVM in minutes.

--- a/docs/get-started/quickstart-provider.mdx
+++ b/docs/get-started/quickstart-provider.mdx
@@ -3,7 +3,7 @@ title: "Provider quickstart"
 description: "The 10-minute path from zero to a registered Morpheus provider with a live bid."
 audience: ["provider-full", "provider-resale"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.5.0"
 ---
 
 This page is the high-level checklist. For the full setup, branch into one of:
@@ -32,20 +32,23 @@ This page is the high-level checklist. For the full setup, branch into one of:
   <Step title="Have a backend model">
     OpenAI-compatible endpoint reachable from your proxy-router host (e.g. `http://my-model:8080/v1/chat/completions`).
   </Step>
+  <Step title="Look up what already exists">
+    Before minting a new marketplace model, check [active.mor.org/status](https://active.mor.org/status) (or `active_models.json` / `active_bids.json`) for the model name you intend to serve and competing prices. Prefer **bidding on an existing `modelId`**. See [Register on chain → Step 0](/providers/full/register-onchain#step-0--look-up-models-before-you-mint).
+  </Step>
   <Step title="Have a funded wallet">
-    BASE wallet with at least `~0.6` MOR (provider stake `+` model stake `+` bid fee) plus a little ETH for gas. See [Networks and tokens](/get-started/networks-and-tokens).
+    BASE wallet with enough MOR for provider stake + bid fee (and model stake only if you must mint a new model), plus a little ETH for gas. See [Networks and tokens](/get-started/networks-and-tokens).
   </Step>
   <Step title="Have a publicly reachable endpoint">
-    The proxy-router needs to be reachable on `host:3333` from the internet so consumers can connect. The Swagger/admin UI on `:8082` should **not** be public — see [API auth](/reference/api-auth).
+    The proxy-router needs to be reachable on `host:3333` from the internet so consumers can connect. The Swagger/admin UI on `:8082` should **not** be public — see [API auth](/reference/api-auth). SecretVM exposes HTTPS admin on `:443`, which pairs well with [MyProvider](https://myprovider.mor.org).
   </Step>
   <Step title="Run the proxy-router">
-    Configure `.env`, `models-config.json`, `rating-config.json` and start the binary. See [Provider quickstart](/providers/full/quickstart).
+    Configure `.env`, `models-config.json`, `rating-config.json` and start the binary — or follow [SecretVM quickstart](/providers/full/secretvm-quickstart). See [Provider quickstart](/providers/full/quickstart).
   </Step>
-  <Step title="Register on chain">
-    Approve the Diamond contract, register your provider, register your model (with the `tee` tag if you're TEE-enabled), and post a bid. See [Register on chain](/providers/full/register-onchain). Be aware: every `postModelBid` charges a non-refundable `0.3 MOR` `marketplaceBidFee`; finish your local setup before posting your first bid to avoid paying the fee multiple times — see [Pricing](/providers/full/pricing) and [Quickstart → What can cost you MOR](/providers/full/quickstart#what-can-cost-you-mor-during-setup).
+  <Step title="Register on chain (prefer MyProvider)">
+    Use [MyProvider](/providers/full/myprovider-gui) when you can (HTTPS node / SecretVM): register the provider, then **bid on an existing model**. Mint a new model only when nothing suitable exists (or you need a new `tee`-tagged listing). Swagger/API steps: [Register on chain](/providers/full/register-onchain). Every `postModelBid` charges a non-refundable `0.3 MOR` fee — finish local config before your first bid; see [Pricing](/providers/full/pricing).
   </Step>
   <Step title="Verify end-to-end">
-    Don't trust startup logs alone — run the five-step self-check in [Verify your provider setup](/providers/full/verify-setup): healthcheck, public TCP, on-chain records, `active.mor.org` discovery, and a real prompt via the hosted Inference API. This is exactly the procedure Discord support runs when a new provider asks "can you check if my setup is OK?".
+    Don't trust startup logs alone — run the five-step self-check in [Verify your provider setup](/providers/full/verify-setup): healthcheck, public TCP, on-chain records, `active.mor.org` discovery, and a real prompt via the hosted Inference API.
   </Step>
 </Steps>
 

--- a/docs/providers/full/aws.mdx
+++ b/docs/providers/full/aws.mdx
@@ -145,7 +145,7 @@ flowchart LR
 
 ## Part 3 — Register on chain
 
-Now register your provider, model, and bid following [Register on chain](/providers/full/register-onchain). The provider `endpoint` you set there must be reachable from the public internet on `:3333` — i.e. `<proxy-router-public-dns>:3333`.
+Now register your provider and bid following [Register on chain](/providers/full/register-onchain) — look up an existing model on [active.mor.org](https://active.mor.org/status) first; use [MyProvider](/providers/full/myprovider-gui) if you terminate TLS in front of `:8082`. The provider `endpoint` you set must be reachable from the public internet on `:3333` — i.e. `<proxy-router-public-dns>:3333`.
 
 ## Operational notes
 

--- a/docs/providers/full/headless.mdx
+++ b/docs/providers/full/headless.mdx
@@ -8,6 +8,8 @@ last_verified: "v7.0.0"
 
 A "headless" provider is the proxy-router binary running as a long-lived service — no MorpheusUI, no human at a keyboard. This is the typical production deployment.
 
+For day-to-day registration and bidding against that headless node, prefer [MyProvider](/providers/full/myprovider-gui) (HTTPS admin URL or desktop/local app) over hand-editing Swagger — especially after you have looked up existing models on [active.mor.org](https://active.mor.org/status).
+
 ## Topology
 
 ```mermaid

--- a/docs/providers/full/myprovider-gui.mdx
+++ b/docs/providers/full/myprovider-gui.mdx
@@ -1,41 +1,79 @@
 ---
 title: "MyProvider GUI"
-description: "Use myprovider.mor.org's hosted operator dashboard to manage a Morpheus provider node."
+description: "Use myprovider.mor.org to register as a provider, bid on existing models, and sync models-config — the preferred operator UI for most providers."
 audience: ["provider-full", "provider-resale"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.5.0"
 source_url: "https://myprovider.mor.org"
 ---
 
-[MyProvider](https://myprovider.mor.org) is a hosted operator GUI maintained by the Morpheus ecosystem. It lets you manage providers, models, bids, and sessions without scripting against the API directly.
+[MyProvider](https://myprovider.mor.org) is the hosted operator GUI for Morpheus providers. It talks to **your** proxy-router over HTTP Basic Auth (same credentials as Swagger) and wraps the blockchain admin calls you would otherwise run by hand.
+
+Use it as the default path for first-time registration and day-to-day bid/config work — especially on [SecretVM](/providers/full/secretvm-quickstart), where the node already exposes HTTPS on port 443.
 
 <Note>
-This page is a **mirror summary** of public information about MyProvider, last verified for v7.0.0. For canonical, current behavior, always defer to [myprovider.mor.org](https://myprovider.mor.org).
+This page describes current MyProvider behavior as of the last verification. The app will keep evolving (including better active.mor.org model lookup); when in doubt, defer to [myprovider.mor.org](https://myprovider.mor.org) and the [register-onchain](/providers/full/register-onchain) contract flow.
 </Note>
 
-## What it gives you
+## Recommended first-time flow
 
-- **Provider dashboard** — register/update your provider record, view stake, status, and earnings.
-- **Model management** — register, tag (including `tee`), and update models.
-- **Bid management** — post, edit, and retire bids.
-- **Session monitoring** — see active and historical sessions, pending claims, and earnings.
-- **Health pings** — quick visibility into whether your `:3333` and `/healthcheck` are reachable.
+1. **Look up** the model you intend to serve on [active.mor.org/status](https://active.mor.org/status) (or `active_models.json` / `active_bids.json`) — copy the existing `Id` and note competing prices. See [Register on chain → Step 0](/providers/full/register-onchain#step-0--look-up-models-before-you-mint).
+2. **Fund** a dedicated provider wallet with MOR + ETH on Base; put the private key in the node's `.env` / SecretVM secrets (MyProvider does **not** hold or connect that wallet in the browser).
+3. **Run** the proxy-router (or SecretVM) until `/healthcheck` is healthy and `:3333` is public.
+4. **Open** [myprovider.mor.org](https://myprovider.mor.org), connect with node URL + Basic Auth, register the provider, then **bid on the existing model** (Available Models → Add Bid).
+5. **Sync** `models-config` via Model Configuration Sync so your backend `apiUrl` matches the on-chain `modelId` you bid on.
+6. **Verify** with [Verify your provider setup](/providers/full/verify-setup).
 
-## When to use it vs the Swagger / API
+Mint a **new** model only when nothing suitable exists (new weights, or a required `tee` tag with no existing tee-tagged listing).
 
-| Task | Best surface |
-|------|--------------|
-| First-time provider registration | MyProvider GUI or Swagger |
-| Update bids in bulk | API/script |
-| TEE attestation inspection | [SecretVM portal](https://secretai.scrtlabs.com/attestation) + cosign |
-| Day-to-day operator monitoring | MyProvider GUI |
-| Programmatic automation | API ([endpoints reference](/reference/api-endpoints)) |
+## What it gives you today
+
+| Feature | Supported |
+|---------|-----------|
+| Connect to proxy-router API (Basic Auth) | Yes |
+| Register / update / delete provider | Yes |
+| `:3333` endpoint reachability check | Yes |
+| Bid on existing on-chain models ("Available Models") | Yes — **prefer this** |
+| Create model + bid (single flow) | Yes — auto-generates `modelId` / `ipfsCID`; use only for genuinely new models |
+| Delete bids; replace bid price | Yes |
+| Model config sync (`/v1/models` vs bids) + `MODELS_CONFIG_CONTENT` | Yes |
+| Bootstrap `.env` generator | Yes (before connect) |
+| Session monitoring / earnings dashboard | **No** |
+| Built-in `active.mor.org` model lookup | **No** — use the status site / JSON (or curl) first |
+| IPFS upload (`POST /ipfs/add`) | **No** |
 
 ## Authentication
 
-MyProvider authenticates against your provider's wallet — connect a wallet that owns the provider record on chain. Read the privacy and TOS on the site directly before connecting any wallet you care about.
+MyProvider does **not** connect MetaMask or any browser wallet. It authenticates to your proxy-router:
+
+1. Enter the proxy-router base URL (`https://your-node:8082` or SecretVM `https://your-vm/`).
+2. Enter the admin username/password from `.cookie` / `COOKIE_CONTENT`.
+3. The app reads the provider wallet from the node (`GET /wallet`) — that key must already be configured on the node.
+
+## HTTPS requirement
+
+The hosted app at [myprovider.mor.org](https://myprovider.mor.org) can only call **HTTPS** proxy-router APIs (browser mixed-content rules).
+
+| Your node | How to use MyProvider |
+|-----------|------------------------|
+| SecretVM (Traefik TLS on `:443`) | Point MyProvider at `https://<your-secretvm-url>/` |
+| Other HTTPS reverse proxy / ALB | Point at that HTTPS admin URL |
+| HTTP-only `:8082` | Use the [desktop release](https://github.com/MorpheusAIs/Morpheus-MyProvider/releases) or run `npm run dev` locally and connect to `http://…:8082` |
+
+## When to use it vs Swagger / API
+
+| Task | Best surface |
+|------|--------------|
+| First-time provider + bid (esp. SecretVM) | **MyProvider** |
+| Join an existing marketplace model | MyProvider → Available Models, or API `POST /blockchain/bids` |
+| Mint a genuinely new model | MyProvider Create Model & Bid, or Swagger |
+| Bulk / scripted bid updates | API ([endpoints reference](/reference/api-endpoints)) |
+| TEE attestation inspection | [SecretVM portal](https://secretai.scrtlabs.com/attestation) + cosign |
+| Programmatic automation | API |
 
 ## Related
 
-- [Register on chain](/providers/full/register-onchain) — the underlying contract calls MyProvider wraps.
-- [API endpoints](/reference/api-endpoints) — direct API equivalents.
+- [Register on chain](/providers/full/register-onchain) — discover → bid (canonical steps)
+- [SecretVM quickstart](/providers/full/secretvm-quickstart) — MyProvider-first TEE path
+- [active.mor.org](/ecosystem/active-status) — live models and prices
+- [API endpoints](/reference/api-endpoints) — direct equivalents

--- a/docs/providers/full/pricing.mdx
+++ b/docs/providers/full/pricing.mdx
@@ -3,7 +3,7 @@ title: "Pricing your bid"
 description: "How to set pricePerSecond for a Morpheus provider bid: there is no marketplace 'helper' or order book — you estimate cost, set a competitive rate, and adjust."
 audience: ["provider-full", "provider-resale"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.5.0"
 ---
 
 There is **no built-in pricing helper, no order book, and no "always use market price" toggle** for provider bids today. You set `pricePerSecond` (in **wei/sec** of MOR) when you call `postModelBid`, and you adjust it by replacing the bid. This page is the explicit how-to for that workflow.
@@ -30,7 +30,7 @@ Filter by your model (or one similar in size and capability):
 
 ```bash
 curl -sS https://active.mor.org/active_bids.json \
-  | jq '[.[] | select(.modelName == "your-model-name")] | sort_by(.pricePerSecond)'
+  | jq '[.bids[] | select(.ModelName | test("your-model-name"; "i"))] | sort_by(.PricePerSecond | tonumber)'
 ```
 
 Look at the distribution. **Median competitor pricing** is a sane starting point.

--- a/docs/providers/full/quickstart.mdx
+++ b/docs/providers/full/quickstart.mdx
@@ -129,7 +129,13 @@ Run from the working directory (so the relative config and data paths resolve):
 
 ## Next: register on chain
 
-Once running, register your provider, your model (with the `tee` tag if you've TEE-hardened), and your bid. See [Register on chain](/providers/full/register-onchain), then run the [self-checks in Verify your provider setup](/providers/full/verify-setup) before declaring victory.
+Once running:
+
+1. Look up existing models on [active.mor.org/status](https://active.mor.org/status) — prefer bidding on an existing `modelId`.
+2. Register via [MyProvider](/providers/full/myprovider-gui) if your admin API is reachable over HTTPS (or use the desktop/local app for HTTP `:8082`); otherwise use Swagger. Full steps: [Register on chain](/providers/full/register-onchain).
+3. Run the [self-checks in Verify your provider setup](/providers/full/verify-setup) before declaring victory.
+
+Mint a new model only when nothing suitable exists (or you need a new `tee`-tagged listing).
 
 ## What can cost you MOR during setup
 

--- a/docs/providers/full/register-onchain.mdx
+++ b/docs/providers/full/register-onchain.mdx
@@ -1,13 +1,17 @@
 ---
 title: "Register on chain (provider, model, bid)"
-description: "Approve the Diamond contract, register your provider, register your model (with optional tee tag), and post a bid."
+description: "Look up existing models on active.mor.org, register as a provider, bid on a known modelId when possible, and only mint a new model when nothing suitable exists."
 audience: ["provider-full", "provider-resale"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.5.0"
 source: "docs/03-provider-offer.md"
 ---
 
-After your proxy-router is running, register your provider, model, and bid on the BASE Diamond contract. All steps go through your local Swagger UI at `http://localhost:8082/swagger/index.html`.
+After your proxy-router is running, register on the BASE Diamond contract. **Prefer looking up an existing model and posting a bid on it** — minting a new model for every provider floods the marketplace with duplicate names.
+
+<Note>
+**Preferred operator UI:** [MyProvider](https://myprovider.mor.org) ([guide](/providers/full/myprovider-gui)) — especially on SecretVM, where the node already serves HTTPS. Swagger at `http://localhost:8082/swagger/index.html` (or `https://<your-node>/swagger/`) remains the API fallback.
+</Note>
 
 ## Contract minimums
 
@@ -24,44 +28,86 @@ After your proxy-router is running, register your provider, model, and bid on th
 |------|---------|
 | Provider wallet | `0x9E26Fea97F7d644BAf62d0e20e4d4b8F836C166c` |
 | Public endpoint | `server.example.com:3333` |
-| Random `modelId` (32-byte hex) | `0xe1e6e3e77148d140065ef2cd4fba7f4ae59c90e1639184b6df5c84` |
-| `ipfsCID` (32-byte hex) | `0xc2d3a5e4f9b7c1a2c8f0b1d5e6c78492fa7bcd34e9a3b9c9e18f25d3be47a1f6` |
-| Model name | `CapybaraHermes-v2.5-Mistral-7b` |
-| Bid `pricePerSecond` | `10000000000` (`0.00000001` MOR) |
+| Existing or new on-chain `modelId` | From [active.mor.org](https://active.mor.org/status) — see below |
+| Bid `pricePerSecond` | Check competitors first; floor is `10000000000` |
+
+## Step 0 — Look up models before you mint
+
+Browse [active.mor.org/status](https://active.mor.org/status) or pull the JSON snapshots:
+
+| URL | Use |
+|-----|-----|
+| [active_models.json](https://active.mor.org/active_models.json) | Routable models (healthy/degraded bids) — start here |
+| [active_bids.json](https://active.mor.org/active_bids.json) | Competing `pricePerSecond` for a model name |
+| [all_models.json](https://active.mor.org/all_models.json) | All non-deleted on-chain models (including ones with no live healthy provider) |
+| [status](https://active.mor.org/status) | Human UI + uptime / min price views |
+
+```bash
+# Find a model by name (field names are PascalCase in the JSON)
+curl -sS https://active.mor.org/active_models.json \
+  | jq '.models[] | select(.Name | test("llama-3.3"; "i")) | {Name, Id, IpfsCID, Tags, Owner, health}'
+
+# Competing bids for that name
+curl -sS https://active.mor.org/active_bids.json \
+  | jq '[.bids[] | select(.ModelName | test("llama-3.3"; "i"))] | sort_by(.PricePerSecond | tonumber) | .[:5] | .[] | {ModelName, Provider, PricePerSecond, Id}'
+```
+
+**Decision rule:**
+
+| Situation | What to do |
+|-----------|------------|
+| Same logical model already listed (same weights / name you intend to serve) | **Do not create a model.** Register as a provider, then **bid on that existing `Id`**. Put that `Id` in `models-config.json`. |
+| You need a `tee` tag and no suitable `tee`-tagged model exists | Register a **new** model with tag `tee`, then bid. |
+| Genuinely new weights, fine-tune, or metadata | Register a **new** model (new `ipfsCID` / name), then bid. |
+
+Any registered provider can bid on any active model — you do **not** need to own the model record. Creating another model with the same display name still adds a separate marketplace entry and is what produces the duplicate clutter on [active.mor.org](https://active.mor.org).
 
 ## Steps
 
-<Steps>
-  <Step title="Authorize the Diamond contract">
-    `POST /blockchain/approve` — set `spender = <DiamondContract>` and `amount` ≥ `0.6` MOR (in wei: `600000000000000000`) to cover provider stake + model stake + bid fee.
-  </Step>
-  <Step title="Register your provider">
-    `POST /blockchain/providers` — set `addStake` (≥ `0.2` MOR; `10000` MOR for a subnet provider) and `endpoint` (your **publicly accessible** `host:port`, no protocol).
-  </Step>
-  <Step title="Add your model to IPFS">
-    `POST /ipfs/add` — capture the returned `Hash` (this is your `ipfsCID`). Then `POST /ipfs/pin` with the same hash to keep it pinned.
-  </Step>
-  <Step title="Create the model on chain">
-    `POST /blockchain/models` with:
-    - `modelId`: random 32-byte hex (becomes the on-chain id paired with your providerId).
-    - `ipfsCID`: from the previous step.
-    - `Fee`: model fee.
-    - `addStake`: `0.1` MOR minimum.
-    - `Owner`: your provider wallet.
-    - `name`: human-readable model name.
-    - `tags`: array of strings.
-      - **TEE providers must include `"tee"` (case-insensitive)** to opt the model into the two-hop attestation chain.
-      - Other common tags: `llm`, `embedding`, `stt`, `tts`.
-
-    Capture the `modelID` from the JSON response — this combines your requested modelId with your providerId and is required for `models-config.json` and bids.
-  </Step>
-  <Step title="Update models-config.json">
-    Add the new on-chain `modelID` (the combined value) to your `models-config.json` and restart the proxy-router. See [models-config.json](/reference/models-config).
-  </Step>
-  <Step title="Post a bid">
-    `POST /blockchain/bids` with `modelID` and `pricePerSecond` (≥ `10000000000`). Capture the returned `bidID`.
-  </Step>
-</Steps>
+<Tabs>
+  <Tab title="MyProvider (recommended)">
+    <Steps>
+      <Step title="Connect">
+        Open [myprovider.mor.org](https://myprovider.mor.org). Enter your proxy-router base URL and Basic Auth credentials from `.cookie` / `COOKIE_CONTENT` (not a browser wallet). Hosted MyProvider requires **HTTPS** to the node — SecretVM Traefik on `:443` fits; for plain HTTP use the [desktop app or local `npm run dev`](/providers/full/myprovider-gui#https-requirement).
+      </Step>
+      <Step title="Register your provider">
+        **Provider** tab → verify `:3333` reachability → create/update provider with your public `host:3333` endpoint and at least `0.2` MOR stake (`10000` MOR for a subnet provider). Approve the Diamond spend if prompted.
+      </Step>
+      <Step title="Bid on an existing model (preferred)">
+        **Models & Bids** → find the model under **Available Models** (or look up `Id` on active.mor.org first) → **Add Bid**. Set `pricePerSecond` from the competitor check in Step 0. Capture the returned bid id.
+      </Step>
+      <Step title="Only if no suitable model exists — create model + bid">
+        Use **Create Model & Bid** only for a genuinely new offering (or a required `tee` tag with no existing tee model). Include tag `tee` when applicable. Today the GUI auto-generates `modelId` / `ipfsCID` — that is fine for a true new model; it is **not** the path for joining an existing listing.
+      </Step>
+      <Step title="Sync models-config">
+        Use **Model Configuration Sync** to map the on-chain `modelId` to your backend `apiUrl`, copy `MODELS_CONFIG_CONTENT` / update `models-config.json`, and restart or redeploy the node so config matches the bid **before** you rely on live traffic. See [models-config.json](/reference/models-config).
+      </Step>
+    </Steps>
+  </Tab>
+  <Tab title="Swagger / API">
+    <Steps>
+      <Step title="Authorize the Diamond contract">
+        `POST /blockchain/approve` — set `spender = <DiamondContract>` and `amount` ≥ enough MOR for provider stake + (optional) model stake + bid fee. Bidding on an existing model needs provider stake + `0.3` MOR fee (≈ `0.5` MOR); minting a new model adds `0.1` MOR model stake (≈ `0.6` MOR total).
+      </Step>
+      <Step title="Register your provider">
+        `POST /blockchain/providers` — set `addStake` (≥ `0.2` MOR; `10000` MOR for a subnet provider) and `endpoint` (your **publicly accessible** `host:port`, no protocol).
+      </Step>
+      <Step title="Post a bid on an existing model (preferred)">
+        From Step 0, take the model's `Id`. `POST /blockchain/bids` with that `modelID` and `pricePerSecond` (≥ `10000000000`). Put the same `Id` in `models-config.json` and restart the proxy-router. Capture the returned `bidID`.
+      </Step>
+      <Step title="Only if needed — create a new model">
+        `POST /ipfs/add` (and `POST /ipfs/pin`) for a real CID when you have one, then `POST /blockchain/models` with:
+        - `modelId`: random 32-byte hex (base id; on-chain id becomes `keccak256(owner ‖ baseId)`).
+        - `ipfsCID`, `Fee`, `addStake` (`0.1` MOR min), `Owner`, `name`, `tags`.
+        - **TEE providers must include `"tee"`** (case-insensitive).
+        Capture the response `modelID` (combined id) for `models-config.json` and the bid.
+      </Step>
+      <Step title="Update models-config.json">
+        Map the on-chain `modelID` you bid on to your backend `apiUrl`. Restart the proxy-router. See [models-config.json](/reference/models-config).
+      </Step>
+    </Steps>
+  </Tab>
+</Tabs>
 
 ## TEE tag deeper context
 
@@ -72,38 +118,21 @@ Tagging the model `tee` engages two independent verifications on every session a
 
 A v6+ consumer benefits from Phase 2 automatically by trusting your attested v7+ P-Node — no client-side upgrade needed. Models without the `tee` tag are treated as standard providers; neither hop runs.
 
+If you **bid on someone else's model**, you inherit that model's tags. To offer TEE attestation to consumers, bid on an existing `tee`-tagged model or register your own with `"tee"`.
+
 See [TEE overview](/concepts/tee-overview) and [TEE reference](/providers/full/tee-reference).
 
 ## Where things show up afterward
 
 - Your provider on chain: `GET /blockchain/providers`
-- Your model on chain: `GET /blockchain/models`
+- Models on chain: `GET /blockchain/models`
 - Your bids on chain: `GET /blockchain/bids`
-- Live network listings: [active.mor.org](https://active.mor.org)
-- Operator dashboard: [myprovider.mor.org](/providers/full/myprovider-gui)
-
-## Choosing a `modelId` (community convention)
-
-The contract does **not enforce uniqueness** of model names. You can register a `modelId` with the same name and `ipfsCID` as an existing model — the marketplace will simply have multiple entries pointing at the same logical model. As a result, snapshots like [active.mor.org/active_models.json](https://active.mor.org/active_models.json) often show many entries for popular names with one provider each.
-
-Recommended practice:
-
-- **Reuse an existing `modelId`** when you're hosting the same logical model someone else has already registered. This keeps the marketplace clean, gives consumers a single dropdown entry with multiple providers (good for failover and competitive pricing), and avoids fragmenting reputation data.
-- **Mint a new `modelId`** only when your model is genuinely different (different weights, different fine-tune, different `ipfsCID`).
-
-This is convention, not enforcement. Practical workflow:
-
-```bash
-# Look up existing IDs for the model you intend to host
-curl -sS https://active.mor.org/active_models.json \
-  | jq '.[] | select(.modelName == "your-model-name") | {modelId, ipfsCID, providerAddress}'
-```
-
-If you see one already, use that `modelId` (the contract takes the same value as input — see how the on-chain `modelID` is `getModelId(modelOwner, requestedModelId)` in [`ModelRegistry.sol`](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/blob/main/smart-contracts/contracts/diamond/facets/ModelRegistry.sol); the resulting on-chain id will still be unique to your provider, but consumers can match on `modelName` + `ipfsCID`).
+- Live network listings: [active.mor.org](https://active.mor.org/status)
+- Operator dashboard: [MyProvider](/providers/full/myprovider-gui)
 
 ## Pausing or temporarily disabling a model offering
 
-To stop offering a model **without deregistering it** (so you keep the `modelId`, keep the model stake bonded, and can resume cheaply):
+To stop offering a model **without deregistering it** (so you keep any model stake bonded and can resume):
 
 ```bash
 # Find your active bid
@@ -117,7 +146,7 @@ curl -X POST -u 'admin:admin' \
 
 The model record stays on chain. To resume, post a new bid (which charges the `0.3 MOR` `marketplaceBidFee` again — see [pricing](/providers/full/pricing)).
 
-If you want to **completely remove** a model: delete all of its bids first, then call `modelDeregister` to recover the `0.1 MOR` model stake. The contract refuses `modelDeregister` while any bid for that model is still active.
+If you **own** a model and want to **completely remove** it: delete all of its bids first, then call `modelDeregister` to recover the `0.1 MOR` model stake. The contract refuses `modelDeregister` while any bid for that model is still active. If you only ever bid on someone else's model, deleting your bid is enough — you have no model stake to recover.
 
 ## How and when you get paid
 

--- a/docs/providers/full/secretvm-quickstart.mdx
+++ b/docs/providers/full/secretvm-quickstart.mdx
@@ -1,13 +1,15 @@
 ---
 title: "SecretVM TEE quickstart"
-description: "Shortest path to a v7 TEE provider: deploy the hardened -tee image on SecretVM and register a tee-tagged model."
+description: "Shortest path to a v7 TEE provider: deploy the hardened -tee image on SecretVM, then register and bid via MyProvider."
 audience: ["provider-full"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.5.0"
 source: "docs/02.4-proxy-router-secretvm-quickstart.md"
 ---
 
 This guide walks you through deploying a Morpheus TEE-hardened provider node on [SecretVM](https://secretai.scrtlabs.com) (SCRT Labs' confidential VM platform). By the end you'll have a provider running inside a hardware-secured Intel TDX enclave that consumers can cryptographically verify before sending prompts.
+
+Most of the operator work after deploy is **graphical**: [MyProvider](https://myprovider.mor.org) against your SecretVM HTTPS URL, plus looking up models on [active.mor.org/status](https://active.mor.org/status). Swagger remains a fallback.
 
 For deeper details (cosign verification, RTMR3 recomputation, attestation manifest inspection) see [TEE reference](/providers/full/tee-reference). For the trust-chain conceptual picture see [TEE overview](/concepts/tee-overview).
 
@@ -19,6 +21,25 @@ For deeper details (cosign verification, RTMR3 recomputation, attestation manife
 - Your **AI model backend** reachable via a private URL (e.g. `http://my-model:8080/v1/chat/completions`).
 - A **SecretVM account** at https://secretai.scrtlabs.com — sign up to get an API key.
 - *(Recommended)* `secretvm-cli`: `sudo npm install --global secretvm-cli`.
+- *(Recommended)* [MyProvider](https://myprovider.mor.org) for registration and bidding after the VM is healthy.
+
+## Step 0: Pick the model you will serve
+
+Before minting anything on chain, see what already exists and at what price:
+
+```bash
+curl -sS https://active.mor.org/active_models.json \
+  | jq '.models[] | select(.Name | test("your-model-name"; "i")) | {Name, Id, Tags, bidDetail}'
+
+curl -sS https://active.mor.org/active_bids.json \
+  | jq '[.bids[] | select(.ModelName | test("your-model-name"; "i"))] | sort_by(.PricePerSecond | tonumber) | .[:5]'
+```
+
+- If a matching model `Id` already exists **and** (for TEE) it carries a `tee` tag — plan to **bid on that `Id`** and put it in `MODELS_CONFIG_CONTENT` below.
+- If you need TEE and no suitable `tee`-tagged model exists — you will register a new model with tag `tee` after deploy (Step 5).
+- Or browse the human UI: [active.mor.org/status](https://active.mor.org/status).
+
+Full decision table: [Register on chain → Step 0](/providers/full/register-onchain#step-0--look-up-models-before-you-mint).
 
 ## Step 1: Get the Docker Compose file
 
@@ -45,6 +66,8 @@ COOKIE_CONTENT=admin:<your_secure_password>
 ```
 
 `MODELS_CONFIG_CONTENT` must be single-line JSON. Schema: [models-config.json](/reference/models-config).
+
+If Step 0 already gave you an existing on-chain `Id`, put that value in `modelId` now. If you will mint a new `tee` model after deploy, use a placeholder and replace it via MyProvider **Model Configuration Sync** (Step 5) before posting a bid you care about.
 
 ## Step 3: Deploy on SecretVM
 
@@ -107,20 +130,31 @@ curl -k https://<your-secretvm-url>:29343/cpu | head -c 100
 
 Returns a long hex string — your hardware-signed TDX attestation quote.
 
-## Step 5: Register as a TEE provider
+## Step 5: Register via MyProvider (recommended)
 
-Same flow as a standard provider, with one critical addition: **tag your model `tee`**.
+SecretVM already terminates TLS on port 443, so the hosted GUI at [myprovider.mor.org](https://myprovider.mor.org) can talk to your node without mixed-content issues.
 
 <Steps>
-  <Step title="Open Swagger">
-    `https://<your-secretvm-url>/swagger/index.html`
+  <Step title="Open MyProvider">
+    Go to [myprovider.mor.org](https://myprovider.mor.org). Connect with:
+    - **URL:** `https://<your-secretvm-url>/`
+    - **Username / password:** from `COOKIE_CONTENT` (e.g. `admin:yourpassword`)
   </Step>
-  <Step title="Approve, register, bid">
-    Follow [Register on chain](/providers/full/register-onchain). When creating the model, include the tag `"tee"` in the tags array.
+  <Step title="Register provider">
+    **Provider** tab → verify the public `:3333` endpoint → create provider (min `0.2` MOR stake). Approve Diamond spend if prompted.
+  </Step>
+  <Step title="Bid — prefer an existing model">
+    If Step 0 found a suitable model (including `tee` when you need TEE): **Models & Bids → Available Models → Add Bid** using that `Id`. Set price from the competitor check.
+  </Step>
+  <Step title="Only if needed — create a tee-tagged model">
+    If no suitable `tee` model exists, use **Create Model & Bid** and include tag `tee` (comma-separated tags field). The `tee` tag is what triggers consumer-side attestation; without it, consumers treat you as a standard provider.
+  </Step>
+  <Step title="Sync models-config">
+    Use **Model Configuration Sync** to generate updated `MODELS_CONFIG_CONTENT`, then update SecretVM encrypted secrets and redeploy/restart if the on-chain `modelId` changed from your Step 2 placeholder. Details: [MyProvider GUI](/providers/full/myprovider-gui).
   </Step>
 </Steps>
 
-The `tee` tag is what triggers consumer-side attestation verification. Without it, consumers treat you as a standard provider.
+Swagger fallback: `https://<your-secretvm-url>/swagger/index.html` — same contract calls as [Register on chain](/providers/full/register-onchain).
 
 ## Step 6: Verify your attestation
 
@@ -186,10 +220,13 @@ The VM reboots with the new image. Verify with `/healthcheck` and the attestatio
 
 | Resource | Link |
 |----------|------|
+| MyProvider (operator GUI) | [MyProvider GUI](/providers/full/myprovider-gui) |
+| Discover models / bid | [Register on chain](/providers/full/register-onchain) |
+| Live marketplace | [active.mor.org/status](https://active.mor.org/status) |
 | Full TEE reference | [tee-reference](/providers/full/tee-reference) |
 | Conceptual TEE overview | [TEE overview](/concepts/tee-overview) |
 | models-config.json | [reference](/reference/models-config) |
-| Provider/model/bid registration | [Register on chain](/providers/full/register-onchain) |
+| Verify end-to-end | [Verify setup](/providers/full/verify-setup) |
 | Standard Docker (non-TEE) | [proxy-router-docker](/providers/full/proxy-router-docker) |
 | SecretVM documentation | https://docs.scrt.network/secret-network-documentation/secretvm-confidential-virtual-machines |
 | SecretVM CLI | https://docs.scrt.network/secret-network-documentation/secretvm-confidential-virtual-machines/secretvm-cli |

--- a/docs/providers/full/tee-reference.mdx
+++ b/docs/providers/full/tee-reference.mdx
@@ -182,7 +182,7 @@ Expected:
 { "status": "healthy", "version": "<current-version>", "uptime": "1m30s" }
 ```
 
-Then proceed with [Register on chain](/providers/full/register-onchain) (with the `tee` model tag).
+Then proceed with [Register on chain](/providers/full/register-onchain) — prefer [MyProvider](/providers/full/myprovider-gui) on SecretVM; bid on an existing `tee` model when one exists, otherwise mint with the `tee` tag.
 
 ### Step 5: Verify attestation (SecretVM)
 

--- a/docs/providers/full/verify-setup.mdx
+++ b/docs/providers/full/verify-setup.mdx
@@ -6,7 +6,9 @@ product: ["proxy-router"]
 last_verified: "v7.0.0"
 ---
 
-After [registering](/providers/full/register-onchain) your provider, model, and bid, you want to know **before any consumer hits you** that everything works. There is no built-in setup wizard yet. This page walks the same five checks the support team uses to verify a provider when someone posts in Discord asking "can you check if my setup is OK?".
+After [registering](/providers/full/register-onchain) your provider and bid (and a new model only if you had to mint one), you want to know **before any consumer hits you** that everything works. There is no built-in setup wizard yet. This page walks the same five checks the support team uses to verify a provider when someone posts in Discord asking "can you check if my setup is OK?".
+
+If you used [MyProvider](/providers/full/myprovider-gui), confirm **Model Configuration Sync** already wrote the on-chain `modelId` into `models-config.json` / `MODELS_CONFIG_CONTENT` before Step 1.
 
 ## Step 1 — Local health
 
@@ -131,10 +133,19 @@ Two cron-driven dashboards aggregate the marketplace into JSON snapshots. Your p
 
 ```bash
 # Active models — populated when the verifier can reach your provider's :3333 and ping the model
-curl -sS https://active.mor.org/active_models.json | jq '.[] | select(.providerAddress=="0xYOUR_PROVIDER")'
+curl -sS https://active.mor.org/active_models.json \
+  | jq --arg p "0xYOUR_PROVIDER" '
+      .models[]
+      | select(any(.bidDetail[]?; .providerId | ascii_downcase == ($p | ascii_downcase)))
+      | {Name, Id, Tags, bidDetail}
+    '
 
 # Active bids — same, but for bids
-curl -sS https://active.mor.org/active_bids.json | jq '.[] | select(.providerAddress=="0xYOUR_PROVIDER")'
+curl -sS https://active.mor.org/active_bids.json \
+  | jq --arg p "0xYOUR_PROVIDER" '
+      .bids[]
+      | select(.Provider | ascii_downcase == ($p | ascii_downcase))
+    '
 ```
 
 If your bid is on chain (Step 3) but **not** in `active_bids.json`, it means the verifier could reach the chain but **could not reach your `:3333`**. Re-check Step 2.

--- a/docs/providers/resale/overview.mdx
+++ b/docs/providers/resale/overview.mdx
@@ -31,7 +31,7 @@ flowchart LR
 
 1. You run a normal proxy-router (containerized or bare-metal) — see [Container P-Node](/providers/resale/container-pnode).
 2. In your `models-config.json` you set `apiUrl` to the upstream's chat completions endpoint and `apiKey` to your upstream account key.
-3. You register your provider, model, and bid on chain — same as a standard full provider, just **without the `tee` tag**.
+3. You register your provider on chain, then **prefer bidding on an existing model** from [active.mor.org](https://active.mor.org/status) — same as a standard full provider, just **without the `tee` tag**. Mint a new model only when nothing suitable exists. [MyProvider](https://myprovider.mor.org) is the easiest UI for this.
 4. Consumer prompts arrive on `:3333`, get routed to your proxy-router on `:8082`, which forwards to the upstream `apiUrl`. Upstream responses stream back the same way.
 
 ## Things to watch for

--- a/docs/reference/glossary.mdx
+++ b/docs/reference/glossary.mdx
@@ -47,7 +47,7 @@ LLM-friendly definitions — short, opinionated, and consistent across the rest 
 | **`gitbook.mor.org`** | Broader Morpheus documentation hub. Supports an `?ask=<question>` query parameter that returns natural-language answers + sources — useful for AI agents. See [LLM cheatsheet](/ai/llm-prompt-cheatsheet#dynamic-querying-of-the-broader-morpheus-docs). |
 | **`active.mor.org`** | Live marketplace state — status, active models, active bids. |
 | **`tech.mor.org`** | Calculators, sessions, TEE, throughput explainers. |
-| **MyProvider** | Hosted operator GUI at https://myprovider.mor.org for provider management. |
+| **MyProvider** | Hosted operator GUI at https://myprovider.mor.org — Basic Auth to your proxy-router for provider/bid/config management (not a browser wallet). |
 | **NodeNeo** | Cross-platform consumer experience at https://nodeneo.io. |
 | **Everclaw** | Agent project at https://everclaw.xyz, with a Morpheus skill for OpenClaw. |
 | **`models-config.json`** | Local file mapping on-chain `modelId` → backend `apiUrl`. See [reference](/reference/models-config). |

--- a/docs/reference/models-config.mdx
+++ b/docs/reference/models-config.mdx
@@ -22,7 +22,7 @@ source: "docs/models-config.json.md"
 | `capacityPolicy` | optional | `idle_timeout` or `simple` |
 
 <Note>
-**`concurrentSlots` is per-model, not global.** The proxy-router will accept up to `sum(concurrentSlots)` across all configured models concurrently. There is no built-in global cap. If your hardware can serve only one of N models at a time, register all N models but **only post a bid for the one currently active**, and rotate the bid when you want to switch. See [Pausing or temporarily disabling a model offering](/providers/full/register-onchain#pausing-or-temporarily-disabling-a-model-offering).
+**`concurrentSlots` is per-model, not global.** The proxy-router will accept up to `sum(concurrentSlots)` across all configured models concurrently. There is no built-in global cap. If your hardware can serve only one of N models at a time, configure all N in `models-config.json` but **only post a bid for the one currently active**, and rotate the bid when you want to switch. Prefer bidding on existing marketplace `modelId`s rather than minting duplicates — see [Register on chain](/providers/full/register-onchain). See also [Pausing or temporarily disabling a model offering](/providers/full/register-onchain#pausing-or-temporarily-disabling-a-model-offering).
 </Note>
 | `parameters` | optional | Per-`apiType` extra parameters (e.g. SD `cfg_scale`, `steps`) |
 


### PR DESCRIPTION
## Summary
- Steer new providers to discover existing modelIds on [active.mor.org](https://active.mor.org/status) and **bid on them** instead of minting duplicate marketplace models.
- Prefer [MyProvider](https://myprovider.mor.org) (especially SecretVM HTTPS) for registration, bidding, and models-config sync; Swagger remains the fallback.
- Correct active.mor.org JSON field names in verify/pricing examples; rewrite MyProvider mirror pages to match actual Basic Auth behavior.

## Test plan
- [ ] Spot-check `register-onchain`, `secretvm-quickstart`, `myprovider-gui`, `quickstart-provider` on Mintlify preview / after deploy to nodedocs.dev
- [ ] Confirm jq examples against live `active_models.json` / `active_bids.json`
- [ ] Confirm MyProvider auth/HTTPS wording matches current app


Made with [Cursor](https://cursor.com)