### PR TITLE
docs: MyProvider onboarding + Venice Diem resale path

### DIFF
--- a/docs/ecosystem/myprovider.mdx
+++ b/docs/ecosystem/myprovider.mdx
@@ -1,6 +1,6 @@
 ---
 title: "MyProvider"
-description: "Mirror summary of myprovider.mor.org — hosted operator GUI for Morpheus providers (Basic Auth to your proxy-router)."
+description: "Mirror summary of myprovider.mor.org — onboarding wizard, active.mor.org lookup, SecretVM secrets, Venice Diem presets, and provider/bid management."
 audience: ["provider-full", "provider-resale"]
 product: ["proxy-router"]
 last_verified: "v7.5.0"
@@ -13,48 +13,43 @@ source_url: "https://myprovider.mor.org"
 
 ## What it is
 
-A hosted operator dashboard for Morpheus providers. It connects to **your** proxy-router with HTTP Basic Auth (same credentials as Swagger) and helps you register the provider, bid on models, and sync `models-config` — without scripting every call by hand.
+A hosted operator dashboard for Morpheus providers. It connects to **your** proxy-router with HTTP Basic Auth (same credentials as Swagger) and helps you:
 
-It does **not** replace funding a wallet or running a node: you still create a provider wallet, load MOR + ETH, and run proxy-router (or SecretVM). MyProvider is the graphical control plane for that node.
+1. Look up existing models on [active.mor.org](https://active.mor.org/status)
+2. Craft SecretVM / Docker / Venice secrets (including `MODELS_CONFIG_CONTENT`)
+3. Register the provider, bid on models, and sync `models-config`
+
+It does **not** replace funding a wallet or running a node — it is the graphical control plane for that node.
+
+## Paths
+
+| Path | Best for |
+|------|----------|
+| SecretVM TEE | Digest-pinned `-tee` image + 5 encrypted secrets + HTTPS MyProvider |
+| Venice Diem resale | Monetize Venice API access without hosting GPUs |
+| Standard / Docker | Your own LLM backend |
 
 ## Preferred use
 
 1. Look up existing models / prices on [active.mor.org/status](https://active.mor.org/status).
-2. Connect MyProvider to your node and register as a provider.
-3. **Bid on an existing model** when one matches what you serve — avoid minting duplicate marketplace entries.
-4. Sync `models-config` so the on-chain `modelId` points at your backend.
+2. Export secrets from MyProvider onboarding.
+3. Deploy the node; connect MyProvider with Basic Auth.
+4. **Bid on an existing model** when one matches what you serve.
+5. Re-export `MODELS_CONFIG_CONTENT` from Model Configuration Sync after bidding if needed.
 
 Full steps: [Register on chain](/providers/full/register-onchain) and [MyProvider GUI](/providers/full/myprovider-gui).
-
-## What it gives you
-
-- Provider register / update and `:3333` reachability check
-- Bid on existing models; create model + bid only when needed
-- Model configuration sync (`MODELS_CONFIG_CONTENT` / `models-config.json`)
-- Optional `.env` bootstrap before connect
-
-Not included today: session/earnings dashboards, built-in active.mor.org search, or browser-wallet connect.
 
 ## Auth and HTTPS
 
 - Auth = node Basic Auth, **not** MetaMask.
 - Hosted [myprovider.mor.org](https://myprovider.mor.org) requires an **HTTPS** proxy-router URL (SecretVM fits naturally). HTTP-only nodes: desktop app or local `npm run dev`.
 
-## When to use MyProvider vs the API
-
-| Task | Best surface |
-|------|--------------|
-| First-time provider registration | **MyProvider** (or Swagger) |
-| Join existing model (bid only) | **MyProvider** Available Models |
-| Update bids in bulk | API/script |
-| TEE attestation inspection | [SecretVM portal](https://secretai.scrtlabs.com/attestation) + cosign |
-| Programmatic automation | API ([endpoints reference](/reference/api-endpoints)) |
-
 ## Related canonical pages on this site
 
 - [MyProvider GUI](/providers/full/myprovider-gui)
 - [Register on chain](/providers/full/register-onchain)
 - [SecretVM quickstart](/providers/full/secretvm-quickstart)
+- [Reselling Venice (Diem)](/providers/resale/reselling-venice)
 - [active.mor.org](/ecosystem/active-status)
 - [Headless operation](/providers/full/headless)
 - [API endpoints](/reference/api-endpoints)

--- a/docs/get-started/quickstart-provider.mdx
+++ b/docs/get-started/quickstart-provider.mdx
@@ -16,7 +16,7 @@ This page is the high-level checklist. For the full setup, branch into one of:
     Deploy the hardened `-tee` image on SecretVM and tag your model `tee`.
   </Card>
   <Card title="Resale provider" icon="boxes-stacked" href="/providers/resale/overview">
-    Resell capacity from Venice / OpenAI / Anthropic.
+    Resell capacity from Venice / OpenAI / Anthropic — including Venice Diem holders monetizing API access.
   </Card>
   <Card title="Docker" icon="docker" href="/providers/full/proxy-router-docker">
     Containerized proxy-router only.

--- a/docs/providers/full/myprovider-gui.mdx
+++ b/docs/providers/full/myprovider-gui.mdx
@@ -1,6 +1,6 @@
 ---
 title: "MyProvider GUI"
-description: "Use myprovider.mor.org to register as a provider, bid on existing models, and sync models-config — the preferred operator UI for most providers."
+description: "Use myprovider.mor.org to onboard providers: look up models on active.mor.org, craft SecretVM/Venice secrets, register, bid, and sync MODELS_CONFIG_CONTENT."
 audience: ["provider-full", "provider-resale"]
 product: ["proxy-router"]
 last_verified: "v7.5.0"
@@ -12,17 +12,19 @@ source_url: "https://myprovider.mor.org"
 Use it as the default path for first-time registration and day-to-day bid/config work — especially on [SecretVM](/providers/full/secretvm-quickstart), where the node already exposes HTTPS on port 443.
 
 <Note>
-This page describes current MyProvider behavior as of the last verification. The app will keep evolving (including better active.mor.org model lookup); when in doubt, defer to [myprovider.mor.org](https://myprovider.mor.org) and the [register-onchain](/providers/full/register-onchain) contract flow.
+This page describes MyProvider behavior including the onboarding wizard (active.mor.org lookup, SecretVM 5-secret export, Venice Diem presets). When in doubt, defer to the live app and [Register on chain](/providers/full/register-onchain).
 </Note>
 
 ## Recommended first-time flow
 
-1. **Look up** the model you intend to serve on [active.mor.org/status](https://active.mor.org/status) (or `active_models.json` / `active_bids.json`) — copy the existing `Id` and note competing prices. See [Register on chain → Step 0](/providers/full/register-onchain#step-0--look-up-models-before-you-mint).
-2. **Fund** a dedicated provider wallet with MOR + ETH on Base; put the private key in the node's `.env` / SecretVM secrets (MyProvider does **not** hold or connect that wallet in the browser).
-3. **Run** the proxy-router (or SecretVM) until `/healthcheck` is healthy and `:3333` is public.
-4. **Open** [myprovider.mor.org](https://myprovider.mor.org), connect with node URL + Basic Auth, register the provider, then **bid on the existing model** (Available Models → Add Bid).
-5. **Sync** `models-config` via Model Configuration Sync so your backend `apiUrl` matches the on-chain `modelId` you bid on.
-6. **Verify** with [Verify your provider setup](/providers/full/verify-setup).
+1. Open [myprovider.mor.org](https://myprovider.mor.org) — use **New provider onboarding** (no node connection required yet).
+2. Pick a path: **SecretVM TEE**, **Venice Diem resale**, or **Standard / Docker**.
+3. **Look up** the model on [active.mor.org](https://active.mor.org/status) inside the wizard — copy an existing `Id` when possible.
+4. Fill wallet / RPC / admin password and **copy secrets** (`MODELS_CONFIG_CONTENT` value for SecretVM, or a full 5-secret bundle).
+5. Deploy the node (SecretVM portal, Docker, or binary) with those secrets.
+6. **Connect** MyProvider to the node URL + Basic Auth; register the provider; **bid on the existing model**.
+7. Use **Model Configuration Sync** if you need to re-export `MODELS_CONFIG_CONTENT` after bidding.
+8. **Verify** with [Verify your provider setup](/providers/full/verify-setup).
 
 Mint a **new** model only when nothing suitable exists (new weights, or a required `tee` tag with no existing tee-tagged listing).
 
@@ -30,17 +32,19 @@ Mint a **new** model only when nothing suitable exists (new weights, or a requir
 
 | Feature | Supported |
 |---------|-----------|
+| Guided onboarding (SecretVM / Venice / standard) | Yes |
+| Look up models + competitor prices via active.mor.org | Yes |
+| Craft SecretVM 5 secrets + `MODELS_CONFIG_CONTENT` value | Yes |
+| Venice Diem API URL presets | Yes |
 | Connect to proxy-router API (Basic Auth) | Yes |
 | Register / update / delete provider | Yes |
 | `:3333` endpoint reachability check | Yes |
 | Bid on existing on-chain models ("Available Models") | Yes — **prefer this** |
-| Create model + bid (single flow) | Yes — auto-generates `modelId` / `ipfsCID`; use only for genuinely new models |
+| Create model + bid (single flow) | Yes — use only for genuinely new models |
 | Delete bids; replace bid price | Yes |
-| Model config sync (`/v1/models` vs bids) + `MODELS_CONFIG_CONTENT` | Yes |
-| Bootstrap `.env` generator | Yes (before connect) |
+| Model config sync + SecretVM / `.env` export | Yes |
+| Bootstrap `.env` generator | Yes |
 | Session monitoring / earnings dashboard | **No** |
-| Built-in `active.mor.org` model lookup | **No** — use the status site / JSON (or curl) first |
-| IPFS upload (`POST /ipfs/add`) | **No** |
 
 ## Authentication
 
@@ -64,7 +68,7 @@ The hosted app at [myprovider.mor.org](https://myprovider.mor.org) can only call
 
 | Task | Best surface |
 |------|--------------|
-| First-time provider + bid (esp. SecretVM) | **MyProvider** |
+| First-time provider + secrets + bid (esp. SecretVM / Venice) | **MyProvider** onboarding + tabs |
 | Join an existing marketplace model | MyProvider → Available Models, or API `POST /blockchain/bids` |
 | Mint a genuinely new model | MyProvider Create Model & Bid, or Swagger |
 | Bulk / scripted bid updates | API ([endpoints reference](/reference/api-endpoints)) |
@@ -75,5 +79,6 @@ The hosted app at [myprovider.mor.org](https://myprovider.mor.org) can only call
 
 - [Register on chain](/providers/full/register-onchain) — discover → bid (canonical steps)
 - [SecretVM quickstart](/providers/full/secretvm-quickstart) — MyProvider-first TEE path
+- [Reselling Venice (Diem)](/providers/resale/reselling-venice) — Diem → Morpheus income path
 - [active.mor.org](/ecosystem/active-status) — live models and prices
 - [API endpoints](/reference/api-endpoints) — direct equivalents

--- a/docs/providers/resale/overview.mdx
+++ b/docs/providers/resale/overview.mdx
@@ -3,7 +3,7 @@ title: "Resale provider overview"
 description: "Why and how to resell capacity from Venice / OpenAI / Anthropic / Hyperbolic on Morpheus, without hosting your own model."
 audience: ["provider-resale"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.5.0"
 ---
 
 A "resale" provider runs a Morpheus proxy-router but does **not** host the model itself. The proxy-router forwards prompts to a hosted backend (Venice, OpenAI, Anthropic, Hyperbolic, etc.) using the backend's API key, and you collect MOR from the marketplace.
@@ -26,6 +26,10 @@ flowchart LR
 - You are bound by the upstream provider's TOS — many forbid resale; check first.
 - Your margins depend on upstream pricing changes and rate limits.
 - You cannot offer TEE attestation guarantees (see [TEE overview](/concepts/tee-overview)) because you do not control the backend.
+
+## Venice Diem holders
+
+If you already pay for **Venice Diem** (or similar) and want a low-friction way to earn MOR from spare API quota, follow [Reselling Venice (Diem)](/providers/resale/reselling-venice): look up an existing model on active.mor.org → craft secrets in [MyProvider](https://myprovider.mor.org) → bid. That path is designed to be mostly graphical.
 
 ## How it works mechanically
 

--- a/docs/providers/resale/reselling-venice.mdx
+++ b/docs/providers/resale/reselling-venice.mdx
@@ -1,16 +1,27 @@
 ---
 title: "Reselling Venice (Diem) capacity"
-description: "Stand up a Morpheus resale P-Node fronted by Venice's API, using your Venice Diem subscription's API access."
+description: "Turn Venice Diem API access into Morpheus provider income: look up models on active.mor.org, craft secrets in MyProvider, bid — without minting duplicate models."
 audience: ["provider-resale"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.5.0"
 ---
 
-[Venice](https://venice.ai) sells subscription tiers (including the Diem tier) that include API access. If you have spare headroom in your Venice subscription, you can resell that capacity through Morpheus by configuring your proxy-router to forward to Venice's API.
+[Venice](https://venice.ai) subscription tiers (including **Diem**) include API access. If you have spare headroom, you can resell that capacity through Morpheus: your proxy-router forwards inference to Venice, and consumers pay you in MOR via marketplace bids.
+
+The simplest path today is **MyProvider + an existing marketplace model Id** — not minting a new model for every Diem holder.
 
 <Warning>
 **Read Venice's TOS.** Resale terms vary by tier and over time — confirm yours allows reselling API access before going live. This page describes mechanics, not legal permission.
 </Warning>
+
+## Why this path
+
+| Goal | Approach |
+|------|----------|
+| Earn MOR from unused Venice quota | Bid on an existing Morpheus model that matches what Venice can serve |
+| Avoid marketplace clutter | Do **not** register a new model if one already exists on [active.mor.org](https://active.mor.org/status) |
+| Stay graphical | Use [MyProvider](https://myprovider.mor.org) onboarding → **Venice Diem resale** path |
+| Keep ops cheap | Docker/binary P-Node (or SecretVM if you want TEE for the *router* only — you still cannot tag Venice backends `tee`) |
 
 ## Architecture
 
@@ -22,65 +33,65 @@ flowchart LR
   YourProxy -->|"venice.ai apiKey"| Venice[Venice API]
 ```
 
-## Steps
+## Simple recipe (MyProvider-first)
 
 <Steps>
-  <Step title="Get a Venice API key">
-    Sign up at https://venice.ai and obtain an API key from your account dashboard. Confirm your tier supports the model you intend to resell at the concurrency you intend to advertise.
+  <Step title="Open MyProvider onboarding">
+    Go to [myprovider.mor.org](https://myprovider.mor.org). Choose **Venice Diem resale** in **New provider onboarding**.
   </Step>
-  <Step title="Pick the Venice models you'll resell">
-    Examples: `text-embedding-bge-m3`, `tts-kokoro`, plus chat models supported by Venice. Check Venice's docs for the exact `apiUrl` per model.
+  <Step title="Look up the model to join">
+    Search [active.mor.org](https://active.mor.org/status) (built into the wizard) for a model name Venice can serve. Copy the existing `Id`. Prefer bidding on that Id over creating a new model.
   </Step>
-  <Step title="Stand up the proxy-router container">
-    Follow [Container P-Node](/providers/resale/container-pnode). Start the container; it will create `models-config.json` defaults you can edit.
+  <Step title="Fill Venice backend + secrets">
+    Pick a Venice preset (chat / embeddings / TTS), paste your Venice API key, and export `MODELS_CONFIG_CONTENT` (and the rest of your `.env` / container secrets). Details also in [MyProvider GUI](/providers/full/myprovider-gui).
   </Step>
-  <Step title="Edit models-config.json">
-    ```json
-    {
-      "$schema": "./internal/config/models-config-schema.json",
-      "models": [
-        {
-          "modelId": "0x<your_chain_modelId_for_chat>",
-          "modelName": "venice-chat",
-          "apiType": "openai",
-          "apiUrl": "https://api.venice.ai/api/v1/chat/completions",
-          "apiKey": "<your_venice_api_key>",
-          "concurrentSlots": 4,
-          "capacityPolicy": "simple"
-        },
-        {
-          "modelId": "0x<your_chain_modelId_for_embeddings>",
-          "modelName": "text-embedding-bge-m3",
-          "apiType": "openai",
-          "apiUrl": "https://api.venice.ai/api/v1/embeddings",
-          "apiKey": "<your_venice_api_key>"
-        },
-        {
-          "modelId": "0x<your_chain_modelId_for_tts>",
-          "modelName": "tts-kokoro",
-          "apiType": "openai",
-          "apiUrl": "https://api.venice.ai/api/v1/audio/speech",
-          "apiKey": "<your_venice_api_key>"
-        }
-      ]
-    }
-    ```
-    Restart the proxy-router after edits.
+  <Step title="Run a proxy-router">
+    Docker or binary is enough — see [Container P-Node](/providers/resale/container-pnode). Point `models-config` / `MODELS_CONFIG_CONTENT` at Venice URLs with your key. Expose `:3333` publicly; keep admin private (or HTTPS for hosted MyProvider).
   </Step>
-  <Step title="Register on chain">
-    Same as a full provider, **without** the `tee` tag (you cannot attest Venice). Follow [Register on chain](/providers/full/register-onchain).
+  <Step title="Register provider + bid">
+    Connect MyProvider to your node → **Provider** tab → register `host:3333`. **Models & Bids → Available Models → Add Bid** on the Id from step 2. Do **not** use the `tee` tag.
   </Step>
-  <Step title="Pick a bid price">
-    Lower is more attractive but you must clear your Venice cost. See [Registering a bid](/providers/resale/registering-bid) for the math.
+  <Step title="Price above your Venice cost">
+    See [Pricing a resale bid](/providers/resale/registering-bid). Every bid costs a non-refundable `0.3 MOR` fee — finish config before posting.
   </Step>
-  <Step title="Validate end-to-end">
-    Open `http://your-host:8082/swagger/index.html`. From a separate consumer node, list models, open a session against your bid, and prompt. Watch your proxy-router logs and Venice usage dashboard simultaneously.
+  <Step title="Verify">
+    Follow [Verify your provider setup](/providers/full/verify-setup). Watch Venice usage limits so a busy session cannot blow your Diem quota.
   </Step>
 </Steps>
+
+## Manual models-config (reference)
+
+If you prefer editing JSON by hand:
+
+```json
+{
+  "$schema": "./internal/config/models-config-schema.json",
+  "models": [
+    {
+      "modelId": "0x<existing_active_mor_org_model_Id>",
+      "modelName": "matching-on-chain-name",
+      "apiType": "openai",
+      "apiUrl": "https://api.venice.ai/api/v1/chat/completions",
+      "apiKey": "<your_venice_api_key>",
+      "concurrentSlots": 4,
+      "capacityPolicy": "simple"
+    }
+  ]
+}
+```
+
+Restart the proxy-router after edits. Full register/bid contract steps: [Register on chain](/providers/full/register-onchain).
 
 ## Operational tips
 
 - **Track Venice usage** — set Venice account limits/alerts so a session can't blow your budget.
-- **Throttle `concurrentSlots`** — start conservatively. Going too high causes upstream 429s, which surface to consumers as a bad experience.
-- **Failover**: if you maintain multiple upstream accounts, run multiple proxy-routers and post separate bids; consumers route to whichever is cheapest and healthy.
+- **Throttle `concurrentSlots`** — start conservatively. Going too high causes upstream 429s.
+- **Failover**: multiple upstream accounts → multiple proxy-routers and separate bids.
 - **Avoid the `tee` tag** — you cannot prove anything about Venice's runtime. Only use `tee` when you control the backend on a SecretVM-style TEE.
+
+## Related
+
+- [MyProvider GUI](/providers/full/myprovider-gui)
+- [Resale overview](/providers/resale/overview)
+- [Register on chain](/providers/full/register-onchain)
+- [active.mor.org](/ecosystem/active-status)


### PR DESCRIPTION
## Summary
- Follow-up to #787: document MyProvider guided onboarding (active.mor.org lookup, SecretVM secrets, MODELS_CONFIG_CONTENT).
- Venice Diem holders: friction-light resale recipe that prefers bidding on existing models via MyProvider.

Also included in the open promote-to-test PR #788 for review on nodedocs.dev.

## Test plan
- [ ] Review reselling-venice, myprovider-gui, resale overview
- [ ] Confirm links to myprovider.mor.org / active.mor.org


Made with [Cursor](https://cursor.com)