### PR TITLE
Dev

### DIFF
--- a/docs/providers/full/model-health.mdx
+++ b/docs/providers/full/model-health.mdx
@@ -34,8 +34,18 @@ Two consequences worth internalizing:
 | `MODEL_HEALTH_CHECK_INTERVAL` | `1h` | How often the full sweep runs; results are cached between sweeps |
 | `MODEL_HEALTH_CHECK_TIMEOUT` | `60s` | Per-model probe timeout; slower probes report `errorKind: timeout` |
 | `MODEL_HEALTH_CHECK_PROBE_DELAY` | `2s` | Pause between consecutive probes within a sweep |
+| `MODEL_HEALTH_MAX_CONSECUTIVE_ERRORS` | `3` | Consecutive real-session prompt failures after which a model is flipped to `unhealthy` immediately, without waiting for the next sweep |
 
 Full env reference: [env-proxy-router](/reference/env-proxy-router).
+
+## Live signals between sweeps
+
+The report is not only cron-driven — real traffic updates it immediately:
+
+- **Consecutive session errors.** When prompts from open sessions fail against your backend (connection error, upstream `5xx`, `401`/`402`/`404`, `429`) `MODEL_HEALTH_MAX_CONSECUTIVE_ERRORS` times in a row, the model is marked `unhealthy` with `errorKind: session_errors` on the spot. Client-fault upstream responses (`400`, `403`, `413`, `422`) count neither way, so a consumer sending malformed requests cannot flip a healthy model. A later successful prompt — or a passing scheduled probe — heals the status and resets the streak.
+- **TEE self-verification.** For `tee`-tagged models the provider verifies its own backend attestation. If that verification fails (at startup, during a sweep, or on the per-session fast-verify), the model is reported with the dedicated status `tee_unverified` and `errorKind: tee_attestation` instead of being probed — session requests for it would be rejected anyway. The status heals once attestation passes again.
+
+Consumers use this report **before opening a session**: the pre-open healthcheck ping reads the pong's `models` array and skips providers that self-report the bid's model as `unhealthy`, `tee_unverified`, or `no_model_configured`, moving on to the next rated bid.
 
 ### Impact on your node and your backend
 
@@ -76,6 +86,7 @@ curl -s http://localhost:8082/healthcheck | jq '.models'
 | `no_bid` | Configured but no active bid; **not probed** |
 | `no_model_configured` | Active bid but no `models-config.json` entry — consumers can open sessions against this bid and get errors |
 | `skipped` | Model type not probeable (TTS, image, video) |
+| `tee_unverified` | `tee`-tagged model whose backend TEE attestation failed or never succeeded; **not probed**, and session requests for it are rejected |
 
 For `unhealthy` models, the diagnosis is the combination of `errorKind` and `httpStatus`:
 
@@ -89,6 +100,8 @@ For `unhealthy` models, the diagnosis is the combination of `errorKind` and `htt
 | `bad_response` | `401` / `403` | Bad or expired `apiKey` |
 | `bad_response` | `5xx` | Upstream itself is failing |
 | `bad_response` | *(absent)* | Backend returned 200 but an empty/invalid completion |
+| `session_errors` | — | Flipped by consecutive real-session prompt failures (see [Live signals](#live-signals-between-sweeps)), not by a probe |
+| `tee_attestation` | — | Accompanies `tee_unverified`: the backend TEE attestation is not currently passed |
 
 A `healthy` model with `promptCorrect: false` deserves attention too: the backend responds, but the model can't answer 2-digit addition — usually the `apiUrl`/`modelName` pair is wired to the wrong model.
 

--- a/docs/proxy-router.all.env
+++ b/docs/proxy-router.all.env
@@ -91,6 +91,9 @@ MODEL_HEALTH_CHECK_DISABLED=false
 MODEL_HEALTH_CHECK_INTERVAL=1h
 # Per-model probe timeout (default 60s)
 MODEL_HEALTH_CHECK_TIMEOUT=60s
+# Consecutive real-session prompt failures after which a model is reported
+# unhealthy immediately, without waiting for the next scheduled probe (default 3)
+MODEL_HEALTH_MAX_CONSECUTIVE_ERRORS=3
 
 # System Configurations
 # Enable system-level configuration adjustments

--- a/docs/reference/env-proxy-router.mdx
+++ b/docs/reference/env-proxy-router.mdx
@@ -183,6 +183,7 @@ On provider nodes the proxy-router periodically probes every model from `models-
 | `MODEL_HEALTH_CHECK_INTERVAL` | `1h` | How often models are probed; results are cached between runs |
 | `MODEL_HEALTH_CHECK_TIMEOUT` | `60s` | Per-model probe timeout |
 | `MODEL_HEALTH_CHECK_PROBE_DELAY` | `2s` | Pause between per-model probes so many-model providers don't burst their upstream into a rate limit |
+| `MODEL_HEALTH_MAX_CONSECUTIVE_ERRORS` | `3` | Consecutive real-session prompt failures after which the model is reported `unhealthy` (`errorKind: session_errors`) immediately, without waiting for the next scheduled probe |
 
 ## TEE (Phase 1 + Phase 2 attestation)
 

--- a/proxy-router/cmd/main.go
+++ b/proxy-router/cmd/main.go
@@ -386,7 +386,8 @@ func start() error {
 			Bids:         blockchainApi,
 			Models:       blockchainApi,
 			ModelConfigs: modelConfigLoader,
-		}, cfg.Proxy.ModelHealthCheckInterval, cfg.Proxy.ModelHealthCheckTimeout, cfg.Proxy.ModelHealthCheckProbeDelay, appLog)
+			TeeStatus:    backendVerifier,
+		}, cfg.Proxy.ModelHealthCheckInterval, cfg.Proxy.ModelHealthCheckTimeout, cfg.Proxy.ModelHealthCheckProbeDelay, cfg.Proxy.ModelHealthMaxConsecErrors, appLog)
 		modelHealthReporter = modelHealthChecker
 	}
 

