### PR TITLE
tee reattest on health cron

### DIFF
--- a/proxy-router/internal/attestation/backend_verifier.go
+++ b/proxy-router/internal/attestation/backend_verifier.go
@@ -308,6 +308,31 @@ func (bv *BackendVerifier) AttestBackend(ctx context.Context, modelID string, at
 	return nil
 }
 
+// ReattestBackend re-runs full backend attestation for a model regardless of
+// the current snapshot status, so a transient failure (e.g. a portal glitch
+// during startup attestation) self-heals on the next health sweep and a
+// stale pass is re-proven. endpoint is the model's apiUrl, used to resolve
+// the attestation URL when no snapshot with a URL exists.
+func (bv *BackendVerifier) ReattestBackend(ctx context.Context, modelID string, endpoint string) error {
+	bv.mu.RLock()
+	snapshot := bv.cache[modelID]
+	bv.mu.RUnlock()
+
+	attestationURL := ""
+	if snapshot != nil {
+		attestationURL = snapshot.AttestationURL
+	}
+	if attestationURL == "" {
+		resolved, err := bv.ResolveAttestationURL(ctx, endpoint)
+		if err != nil {
+			return fmt.Errorf("cannot resolve attestation URL for model %s: %w", modelID, err)
+		}
+		attestationURL = resolved
+	}
+
+	return bv.AttestBackend(ctx, modelID, attestationURL)
+}
+
 // FastVerifyBackend performs a lightweight per-request check.
 // Always re-fetches /cpu and compares sha256(quote) + TLS fingerprint against
 // the cached attestation snapshot (~50ms). If the quote hash changes, triggers

--- a/proxy-router/internal/modelhealth/checker.go
+++ b/proxy-router/internal/modelhealth/checker.go
@@ -57,10 +57,15 @@ type ModelConfigProvider interface {
 	GetAll() ([]common.Hash, []config.ModelConfig)
 }
 
-// TeeStatusProvider exposes the cached backend TEE attestation state
-// (implemented by attestation.BackendVerifier). Optional dependency.
+// TeeStatusProvider exposes the backend TEE attestation state and lets the
+// checker re-run attestation on every sweep (implemented by
+// attestation.BackendVerifier). Optional dependency.
 type TeeStatusProvider interface {
 	GetStatus(modelID string) *attestation.BackendAttestationSnapshot
+	// ReattestBackend re-runs full backend attestation for the model;
+	// endpoint is the model's apiUrl used to resolve the attestation URL
+	// when no snapshot exists yet.
+	ReattestBackend(ctx context.Context, modelID string, endpoint string) error
 }
 
 // DefaultMaxConsecutiveErrors is the number of consecutive real-session
@@ -95,6 +100,12 @@ type Checker struct {
 	// triggerCh carries manual re-check requests into the Run loop; buffered
 	// at 1 so triggers queue at most one extra sweep and can never overlap.
 	triggerCh chan struct{}
+
+	// firstTeeSweepDone flips after the first sweep. Backend TEE attestation
+	// already runs at process startup (cmd/main.go), and the first sweep
+	// fires right after it, so that sweep only reads the cached snapshot;
+	// re-attestation starts from the second sweep onward.
+	firstTeeSweepDone bool
 }
 
 // Deps groups the external dependencies of the checker.
@@ -103,8 +114,10 @@ type Deps struct {
 	Bids         BidProvider
 	Models       ModelMetaProvider
 	ModelConfigs ModelConfigProvider
-	// TeeStatus is optional; when set, TEE-tagged models whose backend
-	// attestation is not currently passed are reported as tee_unverified.
+	// TeeStatus is optional; when set, backend attestation of TEE-tagged
+	// models is re-run on every sweep after the first (pass or fail; the
+	// first sweep relies on the startup attestation), and models whose
+	// attestation does not pass are reported as tee_unverified.
 	TeeStatus TeeStatusProvider
 }
 
