### PR TITLE
docs: align install guidance with current release assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ If the user's question doesn't match anything in this file or the repo:
 ## Repository sub-projects
 
 - `proxy-router/` — Go service: the consumer/provider router. Hosts the HTTP API.
-- `MorpheusUI/` — Electron consumer GUI.
+- `ui-desktop/` — Electron consumer GUI (product name **MorpheusUI**).
 - `cli/` — Go CLI client.
 - `smart-contracts/` — Solidity contracts (Diamond marketplace).
 - `agents/` — agent reference implementations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Prefer conventional prefixes so history stays scannable:
 | Path | Purpose |
 |------|---------|
 | `proxy-router/` | Go service (consumer/provider router, HTTP API, TEE attestation) |
-| `MorpheusUI/` | Electron consumer GUI |
+| `ui-desktop/` | Electron consumer GUI (product name **MorpheusUI**) |
 | `cli/` | Go CLI client |
 | `docs/` | Mintlify site → [nodedocs.mor.org](https://nodedocs.mor.org) |
 | `AGENTS.md` | Rules for AI coding assistants working in this repo |

--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@ The site is structured around **role-based journeys** (consumer / prosumer / pro
 
 ## What's in this repo
 
-- Local `Llama.cpp` and tinyllama model to run locally for demonstration purposes only.
 - Lumerin `proxy-router` — background process that monitors blockchain contract events, manages secure sessions between consumers and providers, and routes prompts and responses between them.
-- Lumerin `MorpheusUI` — the Electron front end UI to interact with LLMs and the Morpheus network as a consumer.
-- Lumerin `cli` — CLI client to interact with LLMs and the Morpheus network as a consumer.
-- Kubo `ipfs` — IPFS client to store and retrieve model/agent files.
+- `ui-desktop/` (**MorpheusUI**) — Electron desktop app for consumers. Release assets are `*-morpheus-app-*` installers (`.dmg` / `.AppImage` / portable `.exe`); on first launch the app downloads the proxy-router, a local `llama.cpp` + tinyllama demo model, and an IPFS (kubo) node. There is no zip / `mor-launch` package in current releases.
+- `cli/` — CLI client (`*-morpheus-cli-*` release binaries; local builds produce `mor-cli`).
+- Standalone `*-morpheus-router-*` release binaries for headless / provider deployments.
 
 ## End-to-end picture
 

--- a/docs/ai/local-vs-blockchain-models.mdx
+++ b/docs/ai/local-vs-blockchain-models.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Local vs blockchain models (LLM cheatsheet)"
-description: "A short, agent-citable distinction between the bundled local model and real Morpheus marketplace models."
+description: "A short, agent-citable distinction between the local demo model and real Morpheus marketplace models."
 audience: ["developer", "consumer", "prosumer"]
 product: ["proxy-router", "ui-desktop"]
 last_verified: "v7.0.0"

--- a/docs/ai/myths.mdx
+++ b/docs/ai/myths.mdx
@@ -19,7 +19,7 @@ If you are an AI assistant answering Morpheus questions, **read this page before
     **No.** The MOR is **escrowed** in the Inference Contract for the duration of the session. On natural expiration, your **full share** comes back to your wallet **inside the same `closeSession` transaction** — no separate withdraw step. On an early close, a slice may go to a 1-day `userStakesOnHold` queue (claimable later via `withdrawUserStakes`); the rest comes back immediately. The provider is paid from a separate protocol funding account, **not** from your stake in real time. See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
   </Accordion>
 
-  <Accordion title="MYTH: The bundled local model is a 'free Morpheus model.'">
+  <Accordion title="MYTH: The local demo model is a 'free Morpheus model.'">
     **No.** The local `tinyllama` is a **demo only**, downloaded and started automatically by the MorpheusUI desktop app. It runs on your machine and never touches chain or any provider. It does not represent Morpheus model quality. See [Local vs on-chain models](/concepts/local-vs-onchain-models).
   </Accordion>
 

--- a/docs/concepts/local-vs-onchain-models.mdx
+++ b/docs/concepts/local-vs-onchain-models.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Local vs on-chain models"
-description: "When you are using the bundled local llama.cpp model versus a real Morpheus blockchain model — and why expectations and pricing differ."
+description: "When you are using the local llama.cpp demo model versus a real Morpheus blockchain model — and why expectations and pricing differ."
 audience: ["consumer", "prosumer"]
 product: ["proxy-router", "ui-desktop"]
 last_verified: "v7.0.0"
 ---
 
-The single biggest source of confusion in Morpheus: **the bundled local model is not a Morpheus model.** Two things are easily conflated.
+The single biggest source of confusion in Morpheus: **the local demo model is not a Morpheus model.** Two things are easily conflated.
 
 ## TL;DR
 

--- a/docs/consumers/install/docker.mdx
+++ b/docs/consumers/install/docker.mdx
@@ -3,7 +3,7 @@ title: "Docker (consumer)"
 description: "Run a consumer-side proxy-router in Docker. The MorpheusUI Electron app is not containerized; pair this with the desktop UI or hit the API directly."
 audience: ["consumer", "developer"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.6.0"
 ---
 
 The proxy-router itself is published as a Docker image at `ghcr.io/morpheusais/morpheus-lumerin-node`. As a **consumer** you typically run it locally next to MorpheusUI or call its HTTP API directly. The container exposes the same `:8082` admin/API and `:3333` proxy ports.
@@ -66,7 +66,7 @@ Switch to BASE Sepolia by replacing the four blockchain values in the `.env`. Se
 
 ## Pairing with MorpheusUI
 
-If you also want the desktop UI, run the packaged release as in [macOS](/consumers/install/macos) / [Windows](/consumers/install/windows) / [Linux](/consumers/install/linux), but stop the bundled proxy-router and point `PROXY_WEB_URL` (in MorpheusUI's `.env`) at your container's `http://localhost:8082`.
+If you also want the desktop UI, install the packaged **MorpheusUI** app ([Consumer quickstart](/consumers/quickstart), or per-OS: [Windows](/consumers/install/windows) / [Linux](/consumers/install/linux)). Then stop the app-managed proxy-router from the startup screen (or quit the app), run your Docker proxy-router, and point MorpheusUI at it with `PROXY_WEB_URL=http://localhost:8082` (see [Env: MorpheusUI](/reference/env-ui-desktop)). For building the UI from source, see [macOS install (from source)](/consumers/install/macos).
 
 ## Direct API use
 

--- a/docs/consumers/install/linux.mdx
+++ b/docs/consumers/install/linux.mdx
@@ -3,7 +3,7 @@ title: "Linux install"
 description: "Run the MorpheusUI desktop app (AppImage) on Linux."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.5.0"
+last_verified: "v7.6.0"
 ---
 
 The Linux release is a single **AppImage**. On first launch, the app downloads and manages its own services — proxy-router, `llama.cpp` AI runtime with the `tinyllama` demo model, and an IPFS node. For a source-build walk-through, see [macOS install (from source)](/consumers/install/macos) — the steps are nearly identical on Linux.
@@ -39,7 +39,11 @@ The Linux release is a single **AppImage**. On first launch, the app downloads a
 </Warning>
 
 ```bash
+rm -rf ~/.config/morpheus-app
+# Older builds may have used:
 rm -rf ~/.config/MorpheusUI
 ```
+
+(`morpheus-app` is the Electron package / `userData` folder name; the product name in the UI is **MorpheusUI**.)
 
 See also: [Troubleshooting](/reference/troubleshooting).

--- a/docs/consumers/install/macos.mdx
+++ b/docs/consumers/install/macos.mdx
@@ -3,8 +3,7 @@ title: "macOS install (from source, 4-terminal walk-through)"
 description: "Build llama.cpp, the proxy-router, MorpheusUI, and the CLI from source on macOS. For developers and contributors."
 audience: ["consumer", "developer"]
 product: ["proxy-router", "ui-desktop", "cli"]
-last_verified: "v7.0.0"
-source: "docs/mac-boot-strap.md"
+last_verified: "v7.6.0"
 ---
 
 A simple guide to get the local `llama.cpp` model, the Lumerin proxy-router, and the MorpheusUI from source running on a Mac.
@@ -45,7 +44,7 @@ You will need a port for the local model server (`8080` in this guide). This set
     model_host=127.0.0.1
     model_port=8080
     ```
-    Then pick a model (full set in [`docs/mac-boot-strap.md`](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/blob/main/docs/mac-boot-strap.md)):
+    Then pick a model, for example the tinyllama demo GGUF:
     ```bash
     model_url=https://huggingface.co/TheBloke
     model_collection=TinyLlama-1.1B-Chat-v1.0-GGUF
@@ -106,8 +105,10 @@ You'll need:
 
 ## Step C — MorpheusUI (terminal 3)
 
+The Electron app lives in `ui-desktop/` (product name **MorpheusUI**):
+
 ```bash
-cd <your_path>/Morpheus-Lumerin-Node/MorpheusUI
+cd <your_path>/Morpheus-Lumerin-Node/ui-desktop
 cp .env.example .env
 vi .env  # confirm PROXY_WEB_URL points at the proxy-router API port
 yarn install
@@ -130,11 +131,13 @@ make build
 ./mor-cli healthcheck
 ```
 
+Release builds of the CLI are named `*-morpheus-cli-<version>` (see [Releases](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases)); a local `make build` still produces `./mor-cli`.
+
 ## Cleaning and troubleshooting
 
 - Save your wallet mnemonic before any cleanup.
-- `rm -rf ./node_modules` from inside `MorpheusUI` if dependencies get stuck.
-- `rm -rf ~/Library/Application\ Support/MorpheusUI` to start with a fresh wallet store.
+- `rm -rf ./node_modules` from inside `ui-desktop` if dependencies get stuck.
+- Packaged-app data lives under Electron's `userData` directory — typically `~/Library/Application Support/MorpheusUI` for the `.app`, or `~/Library/Application Support/morpheus-app` when the package name is used (including `yarn dev`). Delete whichever exists to reset the wallet store and downloaded services.
 - Dangling processes: `ps -ax | grep electron` / `ps -ax | grep proxy-router` then `kill -9 <pid>`.
 - Locked log files in `./data/`: `lsof | grep /proxy-router/data/` and kill the holding process.
 

--- a/docs/consumers/install/windows.mdx
+++ b/docs/consumers/install/windows.mdx
@@ -3,7 +3,7 @@ title: "Windows install"
 description: "Run the MorpheusUI desktop app (portable exe) on Windows."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.5.0"
+last_verified: "v7.6.0"
 ---
 
 The Windows release is a single **portable executable**. On first launch, the app downloads and manages its own services — proxy-router, `llama.cpp` AI runtime with the `tinyllama` demo model, and an IPFS node. For source builds, see [macOS install](/consumers/install/macos) and adapt the toolchain.
@@ -35,7 +35,10 @@ The Windows release is a single **portable executable**. On first launch, the ap
 </Warning>
 
 ```cmd
-rmdir /s /q %APPDATA%\MorpheusUI
+rmdir /s /q %APPDATA%\morpheus-app
+rmdir /s /q %LOCALAPPDATA%\morpheus-app
 ```
+
+(`morpheus-app` is the Electron package / `userData` folder name; the product name in the UI is **MorpheusUI**.)
 
 See also: [Troubleshooting](/reference/troubleshooting).

--- a/docs/consumers/quickstart.mdx
+++ b/docs/consumers/quickstart.mdx
@@ -3,7 +3,7 @@ title: "Consumer quickstart"
 description: "Install the MorpheusUI desktop app, let it fetch its services (proxy-router, local llama.cpp, IPFS), fund a wallet, and chat."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.5.0"
+last_verified: "v7.6.0"
 source: "docs/04-consumer-setup.md"
 ---
 
@@ -92,23 +92,30 @@ If you need to reset to a fresh state (different release, broken state):
 **Save your wallet mnemonic / private key first.** Cleanup deletes the local key store.
 </Warning>
 
-The app keeps everything — downloaded services, proxy-router data, and the wallet store — in its per-user application data directory:
+The app keeps everything — downloaded services, proxy-router data, and the wallet store — in Electron's `userData` directory. The package name is `morpheus-app` (that is the folder name on disk; the product name shown in the UI is **MorpheusUI**):
 
 <Tabs>
   <Tab title="macOS">
     ```bash
+    # Packaged .app often uses the product name:
     rm -rf ~/Library/Application\ Support/MorpheusUI
     rm -rf ~/Library/Logs/MorpheusUI
+    # Electron package name (also used on some builds / when running from source):
+    rm -rf ~/Library/Application\ Support/morpheus-app
+    rm -rf ~/Library/Logs/morpheus-app
     ```
   </Tab>
   <Tab title="Linux">
     ```bash
+    rm -rf ~/.config/morpheus-app
+    # Older builds may have used:
     rm -rf ~/.config/MorpheusUI
     ```
   </Tab>
   <Tab title="Windows">
     ```cmd
-    rmdir /s /q %APPDATA%\MorpheusUI
+    rmdir /s /q %APPDATA%\morpheus-app
+    rmdir /s /q %LOCALAPPDATA%\morpheus-app
     ```
   </Tab>
 </Tabs>

--- a/docs/consumers/troubleshooting.mdx
+++ b/docs/consumers/troubleshooting.mdx
@@ -31,7 +31,7 @@ You probably recovered a **derived** address from your mnemonic. MorpheusUI only
 
 ## Local model returns nonsense
 
-The bundled `tinyllama` is a **demonstration model only**. It will hallucinate, miscount, and contradict itself. Don't compare it to a real Morpheus model. See [Local vs on-chain models](/concepts/local-vs-onchain-models).
+The local `tinyllama` demo (downloaded by the desktop app on first launch) is a **demonstration model only**. It will hallucinate, miscount, and contradict itself. Don't compare it to a real Morpheus model. See [Local vs on-chain models](/concepts/local-vs-onchain-models).
 
 ## Swagger / API not reachable on `:8082`
 

--- a/docs/ecosystem/app-mor-org.mdx
+++ b/docs/ecosystem/app-mor-org.mdx
@@ -21,7 +21,7 @@ source_url: "https://app.mor.org"
 |---|---|---|
 | Install | None | Download release |
 | Wallet | Account on app.mor.org (no on-chain wallet needed for chat) | Self-custodial wallet (mnemonic / private key) |
-| Local model | No | Yes (bundled `tinyllama`) |
+| Local model | No | Yes (local `tinyllama` demo, downloaded on first launch) |
 | Backed by | Hosted [Inference API](/inference-api/overview) gateway | Direct on-chain sessions through your own proxy-router |
 | Pricing | Credits/billing on the Inference API (see [apidocs.mor.org](https://apidocs.mor.org)) | MOR per session-second |
 | Underlying network | Same Morpheus marketplace | Same Morpheus marketplace |

--- a/docs/get-started/introduction.mdx
+++ b/docs/get-started/introduction.mdx
@@ -3,17 +3,18 @@ title: "Introduction"
 description: "What the Morpheus Lumerin Node is, how the moving parts fit together, and which path to follow next."
 audience: ["consumer", "prosumer", "provider-resale", "provider-full", "developer"]
 product: ["proxy-router", "ui-desktop", "cli"]
-last_verified: "v7.0.0"
+last_verified: "v7.6.0"
 ---
 <Note>
   **In a hurry? Pick the fastest path.**
 
-  - **Just want to use it (~5 min):** download the desktop app from the
-    [latest release](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases) and run it —
-    wallet, chat, and proxy-router are bundled. See the [Consumer quickstart](/consumers/quickstart).
-  - **Try it free — no wallet, no tokens:** the desktop app bundles a local `llama.cpp` model for
-    demos, so you can chat immediately without staking MOR. Look for the local model option after
-    install.
+  - **Just want to use it (~5 min):** download the **Desktop Application** asset for your OS from the
+    [latest release](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases)
+    (`*-morpheus-app-*.dmg` / `.AppImage` / `.exe` — not a zip archive) and run it.
+    On first launch the app downloads the proxy-router and related services. See the
+    [Consumer quickstart](/consumers/quickstart).
+  - **Try it free — no wallet, no tokens:** after install, the app also downloads a local `llama.cpp`
+    demo model so you can chat without staking MOR. Look for **Local Model** in Chat.
   - **Building on the marketplace?** jump to the [Hosted Inference API](/inference-api/overview).
 
   New to Morpheus? Read on for how the pieces fit together.
@@ -38,7 +39,7 @@ For the conceptual picture (decentralization rationale, Compute Node contracts, 
     Command-line client that talks to the proxy-router HTTP API.
   </Card>
   <Card title="llama.cpp + tinyllama" icon="microchip">
-    A throw-away local model bundled for demos so you can try the stack without paying MOR.
+    A throw-away local demo model the desktop app downloads on first launch so you can try the stack without paying MOR.
   </Card>
 </CardGroup>
 

--- a/docs/get-started/quickstart-consumer.mdx
+++ b/docs/get-started/quickstart-consumer.mdx
@@ -3,14 +3,14 @@ title: "Consumer quickstart"
 description: "The 5-minute path from zero to chatting with a remote model: download, fund a wallet, open a session, prompt."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.5.0"
+last_verified: "v7.6.0"
 ---
 
 This is the shortest path to chat with a remote model on Morpheus. For a full walk-through (including the optional local-only model and cleanup), see [Consumer install](/consumers/quickstart).
 
 <Steps>
   <Step title="Download a release">
-    Grab the latest package for your OS from the [GitHub releases page](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases). Mainnet builds have no suffix; testnet builds end in `-test`. Asset names look like (version will differ):
+    Grab the latest **Desktop Application** for your OS from the [GitHub releases page](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases). Current releases ship installers (`.dmg` / `.AppImage` / portable `.exe`) — not a zip archive and not `mor-launch`. Mainnet builds have no suffix; testnet builds end in `-test`. Asset names look like (version will differ):
 
     | OS | File |
     |----|------|

--- a/docs/prosumers/overview.mdx
+++ b/docs/prosumers/overview.mdx
@@ -21,7 +21,7 @@ flowchart LR
 
 - **One stable endpoint** for all your local agents to point at — no per-tool wallet juggling.
 - **Bring your own wallet** with a real budget; agents can't drain it without your permission (see [API auth](/reference/api-auth) per-user whitelists).
-- **Mix local + remote** — fall back to bundled `llama.cpp` for free smoke tests; switch to remote Morpheus models for production tasks.
+- **Mix local + remote** — fall back to the desktop app's local `llama.cpp` demo for free smoke tests; switch to remote Morpheus models for production tasks.
 - **TEE on demand** — when an agent needs higher trust, route through a `tee`-tagged model.
 
 ## What's on this path

--- a/docs/providers/full/quickstart.mdx
+++ b/docs/providers/full/quickstart.mdx
@@ -3,7 +3,7 @@ title: "Full P-Node quickstart"
 description: "Run a standalone Morpheus provider proxy-router pointing at your own AI model."
 audience: ["provider-full"]
 product: ["proxy-router"]
-last_verified: "v7.5.0"
+last_verified: "v7.6.0"
 source: "docs/02-provider-setup.md"
 ---
 
@@ -22,7 +22,7 @@ This page covers a **non-TEE provider** running on your own infrastructure. For 
   <Step title="Get the software">
     <Tabs>
       <Tab title="Release binary">
-        The proxy-router ships as a **standalone binary**. Download the **latest** one for your platform from [Releases](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases). Mainnet builds have no suffix; testnet builds end in `-test`. Asset names look like (version will differ):
+        The proxy-router ships as a **standalone binary** (not a zip archive). Download the **latest** `*-morpheus-router-*` asset for your platform from [Releases](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases). Mainnet builds have no suffix; testnet builds end in `-test`. Asset names look like (version will differ):
 
         | Platform | File |
         |----------|------|

--- a/docs/reference/env-ui-desktop.mdx
+++ b/docs/reference/env-ui-desktop.mdx
@@ -3,11 +3,11 @@ title: "Env: MorpheusUI"
 description: "Environment variables consumed by the MorpheusUI Electron desktop app."
 audience: ["consumer", "developer"]
 product: ["ui-desktop"]
-last_verified: "v7.0.0"
+last_verified: "v7.6.0"
 source: "docs/ui-desktop.all.env"
 ---
 
-MorpheusUI configuration lives in `MorpheusUI/.env` (or the equivalent platform-specific resource). The complete annotated dump is at [`docs/ui-desktop.all.env`](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/blob/main/docs/ui-desktop.all.env). Source of truth: `MorpheusUI/src/main/config/index.ts`.
+MorpheusUI configuration lives in `ui-desktop/.env` when building from source (or the equivalent platform-specific resource for a packaged install). The complete annotated dump is at [`docs/ui-desktop.all.env`](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/blob/main/docs/ui-desktop.all.env). Source of truth: [`ui-desktop/src/main/config/index.ts`](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/blob/main/ui-desktop/src/main/config/index.ts).
 
 ## Auth & networking
 

--- a/docs/reference/glossary.mdx
+++ b/docs/reference/glossary.mdx
@@ -32,7 +32,7 @@ LLM-friendly definitions — short, opinionated, and consistent across the rest 
 | **Allowance** | Standard ERC-20 approval the consumer / provider grants to the Diamond contract so it can move MOR on their behalf. |
 | **proxy-router** | The Go service in this repo. Same binary serves consumer and provider roles; configuration differs. |
 | **MorpheusUI** | The Electron desktop UI in this repo. |
-| **mor-cli** | The Go CLI client in this repo. |
+| **mor-cli** | The Go CLI client in this repo. Local builds produce `./mor-cli`; GitHub release assets are named `*-morpheus-cli-<version>`. |
 | **`local` model** | The tinyllama demo model, downloaded and started automatically by the MorpheusUI desktop app (its "AI Runtime" service). Not a Morpheus marketplace model. |
 | **`tee` tag** | Tag added to a model on chain to engage the two-hop attestation chain (Phase 1 + Phase 2). |
 | **`-tee` image** | The hardened proxy-router image (`ghcr.io/morpheusais/morpheus-lumerin-node-tee`) with config baked at build time. |

--- a/docs/ui-desktop.all.env
+++ b/docs/ui-desktop.all.env
@@ -1,4 +1,4 @@
-# Full set of MorpheusUI variables based on the MorpheusUI/src/main/config/index.ts file
+# Full set of MorpheusUI variables based on ui-desktop/src/main/config/index.ts
 # Includes known TESTNET and MAINNET Values if/when known
 # Currently aligned to TESTNET, but after MAINNET launch, will be updated to MAINNET values
 


### PR DESCRIPTION
## Summary
- Align consumer/provider install docs with what current GitHub releases actually ship (`*-morpheus-app-*` / `*-morpheus-router-*` installers — not zip/`mor-launch`).
- Fix stale source-tree paths (`MorpheusUI/` → `ui-desktop/`), broken `mac-boot-strap.md` references, and Windows/Linux app-data cleanup folders (`morpheus-app`).
- Clarify first-launch service download behavior and CLI release naming so newcomers are not led down a dead-end path (#796).

## Test plan
- [ ] Spot-check [Consumer quickstart](docs/consumers/quickstart.mdx) and get-started consumer page against the latest release asset list
- [ ] Confirm Windows/Linux cleanup paths match `%APPDATA%\morpheus-app` / `~/.config/morpheus-app`
- [ ] Confirm macOS from-source page uses `ui-desktop/` and no longer links `docs/mac-boot-strap.md`
- [ ] Preview with `cd docs && mint dev` if convenient
- [ ] Close #796 after merge if reviewers agree the zip/`mor-launch` guidance is gone


Made with [Cursor](https://cursor.com)