### PR TITLE
fix(ui-desktop): proxy-first startup so optional AI/IPFS cannot block onboarding

### DIFF
--- a/docs/consumers/install/windows.mdx
+++ b/docs/consumers/install/windows.mdx
@@ -3,7 +3,7 @@ title: "Windows install"
 description: "Run the MorpheusUI desktop app (portable exe) on Windows."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.6.0"
+last_verified: "v7.7.0"
 ---
 
 The Windows release is a single **portable executable**. On first launch, the app downloads and manages its own services — proxy-router, `llama.cpp` AI runtime with the `tinyllama` demo model, and an IPFS node. For source builds, see [macOS install](/consumers/install/macos) and adapt the toolchain.
@@ -18,7 +18,7 @@ The Windows release is a single **portable executable**. On first launch, the ap
     Double-click the `.exe`. Windows Defender may prompt — allow it.
   </Step>
   <Step title="Let the app fetch its services">
-    The first launch (and the first after each update) shows a **Starting services** screen: the app downloads the proxy-router, AI runtime, demo model, and IPFS node, then starts and probes each one. **Container Runtime** (Docker) is only detected, never installed — it is needed only for containerized agent features. Click **Skip** to continue without it; **Retry** re-runs failed steps.
+    The first launch (and the first after each update) shows a **Starting services** screen: the app downloads the proxy-router first, then optional AI runtime / demo model / IPFS, and starts the **Proxy Router** before optional services. Local AI Runtime can fail on some Windows setups (e.g. ARM Parallels without AVX2) without blocking onboarding — use remote models, or **Skip** / **Retry** as needed. **Container Runtime** (Docker) is only detected, never installed.
   </Step>
   <Step title="Onboard">
     Accept terms, set a UI password, create or recover a wallet. Save the mnemonic somewhere safe.

--- a/docs/consumers/quickstart.mdx
+++ b/docs/consumers/quickstart.mdx
@@ -3,7 +3,7 @@ title: "Consumer quickstart"
 description: "Install the MorpheusUI desktop app, let it fetch its services (proxy-router, local llama.cpp, IPFS), fund a wallet, and chat."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.6.0"
+last_verified: "v7.7.0"
 source: "docs/04-consumer-setup.md"
 ---
 
@@ -53,10 +53,10 @@ The consumer release is a **single desktop app** per OS. On first launch, the ap
   <Step title="Let the app fetch and start its services">
     The first launch (and the first one after each update) shows a **Starting services** screen with two sections:
 
-    - **Downloading** — the app fetches the proxy-router, the `llama.cpp` AI runtime, the `tinyllama` demo model, and an IPFS node, skipping anything already present on disk.
-    - **Startup** — each service is started and probed: IPFS, AI Runtime, Container Runtime, Proxy Router.
+    - **Downloading** — the app fetches the proxy-router first (required), then best-effort downloads for the `llama.cpp` AI runtime, the `tinyllama` demo model, and an IPFS node, skipping anything already present on disk.
+    - **Startup** — **Proxy Router** starts first (required for onboarding and marketplace use). IPFS, AI Runtime, and Container Runtime are optional and started afterward; a failure there does not block the UI.
 
-    **Container Runtime** (Docker) is only *detected*, never installed — it is needed solely for containerized agent features. If you don't have or need Docker (or another service fails), click **Skip** to continue into the app anyway; **Retry** re-runs any failed step.
+    **Container Runtime** (Docker) is only *detected*, never installed — it is needed solely for containerized agent features. Local AI Runtime is only for the free `tinyllama` demo; remote Morpheus models do not need it. **Skip** continues into the app; **Retry** re-runs any failed step.
   </Step>
   <Step title="Onboard MorpheusUI">
     - Read & accept the terms.

--- a/docs/get-started/quickstart-consumer.mdx
+++ b/docs/get-started/quickstart-consumer.mdx
@@ -3,7 +3,7 @@ title: "Consumer quickstart"
 description: "The 5-minute path from zero to chatting with a remote model: download, fund a wallet, open a session, prompt."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.6.0"