@@ -182,7 +195,7 @@ func (c *Checker) GetReports() []system.ModelHealthReport {
 // missing from models-config.json (reported as no_model_configured — the
 // provider is selling capacity it cannot serve).
 func (c *Checker) checkAll(ctx context.Context, walletAddr common.Address) {
-	modelIDs, _ := c.deps.ModelConfigs.GetAll()
+	modelIDs, modelCfgs := c.deps.ModelConfigs.GetAll()
 
 	bidsByModel, err := c.activeBidModels(ctx, walletAddr)
 	if err != nil {
@@ -192,8 +205,15 @@ func (c *Checker) checkAll(ctx context.Context, walletAddr common.Address) {
 
 	seen := make(map[string]bool, len(modelIDs)+len(bidsByModel))
 
+	// Skip TEE re-attestation on the very first sweep: it runs right after
+	// the startup attestation in cmd/main.go and would just duplicate it.
+	c.mu.Lock()
+	reattestTee := c.firstTeeSweepDone
+	c.firstTeeSweepDone = true
+	c.mu.Unlock()
+
 	probed := false
-	for _, modelID := range modelIDs {
+	for i, modelID := range modelIDs {
 		select {
 		case <-ctx.Done():
 			return
@@ -207,7 +227,7 @@ func (c *Checker) checkAll(ctx context.Context, walletAddr common.Address) {
 		if hasBid && probed && !c.sleep(ctx, c.probeDelay) {
 			return
 		}
-		c.checkModel(ctx, modelID, bidID, hasBid)
+		c.checkModel(ctx, modelID, bidID, hasBid, modelCfgs[i].ApiURL, reattestTee)
 		if hasBid {
 			probed = true
 		}
@@ -312,7 +332,7 @@ func (c *Checker) activeBidModels(ctx context.Context, walletAddr common.Address
 	return byModel, nil
 }
 
-func (c *Checker) checkModel(ctx context.Context, modelID common.Hash, bidID common.Hash, hasBid bool) {
+func (c *Checker) checkModel(ctx context.Context, modelID common.Hash, bidID common.Hash, hasBid bool, apiURL string, reattestTee bool) {
 	report := system.ModelHealthReport{
 		ModelID:      modelID.Hex(),
 		HasActiveBid: hasBid,
@@ -344,10 +364,23 @@ func (c *Checker) checkModel(ctx context.Context, modelID common.Hash, bidID com
 	report.ModelName = meta.name
 	report.ModelType = string(meta.modelType)
 
-	// A TEE-tagged model whose backend attestation is not currently passed
-	// cannot serve sessions (session requests are rejected by the receiver),
-	// so report it as tee_unverified and skip the backend probe.
+	// Re-run backend attestation for TEE-tagged models on every sweep after
+	// the first (the first sweep relies on the startup attestation),
+	// regardless of the current snapshot status: a transient failure at
+	// startup self-heals here instead of sticking until a restart, and a
+	// stale pass is re-proven against the live backend. A model whose
+	// attestation does not pass cannot serve sessions (session requests are
+	// rejected by the receiver), so it is reported as tee_unverified and the
+	// backend probe is skipped.
 	if meta.isTee && c.deps.TeeStatus != nil {
+		if reattestTee {
+			attestCtx, cancel := context.WithTimeout(ctx, c.timeout)
+			if err := c.deps.TeeStatus.ReattestBackend(attestCtx, modelID.Hex(), apiURL); err != nil {
+				c.log.Warnf("model %s: backend TEE re-attestation failed: %s", lib.Short(modelID), err)
+			}
+			cancel()
+		}
+
 		snapshot := c.deps.TeeStatus.GetStatus(modelID.Hex())
 		if snapshot == nil || snapshot.Status != attestation.StatusPassed {
 			c.log.Warnf("model %s: backend TEE attestation is not passed, reporting tee_unverified", lib.Short(modelID))

--- a/proxy-router/internal/modelhealth/checker_test.go
+++ b/proxy-router/internal/modelhealth/checker_test.go
@@ -75,13 +75,28 @@ type mockDeps struct {
 	teeStatus  TeeStatusProvider
 }
 
-// mockTeeStatus returns canned backend attestation snapshots per model.
+// mockTeeStatus returns canned backend attestation snapshots per model and
+// records ReattestBackend calls. When onReattest is set, it is applied to the
+// snapshot map before the checker reads the status back.
 type mockTeeStatus struct {
-	snapshots map[string]*attestation.BackendAttestationSnapshot
+	snapshots  map[string]*attestation.BackendAttestationSnapshot
+	reattested map[string]int
+	onReattest func(modelID string)
 }
 
 func (m *mockTeeStatus) GetStatus(modelID string) *attestation.BackendAttestationSnapshot {
 	return m.snapshots[modelID]
+}
+
+func (m *mockTeeStatus) ReattestBackend(ctx context.Context, modelID string, endpoint string) error {
+	if m.reattested == nil {
+		m.reattested = make(map[string]int)
+	}
+	m.reattested[modelID]++
+	if m.onReattest != nil {
+		m.onReattest(modelID)
+	}
+	return nil
 }
 
 func (m *mockDeps) GetActiveBidsByProvider(ctx context.Context, provider common.Address, offset *big.Int, limit uint8, order registries.Order) ([]*structs.Bid, error) {
@@ -478,6 +493,37 @@ func TestCheckAllTeeModelAttestationGate(t *testing.T) {
 		llm := reportByID(t, checker.GetReports(), modelLLM)
 		require.Equal(t, system.ModelHealthStatusHealthy, llm.Status)
 		require.NotNil(t, llm.PromptCorrect)
+	})
+
+	t.Run("first sweep skips re-attestation, later sweeps re-attest regardless of status", func(t *testing.T) {
+		tee := &mockTeeStatus{snapshots: map[string]*attestation.BackendAttestationSnapshot{
+			modelLLM.Hex(): {ModelID: modelLLM.Hex(), Status: attestation.StatusPassed},
+		}}
+		checker := newTestChecker(teeDeps(tee))
+
+		checker.checkAll(context.Background(), common.Address{})
+		require.Zero(t, tee.reattested[modelLLM.Hex()], "first sweep must rely on the startup attestation")
+
+		checker.checkAll(context.Background(), common.Address{})
+		checker.checkAll(context.Background(), common.Address{})
+		require.Equal(t, 2, tee.reattested[modelLLM.Hex()], "re-attestation must run on every later sweep, even when passed")
+	})
+
+	t.Run("failed attestation self-heals when re-attestation passes", func(t *testing.T) {
+		tee := &mockTeeStatus{snapshots: map[string]*attestation.BackendAttestationSnapshot{
+			modelLLM.Hex(): {ModelID: modelLLM.Hex(), Status: attestation.StatusFailed},
+		}}
+		tee.onReattest = func(modelID string) {
+			tee.snapshots[modelID] = &attestation.BackendAttestationSnapshot{ModelID: modelID, Status: attestation.StatusPassed}
+		}
+		checker := newTestChecker(teeDeps(tee))
+		checker.firstTeeSweepDone = true
+
+		checker.checkAll(context.Background(), common.Address{})
+
+		llm := reportByID(t, checker.GetReports(), modelLLM)
+		require.Equal(t, system.ModelHealthStatusHealthy, llm.Status, "a stale startup failure must heal once re-attestation passes")
+		require.Equal(t, 1, tee.reattested[modelLLM.Hex()])
 	})
 
 	t.Run("no TEE status provider probes normally", func(t *testing.T) {


### PR DESCRIPTION
A transient failure during startup backend attestation used to leave a TEE model stuck in `tee_unverified` until a process restart. The hourly model-health sweep only **read** the cached attestation snapshot and reported it; nothing ever re-ran the attestation, because consumers avoid `tee_unverified` models, so the prompt-path re-attestation (`FastVerifyBackend`) never fired either — the failure was self-sustaining.

This MR makes the model-health sweep re-run **full backend attestation** (CPU quote → portal → TLS binding → workload → GPU NRAS) for every TEE-tagged model with an active bid, on every sweep after the first, regardless of whether the current snapshot is passed or failed:

- a stale startup failure **self-heals** at the next sweep once the transient cause (e.g. a SecretAI Portal glitch) clears;
- a stale pass is **re-proven** against the live backend every interval (fail-closed).