--- a/proxy-router/internal/blockchainapi/model_health_gate_test.go
+++ b/proxy-router/internal/blockchainapi/model_health_gate_test.go
@@ -1,0 +1,37 @@
+package blockchainapi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/system"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockingModelHealthStatus(t *testing.T) {
+	modelID := common.HexToHash("0x01")
+	otherID := common.HexToHash("0x02")
+
+	tests := []struct {
+		name    string
+		reports []system.ModelHealthReport
+		want    string
+	}{
+		{"no reports (pre-upgrade provider)", nil, ""},
+		{"model not in report", []system.ModelHealthReport{{ModelID: otherID.Hex(), Status: system.ModelHealthStatusUnhealthy}}, ""},
+		{"healthy", []system.ModelHealthReport{{ModelID: modelID.Hex(), Status: system.ModelHealthStatusHealthy}}, ""},
+		{"skipped (non-probeable type)", []system.ModelHealthReport{{ModelID: modelID.Hex(), Status: system.ModelHealthStatusSkipped}}, ""},
+		{"no_bid (stale self-report)", []system.ModelHealthReport{{ModelID: modelID.Hex(), Status: system.ModelHealthStatusNoBid}}, ""},
+		{"unhealthy", []system.ModelHealthReport{{ModelID: modelID.Hex(), Status: system.ModelHealthStatusUnhealthy}}, system.ModelHealthStatusUnhealthy},
+		{"tee_unverified", []system.ModelHealthReport{{ModelID: modelID.Hex(), Status: system.ModelHealthStatusTeeUnverified}}, system.ModelHealthStatusTeeUnverified},
+		{"no_model_configured", []system.ModelHealthReport{{ModelID: modelID.Hex(), Status: system.ModelHealthStatusNoModel}}, system.ModelHealthStatusNoModel},
+		{"case-insensitive model ID match", []system.ModelHealthReport{{ModelID: strings.ToUpper(modelID.Hex()), Status: system.ModelHealthStatusUnhealthy}}, system.ModelHealthStatusUnhealthy},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, blockingModelHealthStatus(tt.reports, modelID))
+		})
+	}
+}

--- a/proxy-router/internal/blockchainapi/service.go
+++ b/proxy-router/internal/blockchainapi/service.go
@@ -1204,6 +1204,11 @@ func (s *BlockchainService) GetTransactions(ctx context.Context, page uint64, li
 	return allTrxs, nil
 }
 
