### PR TITLE
fix(tee): Phase 2 attestation port 21434 + SecretVM prod deploy

### DIFF
--- a/.ai-docs/TEE_Attestation_Architecture.md
+++ b/.ai-docs/TEE_Attestation_Architecture.md
@@ -51,10 +51,10 @@ A consumer node should be able to **cryptographically verify**, before sending a
 **P-Node verifies its own backend LLM** (the gap previously "accepted" for Phase 1 is now closed without co-locating):
 
 - `BackendVerifier.AttestBackend` at startup — **DONE**
-  - Fetch backend CPU quote from `:29343/cpu`; verify via SecretAI portal
+  - Fetch backend CPU quote from `:21434/cpu`; verify via SecretAI portal
   - TLS binding: compare TLS cert SHA-256 with CPU quote `reportData[0:32]`
   - Workload verification: parse TDX quote, look up MRTD + RTMR0-2 in the published SecretVM TDX artifact registry CSV, replay RTMR3 using SHA-384 extend chain over `SHA-256(docker-compose)` + rootfs data
-  - GPU attestation: fetch from `:29343/gpu`, verify CPU-GPU binding via `reportData[32:64] == GPU nonce`
+  - GPU attestation: fetch from `:21434/gpu`, verify CPU-GPU binding via `reportData[32:64] == GPU nonce`
   - NVIDIA NRAS v4 API: submit GPU evidence for independent hardware validation (non-fatal if unreachable)
 - `BackendVerifier.FastVerifyBackend` on every prompt — **DONE**
   - Always re-fetches CPU quote (~50 ms), compares hash + TLS fingerprint against cached snapshot
@@ -559,8 +559,14 @@ The `test` environment uses custom deployment branch policies. The allowed branc
 
 **First successful end-to-end run:** https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/actions/runs/22969993910
 
-**Future: production deployment**
-Add a `Deploy-SecretVM-Prod` job bound to `environment: production`, triggered only on `main` branch, with its own set of secrets (`SECRETVM_API_KEY`, `SECRETVM_PROD_VM_UUID`, `SECRETVM_PROD_ENV`). Environment protection rules (reviewers, wait timer) can gate production deploys.
+**Production deployment**
+A `Deploy-SecretVM-Prod` job mirrors the test flow, bound to `environment: main`, triggered only on the `main` branch. Required secrets on the `main` GitHub Environment:
+
+| Secret | Value |
+|---|---|
+| `SECRETVM_API_KEY` | SCRT Labs API key (same account as test is fine) |
+| `SECRETVM_PROD_VM_UUID` | UUID of the production SecretVM |
+| `SECRETVM_PROD_ENV` | The 5 runtime secrets as a `.env` file, base64-encoded |
 
 **Security notes:**
 - The env file is decoded to `/tmp` and deleted immediately after `vm edit`
@@ -712,24 +718,26 @@ This is the Phase 2 capability that makes v7 the "full TEE" release. It closes t
 - `proxy-router/internal/aiengine/ai_engine.go` — returns a `PinnedHTTPClient` for TEE models; the client's `VerifyPeerCertificate` callback refuses any onward TLS cert whose SHA-256 doesn't match the attested fingerprint
 - `proxy-router/internal/proxyapi/controller_http.go` — `GET /v1/models/attestation` returns per-model attestation state (verified / pending / failed + workload-match / last-success timestamp / error detail)
 
