### PR TITLE
feat(mobile): OpenSessionOmitting + OpenSessionByBid for consumer failover

### DIFF
--- a/proxy-router/internal/blockchainapi/service.go
+++ b/proxy-router/internal/blockchainapi/service.go
@@ -1204,6 +1204,11 @@ func (s *BlockchainService) GetTransactions(ctx context.Context, page uint64, li
 	return allTrxs, nil
 }
 
+// OpenSessionByBidId opens a session against a specific bid (no provider failover).
+func (s *BlockchainService) OpenSessionByBidId(ctx context.Context, bidID common.Hash, duration *big.Int, agentUsername string) (common.Hash, error) {
+	return s.openSessionByBid(ctx, bidID, duration, agentUsername)
+}
+
 func (s *BlockchainService) openSessionByBid(ctx context.Context, bidID common.Hash, duration *big.Int, agentUsername string) (common.Hash, error) {
 	supply, err := s.GetTokenSupply(ctx)
 	if err != nil {

--- a/proxy-router/mobile/sdk_sessions.go
+++ b/proxy-router/mobile/sdk_sessions.go
@@ -11,12 +11,39 @@ import (
 // OpenSession opens a session with the best-rated provider for a model.
 // duration is in seconds. Returns the session ID (tx hash).
 func (s *SDK) OpenSession(ctx context.Context, modelID string, durationSec int64, directPayment bool) (string, error) {
+	return s.OpenSessionOmitting(ctx, modelID, durationSec, directPayment, "")
+}
+
+// OpenSessionOmitting opens a session while excluding omitProviderAddr from bid
+// selection. Pass an empty string to consider every rated bid (same as OpenSession).
+// Used by consumer failover after a mid-session provider impairment (429/503/etc.).
+func (s *SDK) OpenSessionOmitting(ctx context.Context, modelID string, durationSec int64, directPayment bool, omitProviderAddr string) (string, error) {
 	if err := s.checkClosed(); err != nil {
 		return "", err
 	}
 	id := common.HexToHash(modelID)
 	dur := big.NewInt(durationSec)
-	txHash, err := s.blockchain.OpenSessionByModelId(ctx, id, dur, directPayment, true, common.Address{}, "")
+	omit := common.Address{}
+	if omitProviderAddr != "" {
+		omit = common.HexToAddress(omitProviderAddr)
+	}
+	txHash, err := s.blockchain.OpenSessionByModelId(ctx, id, dur, directPayment, true, omit, "")
+	if err != nil {
+		return "", err
+	}
+	return txHash.Hex(), nil
+}
+
+// OpenSessionByBid opens a session against a specific bid ID.
+// Unlike OpenSession, there is no multi-provider failover — the chosen bid is
+// the only attempt. Prefer OpenSession / OpenSessionOmitting for normal UX.
+func (s *SDK) OpenSessionByBid(ctx context.Context, bidID string, durationSec int64) (string, error) {
+	if err := s.checkClosed(); err != nil {
+		return "", err
+	}
+	id := common.HexToHash(bidID)
+	dur := big.NewInt(durationSec)
+	txHash, err := s.blockchain.OpenSessionByBidId(ctx, id, dur, "")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary
- Add `SDK.OpenSessionOmitting` so consumers can reopen a session while excluding a failed provider address (mid-session failover after 429/503/etc.).
- Add `SDK.OpenSessionByBid` + public `BlockchainService.OpenSessionByBidId` for explicit bid selection without multi-provider failover.
- `OpenSession` becomes a thin wrapper around `OpenSessionOmitting` with an empty omit address (behavior unchanged for existing callers).

## Context
Node Neo (and other mobile/desktop consumers) need Marketplace-API-style failover without inventing bid selection outside the SDK. The HTTP API already supports `omitProvider` on open-by-model; this surfaces the same capability on the mobile SDK.

## Test plan
- [ ] `go test` / build `proxy-router/mobile` package
- [ ] Existing `OpenSession` callers still open a top-rated bid (empty omit)
- [ ] `OpenSessionOmitting` with a real provider address skips that provider's bids
- [ ] `OpenSessionByBid` opens exactly the requested bid
- [ ] Node Neo failover path against this branch (local `replace` or `go get @mobile/open-session-omit`)


Made with [Cursor](https://cursor.com)