### PR TITLE
promote: Windows CLI cookie path fix to test (#818)

### DIFF
--- a/proxy-router/internal/authapi/controller_http.go
+++ b/proxy-router/internal/authapi/controller_http.go
@@ -336,24 +336,30 @@ func (a *AuthController) GetAgentTxs(ctx *gin.Context) {
 //	@Router			/auth/cookie/path [get]
 func (a *AuthController) GetPathToCookieFile(ctx *gin.Context) {
 	cookieFilePath := a.authConfig.CookieFilePath
-	if a.environment == "development" {
-		workingDir, err := os.Getwd()
-		if err != nil {
-			ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
 
-		cookieFilePath = filepath.Join(workingDir, cookieFilePath)
-	} else {
-		executablePath, err := os.Executable()
-		if err != nil {
-			ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
-
-		executableDir := filepath.Dir(executablePath)
-		cookieFilePath = filepath.Join(executableDir, cookieFilePath)
+	// Config load resolves relative paths with filepath.Abs. Still defend against
+	// absolute-path double-joining on Windows (filepath.Join can produce
+	// `base\C:\...` when the second element is not recognized as absolute).
+	if filepath.IsAbs(cookieFilePath) {
+		ctx.JSON(http.StatusOK, gin.H{"path": filepath.Clean(cookieFilePath)})
+		return
 	}
 
-	ctx.JSON(http.StatusOK, gin.H{"path": cookieFilePath})
+	var baseDir string
+	var err error
+	if a.environment == "development" {
+		baseDir, err = os.Getwd()
+	} else {
+		var executablePath string
+		executablePath, err = os.Executable()
+		if err == nil {
+			baseDir = filepath.Dir(executablePath)
+		}
+	}
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"path": filepath.Clean(filepath.Join(baseDir, cookieFilePath))})
 }

--- a/proxy-router/internal/authapi/cookie_path_test.go
+++ b/proxy-router/internal/authapi/cookie_path_test.go
@@ -1,0 +1,41 @@
+package authapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/MorpheusAIs/Morpheus-Lumerin-Node/proxy-router/internal/system"
+	"github.com/gin-gonic/gin"
+)
+
+func TestGetPathToCookieFileDoesNotDoubleJoinAbsolute(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	abs := filepath.Join(t.TempDir(), ".cookie")
+
+	authCfg := system.NewAuthConfig("./proxy.conf", abs, "", nil)
+	ctrl := NewAuthController(authCfg, "production", nil)
+
+	r := gin.New()
+	r.GET("/auth/cookie/path", ctrl.GetPathToCookieFile)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/cookie/path", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d body %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Path != filepath.Clean(abs) {
+		t.Fatalf("got %q want %q", body.Path, filepath.Clean(abs))
+	}
+}

--- a/proxy-router/internal/config/config.go
+++ b/proxy-router/internal/config/config.go
@@ -246,6 +246,23 @@ func (cfg *Config) SetDefaults() {
 	cfg.Proxy.RatingConfigPath = filepath.FromSlash(cfg.Proxy.RatingConfigPath)
 	cfg.Proxy.CookieFilePath = filepath.FromSlash(cfg.Proxy.CookieFilePath)
 	cfg.Proxy.AuthConfigFilePath = filepath.FromSlash(cfg.Proxy.AuthConfigFilePath)
+
+	// Resolve relative auth paths against the process working directory once at
+	// startup. Without this, /auth/cookie/path may re-join a path that is already
+	// absolute and produce invalid Windows paths (issue #792).
+	cfg.Proxy.CookieFilePath = mustAbsPath(cfg.Proxy.CookieFilePath)
+	cfg.Proxy.AuthConfigFilePath = mustAbsPath(cfg.Proxy.AuthConfigFilePath)
+}
+
+func mustAbsPath(p string) string {
+	if p == "" || filepath.IsAbs(p) {
+		return filepath.Clean(p)
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return filepath.Clean(p)
+	}
+	return abs
 }
 
 // GetSanitized returns a copy of the config with sensitive data removed

--- a/proxy-router/internal/config/config_abspath_test.go
+++ b/proxy-router/internal/config/config_abspath_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestMustAbsPathLeavesAbsoluteUnchanged(t *testing.T) {
+	abs := filepath.Join(t.TempDir(), ".cookie")
+	got := mustAbsPath(abs)
+	if got != filepath.Clean(abs) {
+		t.Fatalf("got %q want %q", got, filepath.Clean(abs))
+	}
+}
+
+func TestMustAbsPathResolvesRelative(t *testing.T) {
+	got := mustAbsPath("./.cookie")
+	if !filepath.IsAbs(got) {
+		t.Fatalf("expected absolute path, got %q", got)
+	}
+	if filepath.Base(got) != ".cookie" {
+		t.Fatalf("expected basename .cookie, got %q", got)
+	}
+}
+
+func TestMustAbsPathEmpty(t *testing.T) {
+	if got := mustAbsPath(""); got != "." && got != "" {
+		// Clean("") == "." on most platforms
+		if filepath.Clean("") != got {
+			t.Fatalf("unexpected empty handling: %q", got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Promote current `dev` → `test` so the Windows CLI cookie-path fix can be validated on the test channel.

### Included changes (`test`..`dev`)

| PR | What |
|----|------|
| [#818](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/818) | Resolve cookie/auth paths absolutely at startup; stop `/auth/cookie/path` double-joining on Windows so `mor-cli.exe` can read the cookie (#792) |

## Test plan
- [ ] CI on this promote PR is green
- [ ] On Windows test build: start local router / desktop app, then `mor-cli.exe --help` and a simple authenticated command against `localhost:8082`
- [ ] Confirm `GET /auth/cookie/path` returns a single clean absolute path (no `services\C:\...` duplication)
- [ ] After merge, close #792 if Windows smoke passes


Made with [Cursor](https://cursor.com)