+// OpenSessionByBidId opens a session against a specific bid (no provider failover).
+func (s *BlockchainService) OpenSessionByBidId(ctx context.Context, bidID common.Hash, duration *big.Int, agentUsername string) (common.Hash, error) {
+	return s.openSessionByBid(ctx, bidID, duration, agentUsername)
+}
+
 func (s *BlockchainService) openSessionByBid(ctx context.Context, bidID common.Hash, duration *big.Int, agentUsername string) (common.Hash, error) {
 	supply, err := s.GetTokenSupply(ctx)
 	if err != nil {

--- a/proxy-router/internal/blockchainapi/service.go
+++ b/proxy-router/internal/blockchainapi/service.go
@@ -113,6 +113,9 @@ var (
 
 	ErrNoBid = errors.New("no bids available")
 	ErrModel = errors.New("can't get model")
+
+	ErrProviderUnreachable    = errors.New("provider healthcheck ping failed")
+	ErrProviderModelUnhealthy = errors.New("provider self-reports model as not serviceable")
 )
 
 func NewBlockchainService(
@@ -1437,6 +1440,22 @@ func (s *BlockchainService) tryOpenSession(ctx context.Context, bid *structs.Bid
 		return common.Hash{}, false, lib.WrapError(ErrProvider, err)
 	}
 
+	// Healthcheck ping before opening the session: verifies the provider is
+	// reachable and inspects its model health self-report from the pong. A
+	// provider that answers but reports the bid's model as not serviceable
+	// is skipped the same way an unreachable one is.
+	pingCtx, cancelPing := context.WithTimeout(ctx, proxyapi.TimeoutPingDefault)
+	_, _, models, err := s.proxyService.Ping(pingCtx, provider.Endpoint, bid.Provider)
+	cancelPing()
+	if err != nil {
+		log.Warnf("provider %s healthcheck ping failed: %s", bid.Provider, err)
+		return common.Hash{}, true, lib.WrapError(ErrProviderUnreachable, err)
+	}
+	if status := blockingModelHealthStatus(models, bid.ModelAgentId); status != "" {
+		log.Warnf("provider %s reports model %s as %s, skipping", bid.Provider, bid.ModelAgentId, status)
+		return common.Hash{}, true, lib.WrapError(ErrProviderModelUnhealthy, fmt.Errorf("model %s status: %s", bid.ModelAgentId, status))
+	}
+
 	if isTeeSession && s.attestationVerifier != nil {
 		if err := s.attestationVerifier.VerifyProviderQuick(ctx, provider.Endpoint, bid.Provider.Hex(), true); err != nil {
 			log.Warnf("TEE attestation failed for provider %s: %s", bid.Provider, err)
@@ -1470,6 +1489,28 @@ func (s *BlockchainService) tryOpenSession(ctx context.Context, bid *structs.Bid
 	}
 
 	return hash, false, nil
+}
+
+// blockingModelHealthStatus inspects the provider's model health self-report
+// (from the healthcheck pong) and returns the reported status when it means a
+// session for the model would not be serviceable: the model backend is
+// unhealthy, its backend TEE attestation failed, or the provider has a bid
+// but no backend configured for the model. An empty result means the session
+// open may proceed — including when the report is absent (pre-upgrade
+// provider or health checks disabled), since absence of data is not evidence
+// of failure.
+func blockingModelHealthStatus(models []system.ModelHealthReport, modelID common.Hash) string {
+	for _, report := range models {
+		if !strings.EqualFold(report.ModelID, modelID.Hex()) {
+			continue
+		}
+		switch report.Status {
+		case system.ModelHealthStatusUnhealthy, system.ModelHealthStatusTeeUnverified, system.ModelHealthStatusNoModel:
+			return report.Status
+		}
+		return ""
+	}
+	return ""
 }
 
 func (s *BlockchainService) GetMyAddress(ctx context.Context) (common.Address, error) {

--- a/proxy-router/internal/config/config.go
+++ b/proxy-router/internal/config/config.go
@@ -78,6 +78,7 @@ type Config struct {
 		ModelHealthCheckInterval   time.Duration `env:"MODEL_HEALTH_CHECK_INTERVAL" flag:"model-health-check-interval" validate:"omitempty,duration" desc:"how often to probe configured models with a test prompt, result is cached between runs"`
 		ModelHealthCheckTimeout    time.Duration `env:"MODEL_HEALTH_CHECK_TIMEOUT" flag:"model-health-check-timeout" validate:"omitempty,duration" desc:"per-model health probe timeout"`
 		ModelHealthCheckProbeDelay time.Duration `env:"MODEL_HEALTH_CHECK_PROBE_DELAY" flag:"model-health-check-probe-delay" validate:"omitempty,duration" desc:"pause between per-model health probes so many-model providers don't burst their upstream and trip rate limits"`
+		ModelHealthMaxConsecErrors int           `env:"MODEL_HEALTH_MAX_CONSECUTIVE_ERRORS" flag:"model-health-max-consecutive-errors" validate:"omitempty,gte=1" desc:"consecutive session prompt failures after which a model is immediately reported unhealthy, without waiting for the next scheduled probe"`
 	}
 	System struct {
 		Enable           bool   `env:"SYS_ENABLE"              flag:"sys-enable" desc:"enable system level configuration adjustments"`
@@ -222,6 +223,9 @@ func (cfg *Config) SetDefaults() {
 	if cfg.Proxy.ModelHealthCheckProbeDelay == 0 {
 		cfg.Proxy.ModelHealthCheckProbeDelay = 2 * time.Second
 	}
+	if cfg.Proxy.ModelHealthMaxConsecErrors == 0 {
+		cfg.Proxy.ModelHealthMaxConsecErrors = 3
+	}
 
 	// IPFS
 	if cfg.IPFS.Address == "" {
@@ -283,6 +287,7 @@ func (cfg *Config) GetSanitized() interface{} {
 	publicCfg.Proxy.ModelHealthCheckInterval = cfg.Proxy.ModelHealthCheckInterval
 	publicCfg.Proxy.ModelHealthCheckTimeout = cfg.Proxy.ModelHealthCheckTimeout
 	publicCfg.Proxy.ModelHealthCheckProbeDelay = cfg.Proxy.ModelHealthCheckProbeDelay
+	publicCfg.Proxy.ModelHealthMaxConsecErrors = cfg.Proxy.ModelHealthMaxConsecErrors
 
 	publicCfg.System.Enable = cfg.System.Enable
 	publicCfg.System.LocalPortRange = cfg.System.LocalPortRange

--- a/proxy-router/internal/modelhealth/checker.go
+++ b/proxy-router/internal/modelhealth/checker.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/aiengine"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/attestation"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/blockchainapi"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/blockchainapi/structs"
 	gcs "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/chatstorage/genericchatstorage"
@@ -56,11 +57,23 @@ type ModelConfigProvider interface {
 	GetAll() ([]common.Hash, []config.ModelConfig)
 }
 
+// TeeStatusProvider exposes the cached backend TEE attestation state
+// (implemented by attestation.BackendVerifier). Optional dependency.
+type TeeStatusProvider interface {
+	GetStatus(modelID string) *attestation.BackendAttestationSnapshot
+}
+
+// DefaultMaxConsecutiveErrors is the number of consecutive real-session
+// prompt failures after which a model is flipped to unhealthy without
+// waiting for the next scheduled probe sweep.
+const DefaultMaxConsecutiveErrors = 3
+
 // modelMeta caches the public on-chain facts about a model so each sweep
 // only pays one registry call per previously unseen model.
 type modelMeta struct {
 	name      string
 	modelType structs.ModelType
+	isTee     bool
 }
 
 type Checker struct {
@@ -68,11 +81,16 @@ type Checker struct {
 	interval   time.Duration
 	timeout    time.Duration
 	probeDelay time.Duration
-	log        lib.ILogger
+	// maxConsecutiveErrors is the threshold of consecutive session prompt
+	// failures that dynamically flips a model to unhealthy.
+	maxConsecutiveErrors int
+	log                  lib.ILogger
 
 	mu        sync.RWMutex
 	reports   map[string]system.ModelHealthReport
 	modelMeta map[string]modelMeta
+	// failures counts consecutive real-session prompt failures per model.
+	failures map[string]int
 
 	// triggerCh carries manual re-check requests into the Run loop; buffered
 	// at 1 so triggers queue at most one extra sweep and can never overlap.
@@ -85,18 +103,26 @@ type Deps struct {
 	Bids         BidProvider
 	Models       ModelMetaProvider
 	ModelConfigs ModelConfigProvider
+	// TeeStatus is optional; when set, TEE-tagged models whose backend
+	// attestation is not currently passed are reported as tee_unverified.
+	TeeStatus TeeStatusProvider
 }
 
-func NewChecker(deps Deps, interval, timeout, probeDelay time.Duration, log lib.ILogger) *Checker {
+func NewChecker(deps Deps, interval, timeout, probeDelay time.Duration, maxConsecutiveErrors int, log lib.ILogger) *Checker {
+	if maxConsecutiveErrors <= 0 {
+		maxConsecutiveErrors = DefaultMaxConsecutiveErrors
+	}
 	return &Checker{
-		deps:       deps,
-		interval:   interval,
-		timeout:    timeout,
-		probeDelay: probeDelay,
-		log:        log.Named("MODEL_HEALTH"),
-		reports:    make(map[string]system.ModelHealthReport),
-		modelMeta:  make(map[string]modelMeta),
-		triggerCh:  make(chan struct{}, 1),
+		deps:                 deps,
+		interval:             interval,
+		timeout:              timeout,
+		probeDelay:           probeDelay,
+		maxConsecutiveErrors: maxConsecutiveErrors,
+		log:                  log.Named("MODEL_HEALTH"),
+		reports:              make(map[string]system.ModelHealthReport),
+		modelMeta:            make(map[string]modelMeta),
+		failures:             make(map[string]int),
+		triggerCh:            make(chan struct{}, 1),
 	}
 }
 
@@ -318,6 +344,20 @@ func (c *Checker) checkModel(ctx context.Context, modelID common.Hash, bidID com
 	report.ModelName = meta.name
 	report.ModelType = string(meta.modelType)
 
+	// A TEE-tagged model whose backend attestation is not currently passed
+	// cannot serve sessions (session requests are rejected by the receiver),
+	// so report it as tee_unverified and skip the backend probe.
+	if meta.isTee && c.deps.TeeStatus != nil {
+		snapshot := c.deps.TeeStatus.GetStatus(modelID.Hex())
+		if snapshot == nil || snapshot.Status != attestation.StatusPassed {
+			c.log.Warnf("model %s: backend TEE attestation is not passed, reporting tee_unverified", lib.Short(modelID))
+			report.Status = system.ModelHealthStatusTeeUnverified
+			report.ErrorKind = system.ModelHealthErrorTeeAttestation
+			c.setReport(report)
+			return
+		}
+	}
+
 	var probe func(ctx context.Context, adapter aiengine.AIEngineStream, report *system.ModelHealthReport) error
 	switch meta.modelType {
 	case structs.ModelTypeLLM:
@@ -360,6 +400,9 @@ func (c *Checker) checkModel(ctx context.Context, modelID common.Hash, bidID com
 	} else {
 		report.Status = system.ModelHealthStatusHealthy
 		report.LastHealthy = time.Now().Unix()
+		// A passing probe is direct evidence the backend works again, so the
+		// consecutive session-failure streak (if any) is over.
+		c.resetFailures(modelID)
 	}
 
 	c.setReport(report)
@@ -449,7 +492,7 @@ func (c *Checker) modelMetaFor(ctx context.Context, modelID common.Hash) (modelM
 		return modelMeta{}, err
 	}
 
-	meta := modelMeta{name: name, modelType: blockchainapi.DetectModelType(tags)}
+	meta := modelMeta{name: name, modelType: blockchainapi.DetectModelType(tags), isTee: blockchainapi.IsTeeModel(tags)}
 
 	c.mu.Lock()
 	c.modelMeta[modelID.Hex()] = meta
@@ -468,6 +511,93 @@ func (c *Checker) setReport(report system.ModelHealthReport) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.reports[report.ModelID] = report
+}
+
+// ReportPromptFailure records a failed real-session prompt for the model.
+// After maxConsecutiveErrors failures in a row the model's health report is
+// flipped to unhealthy immediately, without waiting for the next scheduled
+// probe sweep, so consumers pinging before session open skip this provider.
+func (c *Checker) ReportPromptFailure(modelID common.Hash) {
+	id := modelID.Hex()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.failures[id]++
+	count := c.failures[id]
+	if count < c.maxConsecutiveErrors {
+		c.log.Warnf("model %s: session prompt failed (%d/%d consecutive)", lib.Short(modelID), count, c.maxConsecutiveErrors)
+		return
+	}
+
+	report, ok := c.reports[id]
+	if !ok {
+		// A session prompt implies the model has (or had) an active bid even
+		// if no sweep has reported on it yet.
+		report = system.ModelHealthReport{ModelID: id, HasActiveBid: true}
+	}
+	if report.Status != system.ModelHealthStatusUnhealthy {
+		c.log.Warnf("model %s: %d consecutive session prompt failures, marking unhealthy", lib.Short(modelID), count)
+	}
+	report.Status = system.ModelHealthStatusUnhealthy
+	report.ErrorKind = system.ModelHealthErrorSessionErrors
+	report.LastChecked = time.Now().Unix()
+	c.reports[id] = report
+}
+
+// ReportPromptSuccess records a successful real-session prompt: the failure
+// streak resets and, if the model was flipped to unhealthy by session errors,
+// it is healed right away (a real prompt succeeding is stronger evidence than
+// a probe).
+func (c *Checker) ReportPromptSuccess(modelID common.Hash) {
+	id := modelID.Hex()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	delete(c.failures, id)
+
+	report, ok := c.reports[id]
+	if !ok {
+		return
+	}
+	if report.Status == system.ModelHealthStatusUnhealthy && report.ErrorKind == system.ModelHealthErrorSessionErrors {
+		report.Status = system.ModelHealthStatusHealthy
+		report.ErrorKind = ""
+		report.LastChecked = time.Now().Unix()
+	}
+	report.LastHealthy = time.Now().Unix()
+	c.reports[id] = report
+}
+
+// ReportTeeFailure immediately marks the model as tee_unverified after a
+// failed backend TEE self-verification, without waiting for the next
+// scheduled probe sweep. The status heals on a later sweep once the backend
+// attestation passes again.
+func (c *Checker) ReportTeeFailure(modelID common.Hash) {
+	id := modelID.Hex()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	report, ok := c.reports[id]
+	if !ok {
+		report = system.ModelHealthReport{ModelID: id, HasActiveBid: true}
+	}
+	if report.Status != system.ModelHealthStatusTeeUnverified {
+		c.log.Warnf("model %s: backend TEE self-verification failed, marking tee_unverified", lib.Short(modelID))
+	}
+	report.Status = system.ModelHealthStatusTeeUnverified
+	report.ErrorKind = system.ModelHealthErrorTeeAttestation
+	report.LastChecked = time.Now().Unix()
+	c.reports[id] = report
+}
+
+// resetFailures clears the consecutive session-failure counter for a model.
+func (c *Checker) resetFailures(modelID common.Hash) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.failures, modelID.Hex())
 }
 
 // generateArithmeticPrompt returns two random small numbers and a prompt

--- a/proxy-router/internal/modelhealth/checker_test.go
+++ b/proxy-router/internal/modelhealth/checker_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/aiengine"
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/attestation"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/blockchainapi/structs"
 	gcs "github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/chatstorage/genericchatstorage"
 	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/config"
@@ -71,6 +72,16 @@ type mockDeps struct {
 	modelIDs   []common.Hash
 	adapter    aiengine.AIEngineStream
 	adapterErr error
+	teeStatus  TeeStatusProvider
+}
+
+// mockTeeStatus returns canned backend attestation snapshots per model.
+type mockTeeStatus struct {
+	snapshots map[string]*attestation.BackendAttestationSnapshot
+}
+
+func (m *mockTeeStatus) GetStatus(modelID string) *attestation.BackendAttestationSnapshot {
+	return m.snapshots[modelID]
 }
 
 func (m *mockDeps) GetActiveBidsByProvider(ctx context.Context, provider common.Address, offset *big.Int, limit uint8, order registries.Order) ([]*structs.Bid, error) {
@@ -155,7 +166,8 @@ func newTestChecker(deps *mockDeps) *Checker {
 		Bids:         deps,
 		Models:       deps,
 		ModelConfigs: deps,
-	}, time.Hour, time.Second, 0, lib.NewTestLogger())
+		TeeStatus:    deps.teeStatus,
+	}, time.Hour, time.Second, 0, 0, lib.NewTestLogger())
 }
 
 func reportByID(t *testing.T, reports []system.ModelHealthReport, modelID common.Hash) system.ModelHealthReport {
@@ -421,6 +433,164 @@ func TestRunConsumesTrigger(t *testing.T) {
 
 	cancel()
 	<-done
+}
+
+func TestCheckAllTeeModelAttestationGate(t *testing.T) {
+	teeDeps := func(status TeeStatusProvider) *mockDeps {
+		return &mockDeps{
+			bids:      []*structs.Bid{bidFor(modelLLM)},
+			tags:      map[common.Hash][]string{modelLLM: {"llm", "tee"}},
+			modelIDs:  []common.Hash{modelLLM},
+			adapter:   &mathSolvingAdapter{},
+			teeStatus: status,
+		}
+	}
+
+	t.Run("failed attestation reports tee_unverified and skips the probe", func(t *testing.T) {
+		deps := teeDeps(&mockTeeStatus{snapshots: map[string]*attestation.BackendAttestationSnapshot{
+			modelLLM.Hex(): {ModelID: modelLLM.Hex(), Status: attestation.StatusFailed},
+		}})
+		checker := newTestChecker(deps)
+		checker.checkAll(context.Background(), common.Address{})
+
+		llm := reportByID(t, checker.GetReports(), modelLLM)
+		require.Equal(t, system.ModelHealthStatusTeeUnverified, llm.Status)
+		require.Equal(t, system.ModelHealthErrorTeeAttestation, llm.ErrorKind)
+		require.Nil(t, llm.PromptCorrect, "backend must not be probed when TEE attestation failed")
+	})
+
+	t.Run("missing snapshot reports tee_unverified", func(t *testing.T) {
+		deps := teeDeps(&mockTeeStatus{snapshots: map[string]*attestation.BackendAttestationSnapshot{}})
+		checker := newTestChecker(deps)
+		checker.checkAll(context.Background(), common.Address{})
+
+		llm := reportByID(t, checker.GetReports(), modelLLM)
+		require.Equal(t, system.ModelHealthStatusTeeUnverified, llm.Status)
+	})
+
+	t.Run("passed attestation probes normally", func(t *testing.T) {
+		deps := teeDeps(&mockTeeStatus{snapshots: map[string]*attestation.BackendAttestationSnapshot{
+			modelLLM.Hex(): {ModelID: modelLLM.Hex(), Status: attestation.StatusPassed},
+		}})
+		checker := newTestChecker(deps)
+		checker.checkAll(context.Background(), common.Address{})
+
+		llm := reportByID(t, checker.GetReports(), modelLLM)
+		require.Equal(t, system.ModelHealthStatusHealthy, llm.Status)
+		require.NotNil(t, llm.PromptCorrect)
+	})
+
+	t.Run("no TEE status provider probes normally", func(t *testing.T) {
+		deps := teeDeps(nil)
+		checker := newTestChecker(deps)
+		checker.checkAll(context.Background(), common.Address{})
+
+		llm := reportByID(t, checker.GetReports(), modelLLM)
+		require.Equal(t, system.ModelHealthStatusHealthy, llm.Status)
+	})
+}
+
+func TestReportPromptFailureFlipsAfterThreshold(t *testing.T) {
+	deps := &mockDeps{
+		bids:     []*structs.Bid{bidFor(modelLLM)},
+		tags:     map[common.Hash][]string{modelLLM: {"llm"}},
+		modelIDs: []common.Hash{modelLLM},
+		adapter:  &mathSolvingAdapter{},
+	}
+	checker := newTestChecker(deps) // threshold defaults to 3
+	checker.checkAll(context.Background(), common.Address{})
+	require.Equal(t, system.ModelHealthStatusHealthy, reportByID(t, checker.GetReports(), modelLLM).Status)
+
+	checker.ReportPromptFailure(modelLLM)
+	checker.ReportPromptFailure(modelLLM)
+	require.Equal(t, system.ModelHealthStatusHealthy, reportByID(t, checker.GetReports(), modelLLM).Status,
+		"below the threshold the status must not change")
+
+	checker.ReportPromptFailure(modelLLM)
+	llm := reportByID(t, checker.GetReports(), modelLLM)
+	require.Equal(t, system.ModelHealthStatusUnhealthy, llm.Status)
+	require.Equal(t, system.ModelHealthErrorSessionErrors, llm.ErrorKind)
+}
+
+func TestReportPromptSuccessResetsStreakAndHeals(t *testing.T) {
+	deps := &mockDeps{
+		bids:     []*structs.Bid{bidFor(modelLLM)},
+		tags:     map[common.Hash][]string{modelLLM: {"llm"}},
+		modelIDs: []common.Hash{modelLLM},
+		adapter:  &mathSolvingAdapter{},
+	}
+	checker := newTestChecker(deps)
+	checker.checkAll(context.Background(), common.Address{})
+
+	// success in the middle of a streak resets the counter
+	checker.ReportPromptFailure(modelLLM)
+	checker.ReportPromptFailure(modelLLM)
+	checker.ReportPromptSuccess(modelLLM)
+	checker.ReportPromptFailure(modelLLM)
+	checker.ReportPromptFailure(modelLLM)
+	require.Equal(t, system.ModelHealthStatusHealthy, reportByID(t, checker.GetReports(), modelLLM).Status)
+
+	// third consecutive failure flips it...
+	checker.ReportPromptFailure(modelLLM)
+	require.Equal(t, system.ModelHealthStatusUnhealthy, reportByID(t, checker.GetReports(), modelLLM).Status)
+
+	// ...and a successful real prompt heals it right away
+	checker.ReportPromptSuccess(modelLLM)
+	llm := reportByID(t, checker.GetReports(), modelLLM)
+	require.Equal(t, system.ModelHealthStatusHealthy, llm.Status)
+	require.Empty(t, llm.ErrorKind)
+	require.NotZero(t, llm.LastHealthy)
+}
+
+func TestHealthyProbeResetsFailureStreak(t *testing.T) {
+	deps := &mockDeps{
+		bids:     []*structs.Bid{bidFor(modelLLM)},
+		tags:     map[common.Hash][]string{modelLLM: {"llm"}},
+		modelIDs: []common.Hash{modelLLM},
+		adapter:  &mathSolvingAdapter{},
+	}
+	checker := newTestChecker(deps)
+
+	checker.ReportPromptFailure(modelLLM)
+	checker.ReportPromptFailure(modelLLM)
+
+	// a healthy scheduled sweep clears the streak: two more failures stay
+	// below the threshold again
+	checker.checkAll(context.Background(), common.Address{})
+	checker.ReportPromptFailure(modelLLM)
+	checker.ReportPromptFailure(modelLLM)
+	require.Equal(t, system.ModelHealthStatusHealthy, reportByID(t, checker.GetReports(), modelLLM).Status)
+}
+
+func TestReportPromptFailureWithoutPriorReport(t *testing.T) {
+	checker := newTestChecker(&mockDeps{})
+
+	for i := 0; i < DefaultMaxConsecutiveErrors; i++ {
+		checker.ReportPromptFailure(modelLLM)
+	}
+
+	llm := reportByID(t, checker.GetReports(), modelLLM)
+	require.Equal(t, system.ModelHealthStatusUnhealthy, llm.Status)
+	require.Equal(t, system.ModelHealthErrorSessionErrors, llm.ErrorKind)
+	require.True(t, llm.HasActiveBid)
+}
+
+func TestReportTeeFailureImmediate(t *testing.T) {
+	deps := &mockDeps{
+		bids:     []*structs.Bid{bidFor(modelLLM)},
+		tags:     map[common.Hash][]string{modelLLM: {"llm"}},
+		modelIDs: []common.Hash{modelLLM},
+		adapter:  &mathSolvingAdapter{},
+	}
+	checker := newTestChecker(deps)
+	checker.checkAll(context.Background(), common.Address{})
+	require.Equal(t, system.ModelHealthStatusHealthy, reportByID(t, checker.GetReports(), modelLLM).Status)
+
+	checker.ReportTeeFailure(modelLLM)
+
+	llm := reportByID(t, checker.GetReports(), modelLLM)
+	require.Equal(t, system.ModelHealthStatusTeeUnverified, llm.Status)
+	require.Equal(t, system.ModelHealthErrorTeeAttestation, llm.ErrorKind)
 }
 
 func TestCheckAllBidsError(t *testing.T) {

--- a/proxy-router/internal/proxyapi/model_health_tracking_test.go
+++ b/proxy-router/internal/proxyapi/model_health_tracking_test.go
@@ -1,0 +1,60 @@
+package proxyapi
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type fakeHealthTracker struct {
+	successes int
+	failures  int
+	tee       int
+}
+
+func (f *fakeHealthTracker) ReportPromptSuccess(modelID common.Hash) { f.successes++ }
+func (f *fakeHealthTracker) ReportPromptFailure(modelID common.Hash) { f.failures++ }
+func (f *fakeHealthTracker) ReportTeeFailure(modelID common.Hash)    { f.tee++ }
+
+func TestTrackPromptResult(t *testing.T) {
+	modelID := common.HexToHash("0x01")
+
+	tests := []struct {
+		name          string
+		transportErr  error
+		engineStatus  int
+		gotEngineErr  bool
+		wantSuccesses int
+		wantFailures  int
+	}{
+		{"clean completion counts as success", nil, 0, false, 1, 0},
+		{"transport error counts as failure", errors.New("connection refused"), 0, false, 0, 1},
+		{"backend 500 counts as failure", nil, 500, true, 0, 1},
+		{"backend 402 (billing) counts as failure", nil, 402, true, 0, 1},
+		{"backend 429 (rate limit) counts as failure", nil, 429, true, 0, 1},
+		{"unknown status error counts as failure", nil, 0, true, 0, 1},
+		{"client-fault 400 counts as neither", nil, 400, true, 0, 0},
+		{"client-fault 422 counts as neither", nil, 422, true, 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker := &fakeHealthTracker{}
+			r := &ProxyReceiver{modelHealth: tracker}
+			r.trackPromptResult(modelID, tt.transportErr, tt.engineStatus, tt.gotEngineErr)
+			if tracker.successes != tt.wantSuccesses {
+				t.Errorf("successes = %d, want %d", tracker.successes, tt.wantSuccesses)
+			}
+			if tracker.failures != tt.wantFailures {
+				t.Errorf("failures = %d, want %d", tracker.failures, tt.wantFailures)
+			}
+		})
+	}
+}
+
+func TestTrackPromptResultNilTrackerIsNoop(t *testing.T) {
+	r := &ProxyReceiver{}
+	// must not panic when no tracker is wired (health checks disabled)
+	r.trackPromptResult(common.HexToHash("0x01"), errors.New("boom"), 0, false)
+}

--- a/proxy-router/internal/proxyapi/proxy_receiver.go
+++ b/proxy-router/internal/proxyapi/proxy_receiver.go
@@ -25,6 +25,16 @@ type BackendTEEVerifier interface {
 	FastVerifyBackend(ctx context.Context, modelID string) error
 }
 
+// ModelHealthTracker receives live health signals from real session traffic
+// so the model health self-report reflects failures immediately instead of
+// waiting for the next scheduled probe sweep (implemented by
+// modelhealth.Checker).
+type ModelHealthTracker interface {
+	ReportPromptSuccess(modelID common.Hash)
+	ReportPromptFailure(modelID common.Hash)
+	ReportTeeFailure(modelID common.Hash)
+}
+
 // ModelTagsProvider fetches blockchain model tags for TEE tag detection.
 type ModelTagsProvider interface {
 	GetModelTags(ctx context.Context, modelID common.Hash) ([]string, error)
@@ -42,6 +52,7 @@ type ProxyReceiver struct {
 	sessionRepo       *sessionrepo.SessionRepositoryCached
 	backendVerifier   BackendTEEVerifier
 	modelTagsProvider ModelTagsProvider
+	modelHealth       ModelHealthTracker
 }
 
 func NewProxyReceiver(privateKeyHex, publicKeyHex lib.HexString, sessionStorage *storages.SessionStorage, aiEngine *aiengine.AiEngine, chainID *big.Int, modelConfigLoader *config.ModelConfigLoader, blockchainService BidGetter, sessionRepo *sessionrepo.SessionRepositoryCached) *ProxyReceiver {
@@ -66,6 +77,45 @@ func (s *ProxyReceiver) SetModelTagsProvider(p ModelTagsProvider) {
 	s.modelTagsProvider = p
 }
 
+func (s *ProxyReceiver) SetModelHealthTracker(t ModelHealthTracker) {
+	s.modelHealth = t
+}
+
+// isBackendFaultStatus reports whether an upstream error status indicates a
+// problem with the model backend (or its configuration/billing) rather than
+// with the consumer's request. Client-fault statuses (bad payload, too large,
+// unprocessable) must not count towards the consecutive failure streak,
+// otherwise a misbehaving consumer could flip a healthy model to unhealthy.
+func isBackendFaultStatus(status int) bool {
+	switch status {
+	case 400, 403, 413, 422:
+		return false
+	}
+	return true
+}
+
+// trackPromptResult feeds the outcome of a real session prompt into the model
+// health tracker. engineErrStatus is the upstream HTTP status captured from
+// an AiEngineErrorResponse (0 when the backend never returned an error
+// response).
+func (s *ProxyReceiver) trackPromptResult(modelID common.Hash, transportErr error, engineErrStatus int, gotEngineErr bool) {
+	if s.modelHealth == nil {
+		return
+	}
+	if transportErr != nil {
+		s.modelHealth.ReportPromptFailure(modelID)
+		return
+	}
+	if gotEngineErr {
+		if isBackendFaultStatus(engineErrStatus) {
+			s.modelHealth.ReportPromptFailure(modelID)
+		}
+		// client-fault errors count neither as failure nor success
+		return
+	}
+	s.modelHealth.ReportPromptSuccess(modelID)
+}
+
 func (s *ProxyReceiver) isTeeModel(ctx context.Context, modelID common.Hash) bool {
 	if s.modelTagsProvider == nil {
 		return false
@@ -84,7 +134,7 @@ func (s *ProxyReceiver) isTeeModel(ctx context.Context, modelID common.Hash) boo
 
 // handleSessionError is a helper function to log errors and return consistent output
 func handleError(err error, message string, sourceLog lib.ILogger) (int, int, int, error) {
-	wrappedErr := lib.WrapError(fmt.Errorf(message), err)
+	wrappedErr := lib.WrapError(fmt.Errorf("%s", message), err)
 	sourceLog.Error(wrappedErr)
 	return 0, 0, 0, wrappedErr
 }
@@ -180,6 +230,7 @@ func (s *ProxyReceiver) createCompletionCallback(
 	outputTokens *int,
 	promptTokens int,
 	sendResponse SendResponse,
+	engineErr *engineErrCapture,
 ) genericchatstorage.CompletionCallback {
 	// Track accumulated content for streaming responses. Reasoning ("thinking")
 	// tokens are accumulated separately and folded into completion_tokens so
@@ -189,6 +240,10 @@ func (s *ProxyReceiver) createCompletionCallback(
 
 	return func(ctx context.Context, completion genericchatstorage.Chunk, aiEngineErrorResponse *genericchatstorage.AiEngineErrorResponse) error {
 		if aiEngineErrorResponse != nil {
+			if engineErr != nil {
+				engineErr.got = true
+				engineErr.status = aiEngineErrorResponse.StatusCode
+			}
 			marshalledResponse, err := json.Marshal(aiEngineErrorResponse)
 			if err != nil {
 				return err
@@ -294,6 +349,13 @@ func (s *ProxyReceiver) createCompletionCallback(
 	}
 }
 
+// engineErrCapture records whether the backend returned an error response
+// during a prompt and with which upstream HTTP status (0 when unknown).
+type engineErrCapture struct {
+	got    bool
+	status int
+}
+
 // recordActivity records the session activity
 func (s *ProxyReceiver) recordActivity(ctx context.Context, session *sessionrepo.SessionModel, startTime int64, sourceLog lib.ILogger) {
 	activity := storages.PromptActivity{
@@ -356,6 +418,9 @@ func (s *ProxyReceiver) SessionPrompt(ctx context.Context, requestID string, use
 
 	if s.backendVerifier != nil && session.IsTee() {
 		if verifyErr := s.backendVerifier.FastVerifyBackend(ctx, session.ModelID().Hex()); verifyErr != nil {
+			if s.modelHealth != nil {
+				s.modelHealth.ReportTeeFailure(session.ModelID())
+			}
 			return handleError(verifyErr, "LLM TEE verification failed", sourceLog)
 		}
 	}
@@ -376,7 +441,8 @@ func (s *ProxyReceiver) SessionPrompt(ctx context.Context, requestID string, use
 	}
 
 	// Create completion callback
-	cb := s.createCompletionCallback(ctx, startTime, userPubKey, requestID, sourceLog, &ttftMs, &inputTokens, &outputTokens, promptTokens, sendResponse)
+	engineErr := &engineErrCapture{}
+	cb := s.createCompletionCallback(ctx, startTime, userPubKey, requestID, sourceLog, &ttftMs, &inputTokens, &outputTokens, promptTokens, sendResponse, engineErr)
 
 	// Process request with appropriate adapter method
 	if audioTranscriptionReq != nil {
@@ -392,6 +458,8 @@ func (s *ProxyReceiver) SessionPrompt(ctx context.Context, requestID string, use
 		sourceLog.Infof("Processing chat completion request")
 		err = adapter.Prompt(ctx, chatReq, cb)
 	}
+
+	s.trackPromptResult(session.ModelID(), err, engineErr.status, engineErr.got)
 
 	if err != nil {
 		return handleError(err, "failed to prompt", sourceLog)
@@ -417,6 +485,9 @@ func (s *ProxyReceiver) SessionRequest(ctx context.Context, msgID string, reqID 
 
 	if s.backendVerifier != nil && s.isTeeModel(ctx, bid.ModelAgentId) {
 		if err := s.backendVerifier.FastVerifyBackend(ctx, modelID); err != nil {
+			if s.modelHealth != nil {
+				s.modelHealth.ReportTeeFailure(bid.ModelAgentId)
+			}
 			log.Errorf("LLM TEE verification failed for model %s: %s", modelID, err)
 			return nil, fmt.Errorf("LLM TEE verification failed: %w", err)
 		}

--- a/proxy-router/internal/proxyctl/proxyctl.go
+++ b/proxy-router/internal/proxyctl/proxyctl.go
@@ -200,6 +200,7 @@ func (p *Proxy) run(ctx context.Context, prKey lib.HexString) error {
 	var modelHealthReporter system.ModelHealthReporter
 	if p.modelHealthChecker != nil {
 		modelHealthReporter = p.modelHealthChecker
+		proxyReceiver.SetModelHealthTracker(p.modelHealthChecker)
 	}
 	morTcpHandler := proxyapi.NewMORRPCController(proxyReceiver, p.validator, p.sessionRepo, p.sessionStorage, prKey, modelHealthReporter)
 	tcpHandler := tcphandlers.NewTCPHandler(

--- a/proxy-router/internal/system/structs.go
+++ b/proxy-router/internal/system/structs.go
@@ -30,12 +30,22 @@ const (
 	ModelHealthStatusNoBid     = "no_bid"
 	ModelHealthStatusNoModel   = "no_model_configured"
 	ModelHealthStatusSkipped   = "skipped"
+	// ModelHealthStatusTeeUnverified marks a TEE-tagged model whose backend
+	// TEE self-attestation failed (or never succeeded) on this provider.
+	// Session requests for the model would be rejected, so it is reported
+	// separately from a plain backend probe failure.
+	ModelHealthStatusTeeUnverified = "tee_unverified"
 
 	ModelHealthErrorTimeout     = "timeout"
 	ModelHealthErrorConnection  = "connection"
 	ModelHealthErrorBadResponse = "bad_response"
 	ModelHealthErrorRateLimited = "rate_limited"
 	ModelHealthErrorTypeLookup  = "model_type_lookup"
+	// ModelHealthErrorSessionErrors marks a model flipped to unhealthy by
+	// consecutive real-session prompt failures rather than a scheduled probe.
+	ModelHealthErrorSessionErrors = "session_errors"
+	// ModelHealthErrorTeeAttestation accompanies ModelHealthStatusTeeUnverified.
+	ModelHealthErrorTeeAttestation = "tee_attestation"
 )
 
 // ModelHealthReport is the sanitized per-model self-report exposed on the

--- a/proxy-router/mobile/sdk_sessions.go
+++ b/proxy-router/mobile/sdk_sessions.go
@@ -11,12 +11,39 @@ import (
 // OpenSession opens a session with the best-rated provider for a model.
 // duration is in seconds. Returns the session ID (tx hash).
 func (s *SDK) OpenSession(ctx context.Context, modelID string, durationSec int64, directPayment bool) (string, error) {
+	return s.OpenSessionOmitting(ctx, modelID, durationSec, directPayment, "")
+}
+
+// OpenSessionOmitting opens a session while excluding omitProviderAddr from bid
+// selection. Pass an empty string to consider every rated bid (same as OpenSession).
+// Used by consumer failover after a mid-session provider impairment (429/503/etc.).
+func (s *SDK) OpenSessionOmitting(ctx context.Context, modelID string, durationSec int64, directPayment bool, omitProviderAddr string) (string, error) {
 	if err := s.checkClosed(); err != nil {
 		return "", err
 	}
 	id := common.HexToHash(modelID)
 	dur := big.NewInt(durationSec)
-	txHash, err := s.blockchain.OpenSessionByModelId(ctx, id, dur, directPayment, true, common.Address{}, "")
+	omit := common.Address{}
+	if omitProviderAddr != "" {
+		omit = common.HexToAddress(omitProviderAddr)
+	}
+	txHash, err := s.blockchain.OpenSessionByModelId(ctx, id, dur, directPayment, true, omit, "")
+	if err != nil {
+		return "", err
+	}
+	return txHash.Hex(), nil
+}
+
+// OpenSessionByBid opens a session against a specific bid ID.
+// Unlike OpenSession, there is no multi-provider failover — the chosen bid is
+// the only attempt. Prefer OpenSession / OpenSessionOmitting for normal UX.
+func (s *SDK) OpenSessionByBid(ctx context.Context, bidID string, durationSec int64) (string, error) {
+	if err := s.checkClosed(); err != nil {
+		return "", err
+	}
+	id := common.HexToHash(bidID)
+	dur := big.NewInt(durationSec)
+	txHash, err := s.blockchain.OpenSessionByBidId(ctx, id, dur, "")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## 1. Consumer skips providers with unhealthy models before session open

`tryOpenSession` in `proxy-router/internal/blockchainapi/service.go` now pings the provider (5s timeout) before initiating a session and inspects the `models` self-report already carried in the pong. If the ping fails, or the report marks the bid's model as `unhealthy`, `tee_unverified`, or `no_model_configured`, the provider is skipped with `tryNext=true`, so `OpenSessionByModelId` fails over to the next rated bid (and the reason lands in the failures JSON). A missing report — pre-upgrade provider or health checks disabled — is not treated as evidence of failure and the open proceeds. The status check lives in a new `blockingModelHealthStatus` helper.

## 2. Consecutive session errors flip health state without waiting for the cron

The `modelhealth.Checker` gained live-signal methods, and `ProxyReceiver` (via a new `ModelHealthTracker` interface wired in `proxyctl`) feeds it from real session traffic:

- Every `SessionPrompt` outcome is tracked. Transport errors and backend error responses count as failures; client-fault upstream statuses (`400`, `403`, `413`, `422`) count neither way, so a consumer sending malformed prompts can't flip a healthy model.
- After N consecutive failures (`MODEL_HEALTH_MAX_CONSECUTIVE_ERRORS`, default 3) the report is set to `unhealthy` with a new `errorKind: session_errors` immediately — consumers doing the pre-open ping from item 1 start skipping the provider right away.
- A successful real prompt resets the streak and heals a `session_errors`-flipped model on the spot; a passing scheduled probe also resets the streak.

## 3. Failed TEE self-verification gets its own status

New status `tee_unverified` (`errorKind: tee_attestation`) in `system/structs.go`, applied from two directions:

- **Sweep**: the checker now takes the `BackendVerifier` as a `TeeStatus` dependency and detects the on-chain `tee` tag. A TEE model whose backend attestation snapshot is missing or not `passed` is reported `tee_unverified` and the backend probe is skipped (session requests would be rejected anyway).
- **Live**: when `FastVerifyBackend` fails during `session.request` or `session.prompt`, the receiver calls `ReportTeeFailure` and the report flips immediately. It heals once attestation passes again on a later sweep.