+last_verified: "v7.7.0"
 ---
 
 This is the shortest path to chat with a remote model on Morpheus. For a full walk-through (including the optional local-only model and cleanup), see [Consumer install](/consumers/quickstart).
@@ -43,7 +43,7 @@ This is the shortest path to chat with a remote model on Morpheus. For a full wa
     </Tabs>
   </Step>
   <Step title="Let the app fetch its components">
-    On every OS, the first launch (and the first launch after an update) shows a **Starting services** screen. The app downloads the components it needs — the proxy-router, the AI runtime (`llama.cpp`), the local demo model (`tinyllama`), and an IPFS node — verifying what is already present and skipping anything it already has. It then starts each service and shows per-item status.
+    On every OS, the first launch (and the first launch after an update) shows a **Starting services** screen. The app downloads the proxy-router first (required), then optional local AI / IPFS pieces, and starts the **Proxy Router** before optional services so onboarding is not blocked if local tinyllama or IPFS fails.
 
     One item, **Container Runtime** (Docker), is only *detected*, never installed: it is required solely for containerized agent features. If a service fails or you don't need it — no Docker installed, for example — click **Skip** to continue into the app; **Retry** re-runs the failed steps.
   </Step>

--- a/ui-desktop/src/main/orchestrator/orchestrator.ts
+++ b/ui-desktop/src/main/orchestrator/orchestrator.ts
@@ -87,6 +87,25 @@ export class Orchestrator {
     await this.resetState()
     this.emitStateUpdate()
 
+    // --- Downloads: proxy-router is required; AI / IPFS are best-effort ---
+    await this.downloadProxyRouter()
+    await this.downloadOptionalAiRuntime()
+    await this.downloadOptionalAiModel()
+    await this.downloadOptionalIpfs()
+
+    // --- Startup: proxy-router first (required for UI/onboarding) ---
+    // Local AI, IPFS, and Docker are optional. The proxy only *points at*
+    // localhost AI/IPFS in config; it does not need them running to boot,
+    // open sessions, or serve remote Morpheus models.
+    await this.startProxyRouter()
+    this.emitStateUpdate()
+
+    await this.startOptionalService('ipfs', () => this.ensureIpfsProcess())
+    await this.startOptionalService('aiRuntime', () => this.ensureAiRuntimeProcess())
+    await this.startOptionalService('containerRuntime', () => this.ensureContainerRuntimeProcess())
+  }
+
+  private async downloadProxyRouter() {
     if (this.cfg.proxyRouter.downloadUrl) {
       await downloadFile(
         this.cfg.proxyRouter.downloadUrl,
@@ -101,150 +120,126 @@ export class Orchestrator {
         this.log.scope('Proxy-router download')
       )
     }
-
     this.proxyDownloadState.status = 'success'
     this.emitStateUpdate()
+  }
 
-    if (this.cfg.aiRuntime.downloadUrl && this.cfg.aiRuntime.extractPath) {
-      if (fs.existsSync(resolveAppDataPath(this.cfg.aiRuntime.extractPath))) {
-        this.log.info(
-          'AI runtime already exists, skipping download',
-          resolveAppDataPath(this.cfg.aiRuntime.extractPath)
-        )
-        this.aiRuntimeDownloadState.status = 'success'
-        this.emitStateUpdate()
-      } else {
+  private async downloadOptionalAiRuntime() {
+    try {
+      if (this.cfg.aiRuntime.downloadUrl && this.cfg.aiRuntime.extractPath) {
+        if (fs.existsSync(resolveAppDataPath(this.cfg.aiRuntime.extractPath))) {
+          this.log.info(
+            'AI runtime already exists, skipping download',
+            resolveAppDataPath(this.cfg.aiRuntime.extractPath)
+          )
+        } else {
+          await downloadFile(
+            this.cfg.aiRuntime.downloadUrl,
+            resolveAppDataPath(this.cfg.aiRuntime.fileName),
+            (progress) => {
+              this.aiRuntimeDownloadState.status = progress.status
+              this.aiRuntimeDownloadState.progress = progress.progress
+              this.aiRuntimeDownloadState.error = progress.error
+              this.emitStateUpdate()
+              this.log.info(`Downloading ai-runtime: ${progress.bytesDownloaded} bytes`)
+            },
+            this.log.scope('Ai-runtime download')
+          )
+
+          this.log.info(`unzipping ai runtime`)
+          await extractFile(
+            resolveAppDataPath(this.cfg.aiRuntime.fileName),
+            resolveAppDataPath(this.cfg.aiRuntime.extractPath),
+            (progress) => {
+              this.aiRuntimeDownloadState.status =
+                progress.status === 'error' ? 'error' : 'unzipping'
+              this.aiRuntimeDownloadState.progress = progress.progress
+              this.aiRuntimeDownloadState.error = progress.error
+              this.emitStateUpdate()
+              this.log.info(`Extracting ai-runtime`, progress)
+            }
+          )
+        }
+      }
+      this.aiRuntimeDownloadState.status = 'success'
+    } catch (err) {
+      this.log.error('Optional AI runtime download failed; continuing', err)
+      this.aiRuntimeDownloadState.status = 'error'
+      this.aiRuntimeDownloadState.error = (err as Error)?.message ?? String(err)
+    }
+    this.emitStateUpdate()
+  }
+
+  private async downloadOptionalAiModel() {
+    try {
+      if (this.cfg.aiModel.downloadUrl) {
         await downloadFile(
-          this.cfg.aiRuntime.downloadUrl,
-          resolveAppDataPath(this.cfg.aiRuntime.fileName),
+          this.cfg.aiModel.downloadUrl,
+          resolveAppDataPath(this.cfg.aiModel.fileName),
           (progress) => {
-            this.aiRuntimeDownloadState.status = progress.status
-            this.aiRuntimeDownloadState.progress = progress.progress
-            this.aiRuntimeDownloadState.error = progress.error
+            this.aiModelDownloadState.status = progress.status
+            this.aiModelDownloadState.progress = progress.progress
+            this.aiModelDownloadState.error = progress.error
             this.emitStateUpdate()
-            this.log.info(`Downloading ai-runtime: ${progress.bytesDownloaded} bytes`)
+            this.log.info(`Downloading ai-model: ${progress.bytesDownloaded} bytes`)
           },
-          this.log.scope('Ai-runtime download')
+          this.log.scope('Ai-model download')
+        )
+      }
+      this.aiModelDownloadState.status = 'success'
+    } catch (err) {
+      this.log.error('Optional AI model download failed; continuing', err)
+      this.aiModelDownloadState.status = 'error'
+      this.aiModelDownloadState.error = (err as Error)?.message ?? String(err)
+    }
+    this.emitStateUpdate()
+  }
+
+  private async downloadOptionalIpfs() {
+    try {
+      if (
+        this.cfg.ipfs.downloadUrl &&
+        this.cfg.ipfs.extractPath &&
+        !fs.existsSync(resolveAppDataPath(this.cfg.ipfs.extractPath))
+      ) {
+        await downloadFile(
+          this.cfg.ipfs.downloadUrl,
+          resolveAppDataPath(this.cfg.ipfs.fileName),
+          (progress) => {
+            this.ipfsDownloadState.status = progress.status
+            this.ipfsDownloadState.progress = progress.progress
+            this.ipfsDownloadState.error = progress.error
+            this.emitStateUpdate()
+            this.log.info(`Downloading ipfs: ${progress.bytesDownloaded} bytes`)
+          },
+          this.log.scope('IPFS node download')
         )
 
-        this.log.info(`unzipping ai runtime`)
-
+        this.log.info(`unzipping ipfs`)
         await extractFile(
-          resolveAppDataPath(this.cfg.aiRuntime.fileName),
-          resolveAppDataPath(this.cfg.aiRuntime.extractPath),
+          resolveAppDataPath(this.cfg.ipfs.fileName),
+          resolveAppDataPath(this.cfg.ipfs.extractPath),
           (progress) => {
-            this.aiRuntimeDownloadState.status = progress.status === 'error' ? 'error' : 'unzipping'
-            this.aiRuntimeDownloadState.progress = progress.progress
-            this.aiRuntimeDownloadState.error = progress.error
+            this.ipfsDownloadState.status = progress.status === 'error' ? 'error' : 'unzipping'
+            this.ipfsDownloadState.progress = progress.progress
+            this.ipfsDownloadState.error = progress.error
             this.emitStateUpdate()
-            this.log.info(`Extracting ai-runtime`, progress)
+            this.log.info(`Extracting ipfs: ${progress.status} ${progress.progress}`)
           }
         )
       }
+      this.ipfsDownloadState.status = 'success'
+    } catch (err) {
+      this.log.error('Optional IPFS download failed; continuing', err)
+      this.ipfsDownloadState.status = 'error'
+      this.ipfsDownloadState.error = (err as Error)?.message ?? String(err)
     }
-
-    this.aiRuntimeDownloadState.status = 'success'
     this.emitStateUpdate()
+  }
 
-    if (this.cfg.aiModel.downloadUrl) {
-      await downloadFile(
-        this.cfg.aiModel.downloadUrl,
-        resolveAppDataPath(this.cfg.aiModel.fileName),
-        (progress) => {
-          this.aiModelDownloadState.status = progress.status
-          this.aiModelDownloadState.progress = progress.progress
-          this.aiModelDownloadState.error = progress.error
-          this.emitStateUpdate()
-          this.log.info(`Downloading ai-model: ${progress.bytesDownloaded} bytes`)
-        },
-        this.log.scope('Ai-model download')
-      )
-    }
-    this.aiModelDownloadState.status = 'success'
-    this.emitStateUpdate()
-
-    if (
-      this.cfg.ipfs.downloadUrl &&
-      this.cfg.ipfs.extractPath &&
-      !fs.existsSync(resolveAppDataPath(this.cfg.ipfs.extractPath))
-    ) {
-      await downloadFile(
-        this.cfg.ipfs.downloadUrl,
-        resolveAppDataPath(this.cfg.ipfs.fileName),
-        (progress) => {
-          this.ipfsDownloadState.status = progress.status
-          this.ipfsDownloadState.progress = progress.progress
-          this.ipfsDownloadState.error = progress.error
-          this.emitStateUpdate()
-          this.log.info(`Downloading ipfs: ${progress.bytesDownloaded} bytes`)
-        },
-        this.log.scope('IPFS node download')
-      )
-
-      this.log.info(`unzipping ipfs`)
-
-      await extractFile(
-        resolveAppDataPath(this.cfg.ipfs.fileName),
-        resolveAppDataPath(this.cfg.ipfs.extractPath),
-        (progress) => {
-          this.ipfsDownloadState.status = progress.status === 'error' ? 'error' : 'unzipping'
-          this.ipfsDownloadState.progress = progress.progress
-          this.ipfsDownloadState.error = progress.error
-          this.emitStateUpdate()
-          this.log.info(`Extracting ipfs: ${progress.status} ${progress.progress}`)
-        }
-      )
-    }
-    this.ipfsDownloadState.status = 'success'
-    this.emitStateUpdate()
-
-    if (!this.ipfsProcess) {
-      this.ipfsProcess = await ProcessFactory({
-        command: resolveAppDataPath(this.cfg.ipfs.runPath),
-        args: this.cfg.ipfs.runArgs,
-        log: this.log.scope('IPFS'),
-        redirectProcessOutput: true,
-        probe: this.cfg.ipfs.probe,
-        ports: this.cfg.ipfs.ports,
-        onStateChange: () => this.emitStateUpdate()
-      })
-    }
-
-    await this.ipfsProcess.start()
-    this.emitStateUpdate()
-
-    if (!this.aiRuntimeProcess) {
-      this.aiRuntimeProcess = await ProcessFactory({
-        command: resolveAppDataPath(this.cfg.aiRuntime.runPath),
-        args: this.cfg.aiRuntime.runArgs,
-        log: this.log.scope('Ai-runtime'),
-        redirectProcessOutput: false,
-        probe: this.cfg.aiRuntime.probe,
-        ports: this.cfg.aiRuntime.ports,
-        onStateChange: () => this.emitStateUpdate()
-      })
-    }
-
-    await this.aiRuntimeProcess.start()
-    this.emitStateUpdate()
-
-    // Container runtime
-    if (!this.containerRuntimeProcess) {
-      this.containerRuntimeProcess = await ProcessFactory({
-        probe: this.cfg.containerRuntime.probe,
-        onStateChange: () => this.emitStateUpdate(),
-        log: this.log.scope('Container-runtime')
-      })
-    }
-
-    await this.containerRuntimeProcess.start().catch(this.log.error)
-    this.emitStateUpdate()
-
-    // Proxy router
-
+  private async startProxyRouter() {
     const proxyFolder = path.dirname(resolveAppDataPath(this.cfg.proxyRouter.runPath))
 
-    // writting local config files if not exist
     await this.writeEnvFile(path.join(proxyFolder, '.env'), this.cfg.proxyRouter.env ?? {})
     await this.writeLocalConfigFile(
       path.join(proxyFolder, 'models-config.json'),
@@ -255,6 +250,11 @@ export class Orchestrator {
       this.cfg.proxyRouter.ratingConfig
     )
 
+    await this.ensureProxyRouterProcess()
+    await this.proxyRouterProcess!.start()
+  }
+
+  private async ensureProxyRouterProcess() {
     if (!this.proxyRouterProcess) {
       this.proxyRouterProcess = await ProcessFactory({
         command: resolveAppDataPath(this.cfg.proxyRouter.runPath),
@@ -266,8 +266,61 @@ export class Orchestrator {
         onStateChange: () => this.emitStateUpdate()
       })
     }
+  }
 
-    await this.proxyRouterProcess.start()
+  private async ensureIpfsProcess() {
+    if (!this.ipfsProcess) {
+      this.ipfsProcess = await ProcessFactory({
+        command: resolveAppDataPath(this.cfg.ipfs.runPath),
+        args: this.cfg.ipfs.runArgs,
+        log: this.log.scope('IPFS'),
+        redirectProcessOutput: true,
+        probe: this.cfg.ipfs.probe,
+        ports: this.cfg.ipfs.ports,
+        onStateChange: () => this.emitStateUpdate()
+      })
+    }
+  }
+
+  private async ensureAiRuntimeProcess() {
+    if (!this.aiRuntimeProcess) {
+      this.aiRuntimeProcess = await ProcessFactory({
+        command: resolveAppDataPath(this.cfg.aiRuntime.runPath),
+        args: this.cfg.aiRuntime.runArgs,
+        log: this.log.scope('Ai-runtime'),
+        redirectProcessOutput: false,
+        probe: this.cfg.aiRuntime.probe,
+        ports: this.cfg.aiRuntime.ports,
+        onStateChange: () => this.emitStateUpdate()
+      })
+    }
+  }
+
+  private async ensureContainerRuntimeProcess() {
+    if (!this.containerRuntimeProcess) {
+      this.containerRuntimeProcess = await ProcessFactory({
+        probe: this.cfg.containerRuntime.probe,
+        onStateChange: () => this.emitStateUpdate(),
+        log: this.log.scope('Container-runtime')
+      })
+    }
+  }
+
+  private async startOptionalService(
+    name: string,
+    ensure: () => Promise<void>
+  ): Promise<void> {
+    try {
+      await ensure()
+      const processMap: Record<string, Process | undefined> = {
+        ipfs: this.ipfsProcess,
+        aiRuntime: this.aiRuntimeProcess,
+        containerRuntime: this.containerRuntimeProcess
+      }
+      await processMap[name]?.start()
+    } catch (err) {
+      this.log.error(`Optional service ${name} failed to start; continuing`, err)
+    }
     this.emitStateUpdate()
   }
 
@@ -286,18 +339,36 @@ export class Orchestrator {
   }
 
   public async restartService(service: keyof OrchestratorConfig) {
-    const processMap = {
+    // Ensure the process object exists even if the prior pipeline never
+    // reached this service (e.g. aborted before proxy-router was created).
+    try {
+      if (service === 'proxyRouter') await this.ensureProxyRouterProcess()
+      else if (service === 'aiRuntime') await this.ensureAiRuntimeProcess()
+      else if (service === 'ipfs') await this.ensureIpfsProcess()
+      else if (service === 'containerRuntime') await this.ensureContainerRuntimeProcess()
+      else {
+        this.log.error(`Service ${service} is not restartable`)
+        return
+      }
+    } catch (err) {
+      this.log.error(`Failed to prepare service ${service} for restart`, err)
+      this.emitStateUpdate()
+      return
+    }
+
+    const processMap: Partial<Record<keyof OrchestratorConfig, Process | undefined>> = {
       proxyRouter: this.proxyRouterProcess,
       aiRuntime: this.aiRuntimeProcess,
-      ipfs: this.ipfsProcess
+      ipfs: this.ipfsProcess,
+      containerRuntime: this.containerRuntimeProcess
     }
-    const process: Process | undefined = processMap[service]
+    const process = processMap[service]
     if (!process) {
       this.log.error(`Service ${service} not found`)
       return
     }
 
-    // Only restart managed processes
+    // Only restart managed processes (container runtime is probe-only / external)
     if (process.isExternal()) {
       this.log.warn(`Cannot restart external service ${service}`)
       return
@@ -312,33 +383,24 @@ export class Orchestrator {
       this.emitStateUpdate()
     }
 
-    // If the original startAll pipeline aborted before reaching downstream
-    // services (e.g. IPFS failed, so containerRuntime + proxyRouter were
-    // never started), resume the pipeline now that this service is healthy.
+    // Resume optional services that may still be pending after a proxy restart.
     // startAll is idempotent: downloads check fs.exists, and each process's
     // start() short-circuits when already running.
-    if (process.getState() === 'running' && !this.allServicesRunning()) {
+    if (process.getState() === 'running' && !this.requiredServicesRunning()) {
       this.log.info(
-        `Service ${service} restarted; resuming startup pipeline for any downstream services still pending`
+        `Service ${service} restarted; resuming startup pipeline for any remaining services`
       )
       try {
         await this.startAll()
       } catch (err) {
         this.log.error('Resume after restart failed', err)
-        // Don't rethrow — the explicit restart did succeed; downstream
-        // failures are surfaced via the per-service state.
       }
     }
   }
 
-  private allServicesRunning(): boolean {
-    const all = [
-      this.ipfsProcess,
-      this.aiRuntimeProcess,
-      this.containerRuntimeProcess,
-      this.proxyRouterProcess
-    ]
-    return all.every((p) => p?.getState() === 'running')
+  /** Proxy-router is the only service required for the UI / onboarding to work. */
+  private requiredServicesRunning(): boolean {
+    return this.proxyRouterProcess?.getState() === 'running'
   }
 
   async ping(service: keyof OrchestratorConfig): Promise<boolean> {
@@ -377,6 +439,15 @@ export class Orchestrator {
       ],
       startup: [
         {
+          id: 'proxyRouter',
+          name: 'Proxy Router',
+          status: this.proxyRouterProcess?.getState() ?? 'pending',
+          error: this.proxyRouterProcess?.getError(),
+          stderrOutput: this.proxyRouterProcess?.getOutput(),
+          ports: this.cfg.proxyRouter.ports,
+          isExternal: this.proxyRouterProcess?.isExternal()
+        },
+        {
           id: 'ipfs',
           name: 'IPFS',
           status: this.ipfsProcess?.getState() ?? 'pending',
@@ -401,15 +472,6 @@ export class Orchestrator {
           error: this.containerRuntimeProcess?.getError(),
           stderrOutput: this.containerRuntimeProcess?.getOutput(),
           isExternal: this.containerRuntimeProcess?.isExternal()
-        },
-        {
-          id: 'proxyRouter',
-          name: 'Proxy Router',
-          status: this.proxyRouterProcess?.getState() ?? 'pending',
-          error: this.proxyRouterProcess?.getError(),
-          stderrOutput: this.proxyRouterProcess?.getOutput(),
-          ports: this.cfg.proxyRouter.ports,
-          isExternal: this.proxyRouterProcess?.isExternal()
         }
       ],
       orchestratorStatus
@@ -417,43 +479,13 @@ export class Orchestrator {
   }
 
   private calculateOrchestratorStatus(): OrchestratorStatus {
-    // Check for any errors in downloads
-    const hasDownloadErrors = [
-      this.proxyDownloadState,
-      this.aiRuntimeDownloadState,
-      this.aiModelDownloadState,
-      this.ipfsDownloadState
-    ].some((item) => item.status === 'error')
-
-    // Check for any errors in startup processes
-    const hasStartupErrors = [
-      this.ipfsProcess,
-      this.aiRuntimeProcess,
-      this.proxyRouterProcess,
-      this.containerRuntimeProcess
-    ].some((process) => process?.getError())
-
-    if (hasDownloadErrors || hasStartupErrors) {
+    // Proxy-router download/start is required. Optional service failures must
+    // not block the UI — local AI / IPFS / Docker are best-effort.
+    if (this.proxyDownloadState.status === 'error' || this.proxyRouterProcess?.getError()) {
       return 'error'
     }
 
-    // Check if all downloads are complete
-    const allDownloadsComplete = [
-      this.proxyDownloadState,
-      this.aiRuntimeDownloadState,
-      this.aiModelDownloadState,
-      this.ipfsDownloadState
-    ].every((item) => item.status === 'success')
-
-    // Check if all processes are running
-    const allProcessesRunning = [
-      this.ipfsProcess,
-      this.aiRuntimeProcess,
-      this.proxyRouterProcess,
-      this.containerRuntimeProcess
-    ].every((process) => process?.getState() === 'running')
-
-    if (allDownloadsComplete && allProcessesRunning) {
+    if (this.proxyDownloadState.status === 'success' && this.requiredServicesRunning()) {
       return 'ready'
     }
 

--- a/ui-desktop/src/renderer/src/components/StartupItem.tsx
+++ b/ui-desktop/src/renderer/src/components/StartupItem.tsx
@@ -258,7 +258,9 @@ export const StartupItemComponent: FC<{
             {showLogs ? 'Hide logs' : 'Show logs'}
           </LogsButton>
         )}
-        {props.alwaysShowPingRestart || props.item.status === 'stopped' ? (
+        {props.alwaysShowPingRestart ||
+        props.item.status === 'stopped' ||
+        props.item.status === 'pending' ? (
           <Flex.Row gap="0.5rem" justify="flex-end" grow="1">
             <PingBtn onClick={handlePing}>
               <IconText


### PR DESCRIPTION
## Summary
- Start **Proxy Router** before IPFS / AI Runtime / Container Runtime so a failing local `llama.cpp` (e.g. AVX2 illegal instruction on Windows ARM Parallels) no longer aborts the pipeline before `:8082` is up.
- Soft-fail optional downloads and starts; orchestrator is `ready` once the proxy is running.
- Fix **Restart** for services that never got a process handle (pipeline aborted early), and show Restart while status is still `pending`.
- Docs: consumer / Windows quickstarts describe the new order and that local AI is optional for marketplace use.

## Why
Fresh Windows installs hit AI Runtime health-check timeout → proxy stayed `pending` → onboarding failed with "Failed to finish onboarding". Local tinyllama is not required to use Morpheus.

## Test plan
- [ ] macOS/Linux: first launch — Proxy Router comes up even if AI Runtime is stopped/killed
- [ ] Windows (esp. ARM Parallels): AI Runtime may fail; Proxy Router still reaches `running` and onboarding can complete
- [ ] Settings → Services: Restart on Proxy Router works after a failed optional service
- [ ] Remote model chat works with AI Runtime stopped; local tinyllama only when AI Runtime is healthy

Closes #811


Made with [Cursor](https://cursor.com)