-**Backend attestation endpoints (derived from each TEE model's `apiUrl` host + standard port 29343):**
-- `:29343/cpu` — raw TDX CPU quote hex
-- `:29343/gpu` — JSON containing `nonce`, `arch`, `evidence_list`
-- `:29343/docker-compose` — exact `docker-compose.yaml` loaded into the backend VM (used for RTMR3 replay)
+**Backend attestation endpoints (derived from each TEE model's `apiUrl` host + port 21434):**
+- `:21434/cpu` — raw TDX CPU quote hex
+- `:21434/gpu` — JSON containing `nonce`, `arch`, `evidence_list`
+- `:21434/docker-compose` — exact `docker-compose.yaml` loaded into the backend VM (used for RTMR3 replay)
+
+Phase 1 P-Node host attestation remains on `:29343`.
 
 **Full attestation sequence (`AttestBackend`):**
 ```
-1. GET :29343/cpu            → raw TDX quote
+1. GET :21434/cpu            → raw TDX quote
 2. POST quote to TEE_PORTAL_URL (quote-parse) → portal verification
 3. Extract reportData[0:32]   → compare with SHA-256 of live TLS cert
                                    → TLS binding proven
 4. if ArtifactRegistry loaded:
-     GET :29343/docker-compose
+     GET :21434/docker-compose
      Parse TDX quote: MRTD + RTMR0-3 + reportData
      Lookup (MRTD, RTMR0, RTMR1, RTMR2) in registry CSV → rootfs_data + secretvm_release
      Replay RTMR3 = SHA-384-extend-chain( SHA-256(docker-compose) + rootfs_data )
      if replayed RTMR3 != quote RTMR3 → fail (workload mismatch)
-5. GET :29343/gpu             → {nonce, arch, evidence_list}
+5. GET :21434/gpu             → {nonce, arch, evidence_list}
 6. Extract reportData[32:64]  → compare with GPU nonce
                                    → CPU-GPU binding proven
 7. if NRAS configured:
@@ -743,7 +751,7 @@ This is the Phase 2 capability that makes v7 the "full TEE" release. It closes t
 
 **Per-prompt fast verify (`FastVerifyBackend`):**
 - No TTL. Runs unconditionally on every inference prompt for a `tee`-tagged model (inside `proxy_receiver.SessionPrompt`, on the hot path).
-- Always re-fetches `:29343/cpu` (~50 ms TLS handshake).
+- Always re-fetches `:21434/cpu` (~50 ms TLS handshake).
 - `SHA-256(new_quote) == cached_quote_hash` AND `live_tls_fp == cached_tls_fp` → pass.
 - Quote-hash change → run full `AttestBackend` again (backend restart / redeploy).
 - TLS-fingerprint change → immediate hard fail, prompt refused (MITM signal).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1070,6 +1070,125 @@ jobs:
             exit 1
           fi
 
+  Deploy-SecretVM-Prod:
+    name: Deploy TEE Image to SecretVM (prod)
+    if: |
+      github.ref == 'refs/heads/main' &&
+      (needs.changes.outputs.proxy == 'true' || github.event_name == 'workflow_dispatch')
+    needs:
+      - changes
+      - Generate-Tag
+      - GHCR-Build-and-Push-TEE
+    runs-on: ubuntu-latest
+    environment: main
+    steps:
+      - name: Download deployed compose artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: docker-compose-tee-deployed-${{ needs.Generate-Tag.outputs.tag_name }}
+          path: /tmp
+
+      - name: Deploy to SecretVM prod instance
+        env:
+          SECRETVM_API_KEY: ${{ secrets.SECRETVM_API_KEY }}
+          SECRETVM_PROD_VM_UUID: ${{ secrets.SECRETVM_PROD_VM_UUID }}
+          SECRETVM_PROD_ENV_B64: ${{ secrets.SECRETVM_PROD_ENV }}
+        run: |
+          if [ -z "$SECRETVM_API_KEY" ] || [ -z "$SECRETVM_PROD_VM_UUID" ] || [ -z "$SECRETVM_PROD_ENV_B64" ]; then
+            echo "⏭️  SecretVM prod secrets not configured — skipping deploy" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          npm install --global secretvm-cli
+
+          echo "$SECRETVM_PROD_ENV_B64" | base64 -d > /tmp/secretvm-prod.env
+
+          echo "🚀 Updating SecretVM prod instance ${SECRETVM_PROD_VM_UUID:0:8}..." >> $GITHUB_STEP_SUMMARY
+
+          secretvm-cli -k "$SECRETVM_API_KEY" vm edit "$SECRETVM_PROD_VM_UUID" \
+            --docker-compose /tmp/docker-compose.tee.deployed.yml \
+            --env /tmp/secretvm-prod.env
+
+          rm -f /tmp/secretvm-prod.env
+
+          echo "✅ SecretVM prod instance updated with new TEE image" >> $GITHUB_STEP_SUMMARY
+          echo "   Compose: \`docker-compose-tee-deployed-${{ needs.Generate-Tag.outputs.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "   Expected RTMR3: \`${{ needs.GHCR-Build-and-Push-TEE.outputs.rtmr3 }}\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Verify attestation after deploy
+        env:
+          SECRETVM_API_KEY: ${{ secrets.SECRETVM_API_KEY }}
+          SECRETVM_PROD_VM_UUID: ${{ secrets.SECRETVM_PROD_VM_UUID }}
+          EXPECTED_RTMR3: ${{ needs.GHCR-Build-and-Push-TEE.outputs.rtmr3 }}
+        run: |
+          if [ -z "$SECRETVM_API_KEY" ] || [ -z "$SECRETVM_PROD_VM_UUID" ] || [ -z "$EXPECTED_RTMR3" ]; then
+            echo "⏭️  Skipping attestation verify (missing secrets or RTMR3)" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          echo "⏳ Waiting for VM to reboot with new image..." >> $GITHUB_STEP_SUMMARY
+
+          # vm attestation returns raw TDX quote hex; extract RTMR3 from known offset
+          # TDX Quote v4: 48-byte header + TD Report Body
+          # RTMR3 at body offset 472 bytes (48 bytes long)
+          RTMR3_HEX_START=$(( (48 + 472) * 2 ))
+          RTMR3_HEX_LEN=96
+
+          MAX_ATTEMPTS=12
+          SLEEP_SECS=30
+          MATCHED=false
+
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            echo "  Attestation poll attempt $i/$MAX_ATTEMPTS..."
+
+            RAW_QUOTE=$(secretvm-cli -k "$SECRETVM_API_KEY" vm attestation "$SECRETVM_PROD_VM_UUID" 2>/dev/null) || true
+
+            LIVE_RTMR3=$(echo "$RAW_QUOTE" | python3 -c "
+          import sys, json
+          try:
+              data = json.load(sys.stdin)
+              raw = data.get('result', '')
+              rtmr3 = raw[$RTMR3_HEX_START:$RTMR3_HEX_START+$RTMR3_HEX_LEN]
+              if len(rtmr3) == $RTMR3_HEX_LEN:
+                  print(rtmr3)
+              else:
+                  print('')
+          except:
+              print('')
+          " 2>/dev/null)
+
+            if [ -n "$LIVE_RTMR3" ]; then
+              echo "  Got RTMR3: ${LIVE_RTMR3:0:16}..."
+
+              if [ "$LIVE_RTMR3" = "$EXPECTED_RTMR3" ]; then
+                MATCHED=true
+                echo "🎉 **RTMR3 MATCH** — attestation verified!" >> $GITHUB_STEP_SUMMARY
+                echo "   Live RTMR3:     \`$LIVE_RTMR3\`" >> $GITHUB_STEP_SUMMARY
+                echo "   Expected RTMR3: \`$EXPECTED_RTMR3\`" >> $GITHUB_STEP_SUMMARY
+                break
+              else
+                echo "  RTMR3 mismatch (VM may still be rebooting)"
+                echo "    live:     $LIVE_RTMR3"
+                echo "    expected: $EXPECTED_RTMR3"
+              fi
+            else
+              echo "  No attestation data yet (VM may still be starting)"
+            fi
+
+            if [ "$i" -lt "$MAX_ATTEMPTS" ]; then
+              sleep $SLEEP_SECS
+            fi
+          done
+
+          if [ "$MATCHED" = false ]; then
+            echo "⚠️ **RTMR3 mismatch after ${MAX_ATTEMPTS} attempts** (${SLEEP_SECS}s × ${MAX_ATTEMPTS} = $(( SLEEP_SECS * MAX_ATTEMPTS ))s)" >> $GITHUB_STEP_SUMMARY
+            echo "   Live RTMR3:     \`${LIVE_RTMR3:-unavailable}\`" >> $GITHUB_STEP_SUMMARY
+            echo "   Expected RTMR3: \`$EXPECTED_RTMR3\`" >> $GITHUB_STEP_SUMMARY
+            echo "   This may indicate the VM is still rebooting, or there is a genuine mismatch." >> $GITHUB_STEP_SUMMARY
+            echo "   Check manually: \`secretvm-cli vm attestation $SECRETVM_PROD_VM_UUID\`" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
   Build-Service-Executables:
     name: Build Service Executables
     if: |

--- a/proxy-router/cmd/main.go
+++ b/proxy-router/cmd/main.go
@@ -351,7 +351,7 @@ func start() error {
 		if !blockchainapi.IsTeeModel(tags) {
 			continue
 		}
-		attestURL, err := attestation.DeriveAttestationURL(mc.ApiURL)
+		attestURL, err := attestation.DeriveBackendAttestationURL(mc.ApiURL)
 		if err != nil {
 			appLog.Warnf("cannot derive attestation URL for model %s: %s", modelIDs[i].Hex(), err)
 			continue

--- a/proxy-router/docs/tee-backend-verification.md
+++ b/proxy-router/docs/tee-backend-verification.md
@@ -64,7 +64,7 @@ sequenceDiagram
 
     Note over P: AttestBackend begins
 
-    P->>B: GET :29343/cpu
+    P->>B: GET :21434/cpu
     B-->>P: CPU attestation quote (TDX)
 
     P->>S: POST /quote-parse (CPU quote)
@@ -73,7 +73,7 @@ sequenceDiagram
     Note over P: Extract TLS cert fingerprint<br/>Compare with reportData[0:32]
 
     alt Artifact Registry loaded
-        P->>B: GET :29343/docker-compose
+        P->>B: GET :21434/docker-compose
         B-->>P: docker-compose.yaml
 
         Note over P: Parse TDX quote:<br/>extract MRTD, RTMR0-3
@@ -86,7 +86,7 @@ sequenceDiagram
         Note over P: Compare calculated RTMR3<br/>vs quote RTMR3
     end
 
-    P->>B: GET :29343/gpu
+    P->>B: GET :21434/gpu
     B-->>P: GPU attestation JSON (nonce, arch, evidence_list)
 
     Note over P: Verify reportData[32:64] == GPU nonce<br/>(CPU-GPU binding)
@@ -101,7 +101,7 @@ sequenceDiagram
 
 ### Step-by-Step
 
-1. **Fetch CPU quote** -- The proxy-router requests the raw TDX attestation quote from the backend's attestation port (`:29343/cpu`).
+1. **Fetch CPU quote** -- The proxy-router requests the raw TDX attestation quote from the backend's attestation port (`:21434/cpu`).
 2. **Verify CPU quote** -- The quote is sent to the SecretAI Portal's `quote-parse` API, which performs cryptographic verification against Intel's root of trust.
 3. **TLS binding** -- The proxy-router extracts the TLS certificate fingerprint from the connection and compares it to the first 32 bytes of the quote's `reportData` field. A match proves the TLS endpoint is inside the attested TEE.
 4. **Workload verification** (if artifact registry is loaded):
@@ -110,7 +110,7 @@ sequenceDiagram
    - Look up MRTD + RTMR0-2 in the artifact registry to confirm this is a recognized SecretVM build.
    - Recalculate the expected RTMR3 from `SHA-256(docker-compose.yaml)` combined with `rootfs_data` using a SHA-384 extend chain.
    - Compare the calculated RTMR3 against the quote's RTMR3 to prove workload integrity.
-5. **Fetch GPU attestation** -- Retrieve GPU attestation data (JSON containing nonce, architecture, and evidence list) from `:29343/gpu`.
+5. **Fetch GPU attestation** -- Retrieve GPU attestation data (JSON containing nonce, architecture, and evidence list) from `:21434/gpu`.
 6. **CPU-GPU binding** -- Verify that the second 32 bytes of the CPU `reportData` match the GPU nonce, proving both attestations originate from the same machine and session.
 7. **NRAS verification** (if configured) -- Submit GPU evidence to NVIDIA's Remote Attestation Service for independent hardware validation. NRAS returns a signed JWT (Entity Attestation Token) confirming GPU authenticity.
 8. **Cache snapshot** -- Store the attestation result (quote hash, TLS fingerprint, workload status) for use by the fast verification path. The cache has no TTL -- it remains valid as long as the backend's CPU quote and TLS certificate haven't changed.
@@ -169,7 +169,7 @@ flowchart TD
     CACHE -- No --> REJECT[Error: model not attested]
     CACHE -- Yes --> STATUS{Status is passed?}
     STATUS -- No --> REJECT2[Error: attestation failed]
-    STATUS -- Yes --> FETCH[Re-fetch CPU quote<br/>from :29343/cpu]
+    STATUS -- Yes --> FETCH[Re-fetch CPU quote<br/>from :21434/cpu]
     FETCH --> HASH[Compute SHA-256<br/>of fetched quote]
     HASH --> CMP_HASH{Quote hash matches<br/>cached hash?}
     CMP_HASH -- No --> FULL[Run full AttestBackend<br/>Backend has changed]
@@ -185,7 +185,7 @@ There is no TTL or cache expiry. The fast verify runs the same check on every pr
 
 1. **Cache check** -- If no cached attestation exists (model was never attested), reject the request.
 2. **Status check** -- If the cached status is `failed`, reject the request.
-3. **Re-fetch CPU quote** -- Always request the current CPU quote from `:29343/cpu` (~50ms TLS handshake).
+3. **Re-fetch CPU quote** -- Always request the current CPU quote from `:21434/cpu` (~50ms TLS handshake).
 4. **Hash comparison** -- Compute `SHA-256` of the fetched quote and compare against the cached hash. A mismatch indicates the backend has changed (restart, redeployment) and triggers full re-attestation.
 5. **TLS fingerprint comparison** -- Verify the current connection's TLS certificate fingerprint matches the cached value. A mismatch is treated as a critical error (possible MITM attack) and the request is rejected immediately.
 6. **Pass** -- If both checks succeed, the inference request proceeds to the backend.
@@ -234,13 +234,13 @@ No `isTee` field is required (or accepted) in `models-config.json` — the `mode
 
 ### Backend Attestation Endpoint Derivation
 
-Attestation endpoints are derived from the model's `apiUrl` host with port `29343` (the standard SecretVM attestation port).
+Attestation endpoints are derived from the model's `apiUrl` host with port `21434` (SecretAI backend / GPU TEE attestation; Phase 1 P-Node host attestation remains on `29343`).
 
 Example: a model registered on-chain with the `tee` tag and `apiUrl` set to `https://backend.example.com:8080/v1` will be attested against:
 
-- `https://backend.example.com:29343/cpu` — TDX CPU quote
-- `https://backend.example.com:29343/gpu` — GPU attestation evidence
-- `https://backend.example.com:29343/docker-compose` — backend's compose file for RTMR3 replay
+- `https://backend.example.com:21434/cpu` — TDX CPU quote
+- `https://backend.example.com:21434/gpu` — GPU attestation evidence
+- `https://backend.example.com:21434/docker-compose` — backend's compose file for RTMR3 replay
 
 ### Environment Variables
 

--- a/proxy-router/internal/attestation/backend_verifier.go
+++ b/proxy-router/internal/attestation/backend_verifier.go
@@ -421,7 +421,7 @@ func (bv *BackendVerifier) fetchDockerCompose(ctx context.Context, attestationUR
 
 	content := string(body)
 
-	// The SecretVM :29343/docker-compose endpoint wraps the YAML in an HTML page.
+	// The SecretVM :21434/docker-compose endpoint wraps the YAML in an HTML page.
 	// Extract the raw content from inside <pre>...</pre> tags.
 	content = extractPreContent(content)
 

--- a/proxy-router/internal/attestation/derive_url_test.go
+++ b/proxy-router/internal/attestation/derive_url_test.go
@@ -1,0 +1,25 @@
+package attestation
+
+import "testing"
+
+func TestDeriveAttestationURL_Phase1Port(t *testing.T) {
+	got, err := DeriveAttestationURL("https://provider.example.com:3333/v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://provider.example.com:29343"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestDeriveBackendAttestationURL_Phase2Port(t *testing.T) {
+	got, err := DeriveBackendAttestationURL("https://secretai-rytn.scrtlabs.com:21434/v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://secretai-rytn.scrtlabs.com:21434"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/proxy-router/internal/attestation/verifier.go
+++ b/proxy-router/internal/attestation/verifier.go
@@ -44,10 +44,14 @@ func (c *collateralField) UnmarshalJSON(data []byte) error {
 }
 
 const (
-	AttestationPort     = "29343"
-	DefaultPortalURL    = "https://secretai.scrtlabs.com/api/quote-parse"
-	DefaultPortalURLSEV = "https://secretai.scrtlabs.com/api/quote-parse-sev"
-	VerifyTimeout       = 30 * time.Second
+	// AttestationPort is Phase 1 (consumer → P-Node): SecretVM host attestation.
+	AttestationPort = "29343"
+	// BackendAttestationPort is Phase 2 (P-Node → backend): SecretAI GPU/LLM TEE
+	// attestation co-located with the inference endpoint.
+	BackendAttestationPort = "21434"
+	DefaultPortalURL       = "https://secretai.scrtlabs.com/api/quote-parse"
+	DefaultPortalURLSEV    = "https://secretai.scrtlabs.com/api/quote-parse-sev"
+	VerifyTimeout          = 30 * time.Second
 )
 
 // deriveSEVPortalURL returns the SEV-specific portal URL by appending "-sev"
@@ -606,24 +610,35 @@ func qf(q *QuoteFields, field string) string {
 	}
 }
 
-// DeriveAttestationURL constructs the SecretVM attestation base URL from an endpoint.
+// DeriveAttestationURL constructs the Phase 1 SecretVM host attestation base URL.
 // Input format: "host:port" or "https://host:port/path"
 // Output format: "https://host:29343"
 func DeriveAttestationURL(endpoint string) (string, error) {
+	return deriveAttestationURLWithPort(endpoint, AttestationPort)
+}
+
+// DeriveBackendAttestationURL constructs the Phase 2 backend TEE attestation base URL.
+// Input format: "host:port" or "https://host:port/path"
+// Output format: "https://host:21434"
+func DeriveBackendAttestationURL(endpoint string) (string, error) {
+	return deriveAttestationURLWithPort(endpoint, BackendAttestationPort)
+}
+
+func deriveAttestationURLWithPort(endpoint, port string) (string, error) {
 	if strings.Contains(endpoint, "://") {
 		parsed, err := url.Parse(endpoint)
 		if err != nil {
 			return "", fmt.Errorf("invalid endpoint URL: %w", err)
 		}
 		host := parsed.Hostname()
-		return fmt.Sprintf("https://%s:%s", host, AttestationPort), nil
+		return fmt.Sprintf("https://%s:%s", host, port), nil
 	}
 
 	host, _, err := net.SplitHostPort(endpoint)
 	if err != nil {
 		host = endpoint
 	}
-	return fmt.Sprintf("https://%s:%s", host, AttestationPort), nil
+	return fmt.Sprintf("https://%s:%s", host, port), nil
 }
 
 // deriveAttestationURL is the old unexported alias kept for internal compatibility.

--- a/proxy-router/internal/attestation/workload_rytn_test.go
+++ b/proxy-router/internal/attestation/workload_rytn_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/lib"
 )
 
-const rytnAttestationURL = "https://secretai-rytn.scrtlabs.com:29343"
+const rytnAttestationURL = "https://secretai-rytn.scrtlabs.com:21434"
 
 func skipIfNoNetwork(t *testing.T) {
 	if os.Getenv("TEE_INTEGRATION_TEST") == "" {


### PR DESCRIPTION
## Summary
- Split attestation ports: Phase 1 (consumer → P-Node) stays on `:29343`; Phase 2 (P-Node → backend GPU/LLM TEE) uses `:21434` via `DeriveBackendAttestationURL`.
- Add `Deploy-SecretVM-Prod` CI job (mirrors test) on `main` with `environment: main` and `SECRETVM_PROD_VM_UUID` / `SECRETVM_PROD_ENV` / `SECRETVM_API_KEY`.
- Update TEE docs/tests for the backend port change.

## Test plan
- [ ] Unit: `go test ./internal/attestation/ -run TestDerive`
- [ ] Confirm startup logs hit `https://secretai-*:21434/cpu` (not `:29343`) for tee-tagged models
- [ ] Confirm Phase 1 still targets provider `:29343`
- [ ] After merge to `main`, verify `Deploy-SecretVM-Prod` runs and RTMR3 matches

Made with [Cursor](https://cursor.com)