### PR TITLE
Dev -> test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2240,21 +2240,51 @@ jobs:
           fi
 
           FUNCTION_NAME="${ENV}-routed-sessions-sweep"
-          # deploy_cutoff mode (default): the Lambda derives cutoff from the C-Node
-          # service deployments[0].updatedAt + rehydration + safety, then closes
-          # OPEN rows older than that. release_tag only annotates error_reason.
+          CLUSTER_NAME="ecs-${ENV}-morpheus-engine"
+          SERVICE_NAME="svc-${ENV}-router"
+          # Must match Lambda DEFAULT_REHYDRATION_SECS / DEFAULT_SAFETY_SECS
+          # (02-morpheus_c_node/.terragrunt/06_routed_sessions_sweep.tf).
+          REHYDRATION_SECS=90
+          SAFETY_SECS=120
+          SKEW_BUFFER_SECS=15
+
+          # deploy_cutoff mode (default): the Lambda derives cutoff from the
+          # C-Node PRIMARY deployment updatedAt + rehydration + safety, then
+          # closes OPEN rows older than that. release_tag only annotates
+          # error_reason.
           PAYLOAD="{\"release_tag\":\"${BUILDTAG}\"}"
 
-          # This job starts seconds after the C-Node deploy settles, but the
-          # Lambda's cutoff = deployments[0].updatedAt + 90s rehydration + 120s
-          # safety (~210s ahead) and it REFUSES a future cutoff. So the first
-          # invoke almost always lands before the cutoff and no-ops with a 400.
-          # Retry with backoff until the cutoff has passed (or the budget is
-          # exhausted) so the sweep actually runs. Budget: 10 * 30s = ~5 min,
-          # comfortably past the ~210s cutoff. Only the future-cutoff case is
-          # retried; any other status (200 / SWEEP_MAX_ROWS / error) is terminal.
-          MAX_ATTEMPTS=10
-          SLEEP_SECS=30
+          # Proactive wait: the Lambda REFUSES a future cutoff (would close
+          # fresh sessions). Invoking immediately after C-Node settle almost
+          # always 400s for ~updatedAt+210s, and the old 10×30s retry budget
+          # was barely enough — leaving zombies OPEN long enough to reopen/
+          # failover-storm MOR. Sleep until the same cutoff the Lambda will
+          # derive, then invoke (small retry loop only for clock skew).
+          echo "🔎 Resolving C-Node PRIMARY updatedAt from ${CLUSTER_NAME}/${SERVICE_NAME}..."
+          UPDATED_AT=$(aws ecs describe-services \
+            --cluster "$CLUSTER_NAME" \
+            --services "$SERVICE_NAME" \
+            --query 'services[0].deployments[?status==`PRIMARY`]|[0].updatedAt' \
+            --output text)
+          if [ -z "$UPDATED_AT" ] || [ "$UPDATED_AT" = "None" ]; then
+            echo "⚠️ Could not resolve PRIMARY updatedAt; falling back to fixed ${REHYDRATION_SECS}+${SAFETY_SECS}s wait."
+            sleep $((REHYDRATION_SECS + SAFETY_SECS + SKEW_BUFFER_SECS))
+          else
+            echo "📌 PRIMARY updatedAt: ${UPDATED_AT}"
+            UPDATED_EPOCH=$(date -d "$UPDATED_AT" +%s)
+            CUTOFF_EPOCH=$((UPDATED_EPOCH + REHYDRATION_SECS + SAFETY_SECS + SKEW_BUFFER_SECS))
+            NOW_EPOCH=$(date +%s)
+            WAIT_SECS=$((CUTOFF_EPOCH - NOW_EPOCH))
+            if [ "$WAIT_SECS" -gt 0 ]; then
+              echo "⏳ Waiting ${WAIT_SECS}s for sweep cutoff (updatedAt + ${REHYDRATION_SECS}s + ${SAFETY_SECS}s + ${SKEW_BUFFER_SECS}s skew)..."
+              sleep "$WAIT_SECS"
+            else
+              echo "✅ Cutoff already in the past (${WAIT_SECS}s); invoking immediately."
+            fi
+          fi
+
+          MAX_ATTEMPTS=5
+          SLEEP_SECS=20
           STATUS=""
           BODY=""
           FUNCTION_ERROR=""
@@ -2290,8 +2320,7 @@ jobs:
               break
             fi
 
-            # Retry ONLY the "future cutoff" 400 — we just deployed and need to
-            # wait for the cutoff to pass. Everything else is a final result.
+            # Retry ONLY residual "future cutoff" 400 (clock skew / ECS lag).
             if [ "$STATUS" = "400" ] && echo "$BODY" | grep -qi "in the future"; then
               if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
                 echo "⏳ Cutoff not reached yet; sleeping ${SLEEP_SECS}s before retry."
@@ -2307,6 +2336,7 @@ jobs:
             echo ""
             echo "- **Function:** \`${FUNCTION_NAME}\`"
             echo "- **Release tag:** \`${BUILDTAG}\`"
+            echo "- **PRIMARY updatedAt:** \`${UPDATED_AT:-unknown}\`"
             echo "- **Handler statusCode:** \`${STATUS:-unknown}\`"
             if [ -n "$BODY" ]; then
               echo ""


### PR DESCRIPTION
## Summary
- Promote current tip of `dev` → `test` (includes #820: wait for ECS-derived sweep cutoff before zombie Lambda invoke).
- Standard promote path — not a fix-branch cherry-pick.

## Included since last promote
- #820 — `Sweep-Zombie-Sessions` sleeps until C-Node PRIMARY `updatedAt + 90s + 120s` before invoke (fixes future-cutoff 400 retry loop on test→dev and main→prd).

## Test plan
- [ ] Review full `dev`→`test` diff
- [ ] After merge, next C-Node roll from `test`→dev should show proactive wait + `statusCode: 200` in Sweep job / `/aws/lambda/dev-routed-sessions-sweep`


Made with [Cursor](https://cursor.com)