### PR TITLE
Release v7.8.0 — rating config content/denylist, proxy-first desktop startup, clipboard, zombie-sweep CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,8 +206,9 @@ jobs:
       tee_image_name: ${{ steps.gen_tag_name.outputs.tee_image_name }}
       artifacts_base_url: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ steps.gen_tag_name.outputs.tag_name }}
       # Proxy-router "anchor" the desktop app downloads its bundled router from.
-      # On main this is always vX.Y.0 (the minor's proxy baseline); on test/dev
-      # it is the current self build (router executables are always built there).
+      # On main this is always vX.Y.0 (the minor's proxy baseline). On test,
+      # full (proxy-changed) builds self-anchor; UI-only builds reuse the last
+      # known good -test release that published router binaries.
       anchor_vfull: ${{ steps.gen_tag_name.outputs.anchor_vfull }}
       anchor_tag: ${{ steps.gen_tag_name.outputs.anchor_tag }}
       anchor_artifacts_base_url: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ steps.gen_tag_name.outputs.anchor_tag }}
@@ -223,6 +224,7 @@ jobs:
         shell: bash
         env:
           PROXY_CHANGED: ${{ needs.changes.outputs.proxy }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           IMAGE_NAME="ghcr.io/morpheusais/morpheus-lumerin-node"
           VMAJ_NEW=7
@@ -280,10 +282,32 @@ jobs:
               [ "$GITHUB_EVENT_NAME" = "pull_request" ] && RNAME=pr${GITHUB_REF_NAME%/merge}
               VTAG=v${VFULL}-${RNAME}
               BUMP="prerelease"
-              # test/dev always build their own router executables, so the app
-              # anchors to this same prerelease build (self-contained).
-              ANCHOR_VFULL=${VFULL}
-              ANCHOR_TAG=${VTAG}
+              if [ "${PROXY_CHANGED}" = "true" ] || [ "$GITHUB_REF_NAME" != "test" ]; then
+                  # Full prerelease / non-test branches build their own router
+                  # executables and self-anchor.
+                  ANCHOR_VFULL=${VFULL}
+                  ANCHOR_TAG=${VTAG}
+              else
+                  # UI-only on test: same idea as main's vX.Y.0 — do not rebuild
+                  # router/docker/TEE; point the desktop app at the last known
+                  # good -test release that published router binaries.
+                  ANCHOR_TAG=""
+                  while read -r cand; do
+                      has_router=$(gh release view "$cand" --json assets \
+                        --jq '[.assets[].name | select(contains("morpheus-router"))] | length' 2>/dev/null || echo 0)
+                      if [ "${has_router:-0}" -gt 0 ]; then
+                          ANCHOR_TAG=$cand
+                          break
+                      fi
+                  done < <(git tag -l "v[0-9]*-test" | sort -V -r)
+
+                  if [ -z "$ANCHOR_TAG" ]; then
+                      echo "❌ UI-only test release needs a last-known-good -test release with router binaries" >&2
+                      exit 1
+                  fi
+                  ANCHOR_VFULL=$(echo "$ANCHOR_TAG" | sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+                  BUMP="prerelease (UI-only, proxy anchored to ${ANCHOR_TAG})"
+              fi
           fi
 
           # Output variables for use in subsequent jobs environment
@@ -304,7 +328,7 @@ jobs:
     name: Test Proxy Router Docker Image
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
-      !(github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.proxy != 'true') &&
+      !(github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test') && needs.changes.outputs.proxy != 'true') &&
       (
         (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test' || github.ref == 'refs/heads/dev')) ||
         (github.event_name == 'workflow_dispatch') 
@@ -351,7 +375,7 @@ jobs:
     name: Build & Push Docker Image
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
-      !(github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.proxy != 'true') &&
+      !(github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test') && needs.changes.outputs.proxy != 'true') &&
       (
         (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/')|| github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true') 
@@ -453,7 +477,7 @@ jobs:
     name: Build & Push TEE Docker Image
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
-      !(github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.proxy != 'true') &&
+      !(github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test') && needs.changes.outputs.proxy != 'true') &&
       (
         (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/cicd/')|| github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true') 
@@ -1193,7 +1217,7 @@ jobs:
     name: Build Service Executables
     if: |
       github.repository == 'MorpheusAIs/Morpheus-Lumerin-Node' &&
-      !(github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.proxy != 'true') &&
+      !(github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test') && needs.changes.outputs.proxy != 'true') &&
       (
         (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test')) ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all_os == 'true') 
@@ -3296,16 +3320,16 @@ jobs:
         id: mode
         run: |
           # "full" = router/docker/TEE/executables were built in this run and are
-          # attached to THIS release. "ui-only" = a UI/CLI patch on main where the
-          # router stays at the anchor (vX.Y.0) and is NOT re-attached here.
-          if [ "${{ github.ref }}" != "refs/heads/main" ] || \
-             [ "${{ needs.changes.outputs.proxy }}" = "true" ] || \
-             [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "full=true" >> "$GITHUB_OUTPUT"
-            echo "Release mode: FULL"
-          else
+          # attached to THIS release. "ui-only" = a UI/CLI patch on main or test
+          # where the router stays at the anchor and is NOT re-attached here.
+          if { [ "${{ github.ref }}" = "refs/heads/main" ] || [ "${{ github.ref }}" = "refs/heads/test" ]; } && \
+             [ "${{ needs.changes.outputs.proxy }}" != "true" ] && \
+             [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
             echo "full=false" >> "$GITHUB_OUTPUT"
             echo "Release mode: UI-ONLY (router anchored to ${{ needs.Generate-Tag.outputs.anchor_tag }})"
+          else
+            echo "full=true" >> "$GITHUB_OUTPUT"
+            echo "Release mode: FULL"
           fi
 
       - name: Generate release notes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2240,21 +2240,51 @@ jobs:
           fi
 
           FUNCTION_NAME="${ENV}-routed-sessions-sweep"
-          # deploy_cutoff mode (default): the Lambda derives cutoff from the C-Node
-          # service deployments[0].updatedAt + rehydration + safety, then closes
-          # OPEN rows older than that. release_tag only annotates error_reason.
+          CLUSTER_NAME="ecs-${ENV}-morpheus-engine"
+          SERVICE_NAME="svc-${ENV}-router"
+          # Must match Lambda DEFAULT_REHYDRATION_SECS / DEFAULT_SAFETY_SECS
+          # (02-morpheus_c_node/.terragrunt/06_routed_sessions_sweep.tf).
+          REHYDRATION_SECS=90
+          SAFETY_SECS=120
+          SKEW_BUFFER_SECS=15
+
+          # deploy_cutoff mode (default): the Lambda derives cutoff from the
+          # C-Node PRIMARY deployment updatedAt + rehydration + safety, then
+          # closes OPEN rows older than that. release_tag only annotates
+          # error_reason.
           PAYLOAD="{\"release_tag\":\"${BUILDTAG}\"}"
 
-          # This job starts seconds after the C-Node deploy settles, but the
-          # Lambda's cutoff = deployments[0].updatedAt + 90s rehydration + 120s
-          # safety (~210s ahead) and it REFUSES a future cutoff. So the first
-          # invoke almost always lands before the cutoff and no-ops with a 400.
-          # Retry with backoff until the cutoff has passed (or the budget is
-          # exhausted) so the sweep actually runs. Budget: 10 * 30s = ~5 min,
-          # comfortably past the ~210s cutoff. Only the future-cutoff case is
-          # retried; any other status (200 / SWEEP_MAX_ROWS / error) is terminal.
-          MAX_ATTEMPTS=10
-          SLEEP_SECS=30
+          # Proactive wait: the Lambda REFUSES a future cutoff (would close
+          # fresh sessions). Invoking immediately after C-Node settle almost
+          # always 400s for ~updatedAt+210s, and the old 10×30s retry budget
+          # was barely enough — leaving zombies OPEN long enough to reopen/
+          # failover-storm MOR. Sleep until the same cutoff the Lambda will
+          # derive, then invoke (small retry loop only for clock skew).
+          echo "🔎 Resolving C-Node PRIMARY updatedAt from ${CLUSTER_NAME}/${SERVICE_NAME}..."
+          UPDATED_AT=$(aws ecs describe-services \
+            --cluster "$CLUSTER_NAME" \
+            --services "$SERVICE_NAME" \
+            --query 'services[0].deployments[?status==`PRIMARY`]|[0].updatedAt' \
+            --output text)
+          if [ -z "$UPDATED_AT" ] || [ "$UPDATED_AT" = "None" ]; then
+            echo "⚠️ Could not resolve PRIMARY updatedAt; falling back to fixed ${REHYDRATION_SECS}+${SAFETY_SECS}s wait."
+            sleep $((REHYDRATION_SECS + SAFETY_SECS + SKEW_BUFFER_SECS))
+          else
+            echo "📌 PRIMARY updatedAt: ${UPDATED_AT}"
+            UPDATED_EPOCH=$(date -d "$UPDATED_AT" +%s)
+            CUTOFF_EPOCH=$((UPDATED_EPOCH + REHYDRATION_SECS + SAFETY_SECS + SKEW_BUFFER_SECS))
+            NOW_EPOCH=$(date +%s)
+            WAIT_SECS=$((CUTOFF_EPOCH - NOW_EPOCH))
+            if [ "$WAIT_SECS" -gt 0 ]; then
+              echo "⏳ Waiting ${WAIT_SECS}s for sweep cutoff (updatedAt + ${REHYDRATION_SECS}s + ${SAFETY_SECS}s + ${SKEW_BUFFER_SECS}s skew)..."
+              sleep "$WAIT_SECS"
+            else
+              echo "✅ Cutoff already in the past (${WAIT_SECS}s); invoking immediately."
+            fi
+          fi
+
+          MAX_ATTEMPTS=5
+          SLEEP_SECS=20
           STATUS=""
           BODY=""
           FUNCTION_ERROR=""
@@ -2290,8 +2320,7 @@ jobs:
               break
             fi
 
-            # Retry ONLY the "future cutoff" 400 — we just deployed and need to
-            # wait for the cutoff to pass. Everything else is a final result.
+            # Retry ONLY residual "future cutoff" 400 (clock skew / ECS lag).
             if [ "$STATUS" = "400" ] && echo "$BODY" | grep -qi "in the future"; then
               if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
                 echo "⏳ Cutoff not reached yet; sleeping ${SLEEP_SECS}s before retry."
@@ -2307,6 +2336,7 @@ jobs:
             echo ""
             echo "- **Function:** \`${FUNCTION_NAME}\`"
             echo "- **Release tag:** \`${BUILDTAG}\`"
+            echo "- **PRIMARY updatedAt:** \`${UPDATED_AT:-unknown}\`"
             echo "- **Handler statusCode:** \`${STATUS:-unknown}\`"
             if [ -n "$BODY" ]; then
               echo ""

--- a/docs/consumers/install/windows.mdx
+++ b/docs/consumers/install/windows.mdx
@@ -3,7 +3,7 @@ title: "Windows install"
 description: "Run the MorpheusUI desktop app (portable exe) on Windows."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.6.0"
+last_verified: "v7.7.0"
 ---
 
 The Windows release is a single **portable executable**. On first launch, the app downloads and manages its own services — proxy-router, `llama.cpp` AI runtime with the `tinyllama` demo model, and an IPFS node. For source builds, see [macOS install](/consumers/install/macos) and adapt the toolchain.
@@ -18,7 +18,7 @@ The Windows release is a single **portable executable**. On first launch, the ap
     Double-click the `.exe`. Windows Defender may prompt — allow it.
   </Step>
   <Step title="Let the app fetch its services">
-    The first launch (and the first after each update) shows a **Starting services** screen: the app downloads the proxy-router, AI runtime, demo model, and IPFS node, then starts and probes each one. **Container Runtime** (Docker) is only detected, never installed — it is needed only for containerized agent features. Click **Skip** to continue without it; **Retry** re-runs failed steps.
+    The first launch (and the first after each update) shows a **Starting services** screen: the app downloads the proxy-router first, then optional AI runtime / demo model / IPFS, and starts the **Proxy Router** before optional services. Local AI Runtime can fail on some Windows setups (e.g. ARM Parallels without AVX2) without blocking onboarding — use remote models, or **Skip** / **Retry** as needed. **Container Runtime** (Docker) is only detected, never installed.
   </Step>
   <Step title="Onboard">
     Accept terms, set a UI password, create or recover a wallet. Save the mnemonic somewhere safe.

--- a/docs/consumers/quickstart.mdx
+++ b/docs/consumers/quickstart.mdx
@@ -3,7 +3,7 @@ title: "Consumer quickstart"
 description: "Install the MorpheusUI desktop app, let it fetch its services (proxy-router, local llama.cpp, IPFS), fund a wallet, and chat."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.6.0"
+last_verified: "v7.7.0"
 source: "docs/04-consumer-setup.md"
 ---
 
@@ -53,10 +53,10 @@ The consumer release is a **single desktop app** per OS. On first launch, the ap
   <Step title="Let the app fetch and start its services">
     The first launch (and the first one after each update) shows a **Starting services** screen with two sections:
 
-    - **Downloading** — the app fetches the proxy-router, the `llama.cpp` AI runtime, the `tinyllama` demo model, and an IPFS node, skipping anything already present on disk.
-    - **Startup** — each service is started and probed: IPFS, AI Runtime, Container Runtime, Proxy Router.
+    - **Downloading** — the app fetches the proxy-router first (required), then best-effort downloads for the `llama.cpp` AI runtime, the `tinyllama` demo model, and an IPFS node, skipping anything already present on disk.
+    - **Startup** — **Proxy Router** starts first (required for onboarding and marketplace use). IPFS, AI Runtime, and Container Runtime are optional and started afterward; a failure there does not block the UI.
 
-    **Container Runtime** (Docker) is only *detected*, never installed — it is needed solely for containerized agent features. If you don't have or need Docker (or another service fails), click **Skip** to continue into the app anyway; **Retry** re-runs any failed step.
+    **Container Runtime** (Docker) is only *detected*, never installed — it is needed solely for containerized agent features. Local AI Runtime is only for the free `tinyllama` demo; remote Morpheus models do not need it. **Skip** continues into the app; **Retry** re-runs any failed step.
   </Step>
   <Step title="Onboard MorpheusUI">
     - Read & accept the terms.

--- a/docs/get-started/quickstart-consumer.mdx
+++ b/docs/get-started/quickstart-consumer.mdx
@@ -3,7 +3,7 @@ title: "Consumer quickstart"
 description: "The 5-minute path from zero to chatting with a remote model: download, fund a wallet, open a session, prompt."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.6.0"
+last_verified: "v7.7.0"
 ---
 
 This is the shortest path to chat with a remote model on Morpheus. For a full walk-through (including the optional local-only model and cleanup), see [Consumer install](/consumers/quickstart).
@@ -43,7 +43,7 @@ This is the shortest path to chat with a remote model on Morpheus. For a full wa
     </Tabs>
   </Step>
   <Step title="Let the app fetch its components">
-    On every OS, the first launch (and the first launch after an update) shows a **Starting services** screen. The app downloads the components it needs — the proxy-router, the AI runtime (`llama.cpp`), the local demo model (`tinyllama`), and an IPFS node — verifying what is already present and skipping anything it already has. It then starts each service and shows per-item status.
+    On every OS, the first launch (and the first launch after an update) shows a **Starting services** screen. The app downloads the proxy-router first (required), then optional local AI / IPFS pieces, and starts the **Proxy Router** before optional services so onboarding is not blocked if local tinyllama or IPFS fails.
 
     One item, **Container Runtime** (Docker), is only *detected*, never installed: it is required solely for containerized agent features. If a service fails or you don't need it — no Docker installed, for example — click **Skip** to continue into the app; **Retry** re-runs the failed steps.
   </Step>

--- a/docs/reference/rating-config.mdx
+++ b/docs/reference/rating-config.mdx
@@ -7,13 +7,16 @@ last_verified: "v7.0.0"
 source: "docs/rating-config.json.md"
 ---
 
-`rating-config.json` configures the **rating system** the consumer proxy-router uses when picking which provider to route a session to. It lives in the project root by default; override path via `RATING_CONFIG_PATH`.
+`rating-config.json` configures the **rating system** the consumer proxy-router uses when picking which provider to route a session to. It lives in the project root by default; override path via `RATING_CONFIG_PATH`, or supply the JSON inline via the `RATING_CONFIG_CONTENT` environment variable (useful for containers where mounting a file is inconvenient — same pattern as `MODELS_CONFIG_CONTENT`).
+
+Load order: the file at `RATING_CONFIG_PATH` (or `./rating-config.json`) wins if it exists; otherwise `RATING_CONFIG_CONTENT` is used; otherwise built-in defaults (empty allowlist, `default` algorithm).
 
 ## Fields
 
 | Field | Notes |
 |-------|-------|
 | `providerAllowlist` | Array of provider addresses. **Empty** = allow all providers. |
+| `providerDenylist` | Array of provider addresses excluded from rating and session opening. Takes precedence over the allowlist. |
 | `algorithm` | Rating algorithm. `default` is the canonical built-in. |
 | `params` | Algorithm-specific parameters. For `default`, the `weights` block (see below). |
 

--- a/proxy-router/.env.example
+++ b/proxy-router/.env.example
@@ -36,6 +36,7 @@ WEB_PUBLIC_URL=http://localhost:8082
 MODELS_CONFIG_CONTENT='{"$schema":"./internal/config/models-config-schema.json","models":[{"modelId":"0x0000000000000000000000000000000000000000000000000000000000000000","modelName":"llama2","apiType":"openai","apiUrl":"http://localhost:8080/v1"},{"modelId":"0x0000000000000000000000000000000000000000000000000000000000000001","modelName":"inference.sdxl.txt2img.v1","apiType":"prodia-v2","apiUrl":"https://inference.prodia.com/v2","apiKey":"FILL_ME_IN"},{"modelId":"0x0000000000000000000000000000000000000000000000000000000000000002","modelName":"SDXL1.0-base","apiType":"hyperbolic-sd","apiUrl":"https://api.hyperbolic.xyz/v1","apiKey":"FILL_ME_IN","parameters":{"cfg_scale":"5","steps":"30"}},{"modelId":"0x0000000000000000000000000000000000000000000000000000000000000003","modelName":"claude-3-5-sonnet-20241022","apiType":"claudeai","apiUrl":"https://api.anthropic.com/v1","apiKey":"FILL_ME_IN"},{"modelId":"0x0000000000000000000000000000000000000000000000000000000000000004","modelName":"inference.sd15.txt2img.v1","apiType":"prodia-v2","apiUrl":"https://inference.prodia.com/v2","apiKey":"FILL_ME_IN"},{"modelId":"0x0000000000000000000000000000000000000000000000000000000000000005","modelName":"gpt-4o-mini","apiType":"openai","apiUrl":"https://api.openai.com/v1","apiKey":"FILL_ME_IN"}]}'
 MODELS_CONFIG_PATH=
 RATING_CONFIG_PATH=
+RATING_CONFIG_CONTENT=
 ETH_NODE_USE_SUBSCRIPTIONS=false
 ETH_NODE_ADDRESS=
 ETH_NODE_LEGACY_TX=false

--- a/proxy-router/cmd/main.go
+++ b/proxy-router/cmd/main.go
@@ -274,7 +274,7 @@ func start() error {
 		appLog.Infof("using polling for blockchain events")
 	}
 
-	scorer, err := config.LoadRating(cfg.Proxy.RatingConfigPath, appLog)
+	scorer, err := config.LoadRating(cfg.Proxy.RatingConfigPath, cfg.Proxy.RatingConfigContent, appLog)
 	if err != nil {
 		return err
 	}

--- a/proxy-router/internal/blockchainapi/rating_test.go
+++ b/proxy-router/internal/blockchainapi/rating_test.go
@@ -14,7 +14,7 @@ func TestRating(t *testing.T) {
 	bidIds, bids, pmStats, mStats := sampleDataTPS()
 
 	bs := BlockchainService{
-		rating: rating.NewRating(rating.NewScorerMock(), nil, lib.NewTestLogger()),
+		rating: rating.NewRating(rating.NewScorerMock(), nil, nil, lib.NewTestLogger()),
 	}
 
 	scoredBids := bs.rateBids(bidIds, bids, pmStats, []providerregistry.IProviderStorageProvider{}, mStats, big.NewInt(0), lib.NewTestLogger())

--- a/proxy-router/internal/config/config.go
+++ b/proxy-router/internal/config/config.go
@@ -67,6 +67,7 @@ type Config struct {
 		ModelsConfigPath           string        `env:"MODELS_CONFIG_PATH" flag:"models-config-path" validate:"omitempty"`
 		ModelsConfigContent        string        `env:"MODELS_CONFIG_CONTENT" flag:"models-config-content" validate:"omitempty" desc:"content of the models config file"`
 		RatingConfigPath           string        `env:"RATING_CONFIG_PATH" flag:"rating-config-path" validate:"omitempty" desc:"path to the rating config file"`
+		RatingConfigContent        string        `env:"RATING_CONFIG_CONTENT" flag:"rating-config-content" validate:"omitempty" desc:"content of the rating config file"`
 		CookieFilePath             string        `env:"COOKIE_FILE_PATH" flag:"cookie-file-path" validate:"omitempty" desc:"path to the cookie file"`
 		CookieContent              string        `env:"COOKIE_CONTENT" flag:"cookie-content" validate:"omitempty" desc:"content of the cookie file"`
 		AuthConfigFilePath         string        `env:"AUTH_CONFIG_FILE_PATH" flag:"auth-config-file-path" validate:"omitempty"`

--- a/proxy-router/internal/config/rating_config.go
+++ b/proxy-router/internal/config/rating_config.go
@@ -25,7 +25,7 @@ const (
 	`
 )
 
-func LoadRating(path string, log lib.ILogger) (*rating.Rating, error) {
+func LoadRating(path string, content string, log lib.ILogger) (*rating.Rating, error) {
 	log = log.Named("RATING_LOADER")
 
 	filePath := DefaultRatingConfigPath
@@ -35,8 +35,13 @@ func LoadRating(path string, log lib.ILogger) (*rating.Rating, error) {
 
 	config, err := lib.ReadJSONFile(filePath)
 	if err != nil {
-		log.Warnf("failed to load rating config file, using defaults")
-		config = RatingConfigDefault
+		if content != "" {
+			log.Infof("rating config file not found, using RATING_CONFIG_CONTENT")
+			config = content
+		} else {
+			log.Warnf("failed to load rating config file, using defaults")
+			config = RatingConfigDefault
+		}
 	} else {
 		log.Infof("rating config loaded from file: %s", filePath)
 	}

--- a/proxy-router/internal/rating/rating-config-schema.json
+++ b/proxy-router/internal/rating/rating-config-schema.json
@@ -18,6 +18,16 @@
       "uniqueItems": true,
       "title": "Provider allowlist",
       "description": "List of provider addresses that are allowed to open session with"
+    },
+    "providerDenylist": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^0x[0-9a-fA-F]{40}$"
+      },
+      "uniqueItems": true,
+      "title": "Provider denylist",
+      "description": "List of provider addresses that are excluded from bid rating and session opening; takes precedence over the allowlist"
     }
   },
   "allOf": [

--- a/proxy-router/internal/rating/rating.go
+++ b/proxy-router/internal/rating/rating.go
@@ -12,6 +12,7 @@ import (
 type Rating struct {
 	scorer            Scorer
 	providerAllowList map[common.Address]struct{}
+	providerDenyList  map[common.Address]struct{}
 }
 
 func (r *Rating) RateBids(scoreInputs []RatingInput, log lib.ILogger) []RatingRes {
@@ -20,7 +21,7 @@ func (r *Rating) RateBids(scoreInputs []RatingInput, log lib.ILogger) []RatingRe
 	for _, input := range scoreInputs {
 		score := r.scorer.GetScore(&input.ScoreInput)
 		if !r.isAllowed(input.ProviderID) {
-			log.Warnf("provider %s is not in the allow list, skipping", input.ProviderID.String())
+			log.Warnf("provider %s is filtered out by allowlist/denylist, skipping", input.ProviderID.String())
 			continue
 		}
 
@@ -44,6 +45,9 @@ func (r *Rating) RateBids(scoreInputs []RatingInput, log lib.ILogger) []RatingRe
 }
 
 func (r *Rating) isAllowed(provider common.Address) bool {
+	if _, denied := r.providerDenyList[provider]; denied {
+		return false
+	}
 	if len(r.providerAllowList) == 0 {
 		return true
 	}

--- a/proxy-router/internal/rating/rating_factory.go
+++ b/proxy-router/internal/rating/rating_factory.go
@@ -17,6 +17,7 @@ type RatingConfig struct {
 	Algorithm         string           `json:"algorithm"`
 	Params            json.RawMessage  `json:"params"`
 	ProviderAllowList []common.Address `json:"providerAllowlist"`
+	ProviderDenyList  []common.Address `json:"providerDenylist"`
 }
 
 func NewRatingFromConfig(config json.RawMessage, log lib.ILogger) (*Rating, error) {
@@ -33,10 +34,10 @@ func NewRatingFromConfig(config json.RawMessage, log lib.ILogger) (*Rating, erro
 		return nil, err
 	}
 
-	return NewRating(scorer, cfg.ProviderAllowList, log), nil
+	return NewRating(scorer, cfg.ProviderAllowList, cfg.ProviderDenyList, log), nil
 }
 
-func NewRating(scorer Scorer, providerAllowList []common.Address, log lib.ILogger) *Rating {
+func NewRating(scorer Scorer, providerAllowList []common.Address, providerDenyList []common.Address, log lib.ILogger) *Rating {
 	allowList := map[common.Address]struct{}{}
 
 	if providerAllowList != nil {
@@ -57,19 +58,37 @@ func NewRating(scorer Scorer, providerAllowList []common.Address, log lib.ILogge
 		log.Warnf("added %d addresses from PROVIDER_ALLOW_LIST", len(addresses))
 	}
 
-	if len(allowList) == 0 {
+	denyList := map[common.Address]struct{}{}
+
+	if providerDenyList != nil {
+		for _, addr := range providerDenyList {
+			denyList[addr] = struct{}{}
+		}
+	}
+
+	if len(allowList) == 0 && len(denyList) == 0 {
 		log.Infof("provider filtering is disabled")
 	} else {
-		keys := maps.Keys(allowList)
-		sort.Slice(keys, func(i, j int) bool {
-			return keys[i].Hex() < keys[j].Hex()
-		})
-		log.Warnf("provider filtering is enabled, allowList: %v", keys)
+		if len(allowList) > 0 {
+			keys := maps.Keys(allowList)
+			sort.Slice(keys, func(i, j int) bool {
+				return keys[i].Hex() < keys[j].Hex()
+			})
+			log.Warnf("provider filtering is enabled, allowList: %v", keys)
+		}
+		if len(denyList) > 0 {
+			keys := maps.Keys(denyList)
+			sort.Slice(keys, func(i, j int) bool {
+				return keys[i].Hex() < keys[j].Hex()
+			})
+			log.Warnf("provider filtering is enabled, denyList: %v", keys)
+		}
 	}
 
 	return &Rating{
 		scorer:            scorer,
 		providerAllowList: allowList,
+		providerDenyList:  denyList,
 	}
 }
 

--- a/ui-desktop/src/main/orchestrator/orchestrator.ts
+++ b/ui-desktop/src/main/orchestrator/orchestrator.ts
@@ -87,6 +87,25 @@ export class Orchestrator {
     await this.resetState()
     this.emitStateUpdate()
 
+    // --- Downloads: proxy-router is required; AI / IPFS are best-effort ---
+    await this.downloadProxyRouter()
+    await this.downloadOptionalAiRuntime()
+    await this.downloadOptionalAiModel()
+    await this.downloadOptionalIpfs()
+
+    // --- Startup: proxy-router first (required for UI/onboarding) ---
+    // Local AI, IPFS, and Docker are optional. The proxy only *points at*
+    // localhost AI/IPFS in config; it does not need them running to boot,
+    // open sessions, or serve remote Morpheus models.
+    await this.startProxyRouter()
+    this.emitStateUpdate()
+
+    await this.startOptionalService('ipfs', () => this.ensureIpfsProcess())
+    await this.startOptionalService('aiRuntime', () => this.ensureAiRuntimeProcess())
+    await this.startOptionalService('containerRuntime', () => this.ensureContainerRuntimeProcess())
+  }
+
+  private async downloadProxyRouter() {
     if (this.cfg.proxyRouter.downloadUrl) {
       await downloadFile(
         this.cfg.proxyRouter.downloadUrl,
@@ -101,150 +120,126 @@ export class Orchestrator {
         this.log.scope('Proxy-router download')
       )
     }
-
     this.proxyDownloadState.status = 'success'
     this.emitStateUpdate()
+  }
 
-    if (this.cfg.aiRuntime.downloadUrl && this.cfg.aiRuntime.extractPath) {
-      if (fs.existsSync(resolveAppDataPath(this.cfg.aiRuntime.extractPath))) {
-        this.log.info(
-          'AI runtime already exists, skipping download',
-          resolveAppDataPath(this.cfg.aiRuntime.extractPath)
-        )
-        this.aiRuntimeDownloadState.status = 'success'
-        this.emitStateUpdate()
-      } else {
+  private async downloadOptionalAiRuntime() {
+    try {
+      if (this.cfg.aiRuntime.downloadUrl && this.cfg.aiRuntime.extractPath) {
+        if (fs.existsSync(resolveAppDataPath(this.cfg.aiRuntime.extractPath))) {
+          this.log.info(
+            'AI runtime already exists, skipping download',
+            resolveAppDataPath(this.cfg.aiRuntime.extractPath)
+          )
+        } else {
+          await downloadFile(
+            this.cfg.aiRuntime.downloadUrl,
+            resolveAppDataPath(this.cfg.aiRuntime.fileName),
+            (progress) => {
+              this.aiRuntimeDownloadState.status = progress.status
+              this.aiRuntimeDownloadState.progress = progress.progress
+              this.aiRuntimeDownloadState.error = progress.error
+              this.emitStateUpdate()
+              this.log.info(`Downloading ai-runtime: ${progress.bytesDownloaded} bytes`)
+            },
+            this.log.scope('Ai-runtime download')
+          )
+
+          this.log.info(`unzipping ai runtime`)
+          await extractFile(
+            resolveAppDataPath(this.cfg.aiRuntime.fileName),
+            resolveAppDataPath(this.cfg.aiRuntime.extractPath),
+            (progress) => {
+              this.aiRuntimeDownloadState.status =
+                progress.status === 'error' ? 'error' : 'unzipping'
+              this.aiRuntimeDownloadState.progress = progress.progress
+              this.aiRuntimeDownloadState.error = progress.error
+              this.emitStateUpdate()
+              this.log.info(`Extracting ai-runtime`, progress)
+            }
+          )
+        }
+      }
+      this.aiRuntimeDownloadState.status = 'success'
+    } catch (err) {
+      this.log.error('Optional AI runtime download failed; continuing', err)
+      this.aiRuntimeDownloadState.status = 'error'
+      this.aiRuntimeDownloadState.error = (err as Error)?.message ?? String(err)
+    }
+    this.emitStateUpdate()
+  }
+
+  private async downloadOptionalAiModel() {
+    try {
+      if (this.cfg.aiModel.downloadUrl) {
         await downloadFile(
-          this.cfg.aiRuntime.downloadUrl,
-          resolveAppDataPath(this.cfg.aiRuntime.fileName),
+          this.cfg.aiModel.downloadUrl,
+          resolveAppDataPath(this.cfg.aiModel.fileName),
           (progress) => {
-            this.aiRuntimeDownloadState.status = progress.status
-            this.aiRuntimeDownloadState.progress = progress.progress
-            this.aiRuntimeDownloadState.error = progress.error
+            this.aiModelDownloadState.status = progress.status
+            this.aiModelDownloadState.progress = progress.progress
+            this.aiModelDownloadState.error = progress.error
             this.emitStateUpdate()
-            this.log.info(`Downloading ai-runtime: ${progress.bytesDownloaded} bytes`)
+            this.log.info(`Downloading ai-model: ${progress.bytesDownloaded} bytes`)
           },
-          this.log.scope('Ai-runtime download')
+          this.log.scope('Ai-model download')
+        )
+      }
+      this.aiModelDownloadState.status = 'success'
+    } catch (err) {
+      this.log.error('Optional AI model download failed; continuing', err)
+      this.aiModelDownloadState.status = 'error'
+      this.aiModelDownloadState.error = (err as Error)?.message ?? String(err)
+    }
+    this.emitStateUpdate()
+  }
+
+  private async downloadOptionalIpfs() {
+    try {
+      if (
+        this.cfg.ipfs.downloadUrl &&
+        this.cfg.ipfs.extractPath &&
+        !fs.existsSync(resolveAppDataPath(this.cfg.ipfs.extractPath))
+      ) {
+        await downloadFile(
+          this.cfg.ipfs.downloadUrl,
+          resolveAppDataPath(this.cfg.ipfs.fileName),
+          (progress) => {
+            this.ipfsDownloadState.status = progress.status
+            this.ipfsDownloadState.progress = progress.progress
+            this.ipfsDownloadState.error = progress.error
+            this.emitStateUpdate()
+            this.log.info(`Downloading ipfs: ${progress.bytesDownloaded} bytes`)
+          },
+          this.log.scope('IPFS node download')
         )
 
-        this.log.info(`unzipping ai runtime`)
-
+        this.log.info(`unzipping ipfs`)
         await extractFile(
-          resolveAppDataPath(this.cfg.aiRuntime.fileName),
-          resolveAppDataPath(this.cfg.aiRuntime.extractPath),
+          resolveAppDataPath(this.cfg.ipfs.fileName),
+          resolveAppDataPath(this.cfg.ipfs.extractPath),
           (progress) => {
-            this.aiRuntimeDownloadState.status = progress.status === 'error' ? 'error' : 'unzipping'
-            this.aiRuntimeDownloadState.progress = progress.progress
-            this.aiRuntimeDownloadState.error = progress.error
+            this.ipfsDownloadState.status = progress.status === 'error' ? 'error' : 'unzipping'
+            this.ipfsDownloadState.progress = progress.progress
+            this.ipfsDownloadState.error = progress.error
             this.emitStateUpdate()
-            this.log.info(`Extracting ai-runtime`, progress)
+            this.log.info(`Extracting ipfs: ${progress.status} ${progress.progress}`)
           }
         )
       }
+      this.ipfsDownloadState.status = 'success'
+    } catch (err) {
+      this.log.error('Optional IPFS download failed; continuing', err)
+      this.ipfsDownloadState.status = 'error'
+      this.ipfsDownloadState.error = (err as Error)?.message ?? String(err)
     }
-
-    this.aiRuntimeDownloadState.status = 'success'
     this.emitStateUpdate()
+  }
 
-    if (this.cfg.aiModel.downloadUrl) {
-      await downloadFile(
-        this.cfg.aiModel.downloadUrl,
-        resolveAppDataPath(this.cfg.aiModel.fileName),
-        (progress) => {
-          this.aiModelDownloadState.status = progress.status
-          this.aiModelDownloadState.progress = progress.progress
-          this.aiModelDownloadState.error = progress.error
-          this.emitStateUpdate()
-          this.log.info(`Downloading ai-model: ${progress.bytesDownloaded} bytes`)
-        },
-        this.log.scope('Ai-model download')
-      )
-    }
-    this.aiModelDownloadState.status = 'success'
-    this.emitStateUpdate()
-
-    if (
-      this.cfg.ipfs.downloadUrl &&
-      this.cfg.ipfs.extractPath &&
-      !fs.existsSync(resolveAppDataPath(this.cfg.ipfs.extractPath))
-    ) {
-      await downloadFile(
-        this.cfg.ipfs.downloadUrl,
-        resolveAppDataPath(this.cfg.ipfs.fileName),
-        (progress) => {
-          this.ipfsDownloadState.status = progress.status
-          this.ipfsDownloadState.progress = progress.progress
-          this.ipfsDownloadState.error = progress.error
-          this.emitStateUpdate()
-          this.log.info(`Downloading ipfs: ${progress.bytesDownloaded} bytes`)
-        },
-        this.log.scope('IPFS node download')
-      )
-
-      this.log.info(`unzipping ipfs`)
-
-      await extractFile(
-        resolveAppDataPath(this.cfg.ipfs.fileName),
-        resolveAppDataPath(this.cfg.ipfs.extractPath),
-        (progress) => {
-          this.ipfsDownloadState.status = progress.status === 'error' ? 'error' : 'unzipping'
-          this.ipfsDownloadState.progress = progress.progress
-          this.ipfsDownloadState.error = progress.error
-          this.emitStateUpdate()
-          this.log.info(`Extracting ipfs: ${progress.status} ${progress.progress}`)
-        }
-      )
-    }
-    this.ipfsDownloadState.status = 'success'
-    this.emitStateUpdate()
-
-    if (!this.ipfsProcess) {
-      this.ipfsProcess = await ProcessFactory({
-        command: resolveAppDataPath(this.cfg.ipfs.runPath),
-        args: this.cfg.ipfs.runArgs,
-        log: this.log.scope('IPFS'),
-        redirectProcessOutput: true,
-        probe: this.cfg.ipfs.probe,
-        ports: this.cfg.ipfs.ports,
-        onStateChange: () => this.emitStateUpdate()
-      })
-    }
-
-    await this.ipfsProcess.start()
-    this.emitStateUpdate()
-
-    if (!this.aiRuntimeProcess) {
-      this.aiRuntimeProcess = await ProcessFactory({
-        command: resolveAppDataPath(this.cfg.aiRuntime.runPath),
-        args: this.cfg.aiRuntime.runArgs,
-        log: this.log.scope('Ai-runtime'),
-        redirectProcessOutput: false,
-        probe: this.cfg.aiRuntime.probe,
-        ports: this.cfg.aiRuntime.ports,
-        onStateChange: () => this.emitStateUpdate()
-      })
-    }
-
-    await this.aiRuntimeProcess.start()
-    this.emitStateUpdate()
-
-    // Container runtime
-    if (!this.containerRuntimeProcess) {
-      this.containerRuntimeProcess = await ProcessFactory({
-        probe: this.cfg.containerRuntime.probe,
-        onStateChange: () => this.emitStateUpdate(),
-        log: this.log.scope('Container-runtime')
-      })
-    }
-
-    await this.containerRuntimeProcess.start().catch(this.log.error)
-    this.emitStateUpdate()
-
-    // Proxy router
-
+  private async startProxyRouter() {
     const proxyFolder = path.dirname(resolveAppDataPath(this.cfg.proxyRouter.runPath))
 
-    // writting local config files if not exist
     await this.writeEnvFile(path.join(proxyFolder, '.env'), this.cfg.proxyRouter.env ?? {})
     await this.writeLocalConfigFile(
       path.join(proxyFolder, 'models-config.json'),
@@ -255,6 +250,11 @@ export class Orchestrator {
       this.cfg.proxyRouter.ratingConfig
     )
 
+    await this.ensureProxyRouterProcess()
+    await this.proxyRouterProcess!.start()
+  }
+
+  private async ensureProxyRouterProcess() {
     if (!this.proxyRouterProcess) {
       this.proxyRouterProcess = await ProcessFactory({
         command: resolveAppDataPath(this.cfg.proxyRouter.runPath),
@@ -266,8 +266,61 @@ export class Orchestrator {
         onStateChange: () => this.emitStateUpdate()
       })
     }
+  }
 
-    await this.proxyRouterProcess.start()
+  private async ensureIpfsProcess() {
+    if (!this.ipfsProcess) {
+      this.ipfsProcess = await ProcessFactory({
+        command: resolveAppDataPath(this.cfg.ipfs.runPath),
+        args: this.cfg.ipfs.runArgs,
+        log: this.log.scope('IPFS'),
+        redirectProcessOutput: true,
+        probe: this.cfg.ipfs.probe,
+        ports: this.cfg.ipfs.ports,
+        onStateChange: () => this.emitStateUpdate()
+      })
+    }
+  }
+
+  private async ensureAiRuntimeProcess() {
+    if (!this.aiRuntimeProcess) {
+      this.aiRuntimeProcess = await ProcessFactory({
+        command: resolveAppDataPath(this.cfg.aiRuntime.runPath),
+        args: this.cfg.aiRuntime.runArgs,
+        log: this.log.scope('Ai-runtime'),
+        redirectProcessOutput: false,
+        probe: this.cfg.aiRuntime.probe,
+        ports: this.cfg.aiRuntime.ports,
+        onStateChange: () => this.emitStateUpdate()
+      })
+    }
+  }
+
+  private async ensureContainerRuntimeProcess() {
+    if (!this.containerRuntimeProcess) {
+      this.containerRuntimeProcess = await ProcessFactory({
+        probe: this.cfg.containerRuntime.probe,
+        onStateChange: () => this.emitStateUpdate(),
+        log: this.log.scope('Container-runtime')
+      })
+    }
+  }
+
+  private async startOptionalService(
+    name: string,
+    ensure: () => Promise<void>
+  ): Promise<void> {
+    try {
+      await ensure()
+      const processMap: Record<string, Process | undefined> = {
+        ipfs: this.ipfsProcess,
+        aiRuntime: this.aiRuntimeProcess,
+        containerRuntime: this.containerRuntimeProcess
+      }
+      await processMap[name]?.start()
+    } catch (err) {
+      this.log.error(`Optional service ${name} failed to start; continuing`, err)
+    }
     this.emitStateUpdate()
   }
 
@@ -286,18 +339,36 @@ export class Orchestrator {
   }
 
   public async restartService(service: keyof OrchestratorConfig) {
-    const processMap = {
+    // Ensure the process object exists even if the prior pipeline never
+    // reached this service (e.g. aborted before proxy-router was created).
+    try {
+      if (service === 'proxyRouter') await this.ensureProxyRouterProcess()
+      else if (service === 'aiRuntime') await this.ensureAiRuntimeProcess()
+      else if (service === 'ipfs') await this.ensureIpfsProcess()
+      else if (service === 'containerRuntime') await this.ensureContainerRuntimeProcess()
+      else {
+        this.log.error(`Service ${service} is not restartable`)
+        return
+      }
+    } catch (err) {
+      this.log.error(`Failed to prepare service ${service} for restart`, err)
+      this.emitStateUpdate()
+      return
+    }
+
+    const processMap: Partial<Record<keyof OrchestratorConfig, Process | undefined>> = {
       proxyRouter: this.proxyRouterProcess,
       aiRuntime: this.aiRuntimeProcess,
-      ipfs: this.ipfsProcess
+      ipfs: this.ipfsProcess,
+      containerRuntime: this.containerRuntimeProcess
     }
-    const process: Process | undefined = processMap[service]
+    const process = processMap[service]
     if (!process) {
       this.log.error(`Service ${service} not found`)
       return
     }
 
-    // Only restart managed processes
+    // Only restart managed processes (container runtime is probe-only / external)
     if (process.isExternal()) {
       this.log.warn(`Cannot restart external service ${service}`)
       return
@@ -312,33 +383,24 @@ export class Orchestrator {
       this.emitStateUpdate()
     }
 
-    // If the original startAll pipeline aborted before reaching downstream
-    // services (e.g. IPFS failed, so containerRuntime + proxyRouter were
-    // never started), resume the pipeline now that this service is healthy.
+    // Resume optional services that may still be pending after a proxy restart.
     // startAll is idempotent: downloads check fs.exists, and each process's
     // start() short-circuits when already running.
-    if (process.getState() === 'running' && !this.allServicesRunning()) {
+    if (process.getState() === 'running' && !this.requiredServicesRunning()) {
       this.log.info(
-        `Service ${service} restarted; resuming startup pipeline for any downstream services still pending`
+        `Service ${service} restarted; resuming startup pipeline for any remaining services`
       )
       try {
         await this.startAll()
       } catch (err) {
         this.log.error('Resume after restart failed', err)
-        // Don't rethrow — the explicit restart did succeed; downstream
-        // failures are surfaced via the per-service state.
       }
     }
   }
 
-  private allServicesRunning(): boolean {
-    const all = [
-      this.ipfsProcess,
-      this.aiRuntimeProcess,
-      this.containerRuntimeProcess,
-      this.proxyRouterProcess
-    ]
-    return all.every((p) => p?.getState() === 'running')
+  /** Proxy-router is the only service required for the UI / onboarding to work. */
+  private requiredServicesRunning(): boolean {
+    return this.proxyRouterProcess?.getState() === 'running'
   }
 
   async ping(service: keyof OrchestratorConfig): Promise<boolean> {
@@ -377,6 +439,15 @@ export class Orchestrator {
       ],
       startup: [
         {
+          id: 'proxyRouter',
+          name: 'Proxy Router',
+          status: this.proxyRouterProcess?.getState() ?? 'pending',
+          error: this.proxyRouterProcess?.getError(),
+          stderrOutput: this.proxyRouterProcess?.getOutput(),
+          ports: this.cfg.proxyRouter.ports,
+          isExternal: this.proxyRouterProcess?.isExternal()
+        },
+        {
           id: 'ipfs',
           name: 'IPFS',
           status: this.ipfsProcess?.getState() ?? 'pending',
@@ -401,15 +472,6 @@ export class Orchestrator {
           error: this.containerRuntimeProcess?.getError(),
           stderrOutput: this.containerRuntimeProcess?.getOutput(),
           isExternal: this.containerRuntimeProcess?.isExternal()
-        },
-        {
-          id: 'proxyRouter',
-          name: 'Proxy Router',
-          status: this.proxyRouterProcess?.getState() ?? 'pending',
-          error: this.proxyRouterProcess?.getError(),
-          stderrOutput: this.proxyRouterProcess?.getOutput(),
-          ports: this.cfg.proxyRouter.ports,
-          isExternal: this.proxyRouterProcess?.isExternal()
         }
       ],
       orchestratorStatus
@@ -417,43 +479,13 @@ export class Orchestrator {
   }
 
   private calculateOrchestratorStatus(): OrchestratorStatus {
-    // Check for any errors in downloads
-    const hasDownloadErrors = [
-      this.proxyDownloadState,
-      this.aiRuntimeDownloadState,
-      this.aiModelDownloadState,
-      this.ipfsDownloadState
-    ].some((item) => item.status === 'error')
-
-    // Check for any errors in startup processes
-    const hasStartupErrors = [
-      this.ipfsProcess,
-      this.aiRuntimeProcess,
-      this.proxyRouterProcess,
-      this.containerRuntimeProcess
-    ].some((process) => process?.getError())
-
-    if (hasDownloadErrors || hasStartupErrors) {
+    // Proxy-router download/start is required. Optional service failures must
+    // not block the UI — local AI / IPFS / Docker are best-effort.
+    if (this.proxyDownloadState.status === 'error' || this.proxyRouterProcess?.getError()) {
       return 'error'
     }
 
-    // Check if all downloads are complete
-    const allDownloadsComplete = [
-      this.proxyDownloadState,
-      this.aiRuntimeDownloadState,
-      this.aiModelDownloadState,
-      this.ipfsDownloadState
-    ].every((item) => item.status === 'success')
-
-    // Check if all processes are running
-    const allProcessesRunning = [
-      this.ipfsProcess,
-      this.aiRuntimeProcess,
-      this.proxyRouterProcess,
-      this.containerRuntimeProcess
-    ].every((process) => process?.getState() === 'running')
-
-    if (allDownloadsComplete && allProcessesRunning) {
+    if (this.proxyDownloadState.status === 'success' && this.requiredServicesRunning()) {
       return 'ready'
     }
 

--- a/ui-desktop/src/renderer/src/components/StartupItem.tsx
+++ b/ui-desktop/src/renderer/src/components/StartupItem.tsx
@@ -258,7 +258,9 @@ export const StartupItemComponent: FC<{
             {showLogs ? 'Hide logs' : 'Show logs'}
           </LogsButton>
         )}
-        {props.alwaysShowPingRestart || props.item.status === 'stopped' ? (
+        {props.alwaysShowPingRestart ||
+        props.item.status === 'stopped' ||
+        props.item.status === 'pending' ? (
           <Flex.Row gap="0.5rem" justify="flex-end" grow="1">
             <PingBtn onClick={handlePing}>
               <IconText

--- a/ui-desktop/src/renderer/src/components/models/ModelsTable.tsx
+++ b/ui-desktop/src/renderer/src/components/models/ModelsTable.tsx
@@ -455,19 +455,22 @@ function ModelCard({ onSelect, model, openSelectDownloadFolder, toasts, client, 
     }
   };
 
-  const copyId = () => {
-    navigator.clipboard.writeText(model.Id);
-    toasts.toast("success", "ID copied to clipboard", {
-      autoClose: 700
-    });
+  const copyToClipboard = async (text: string, label: string) => {
+    try {
+      // Use the Electron clipboard bridge; navigator.clipboard silently
+      // fails in the renderer (focus/permissions), see issue #793
+      await window.copyToClipboard(text);
+      toasts.toast("success", `${label} copied to clipboard`, {
+        autoClose: 700
+      });
+    } catch (e) {
+      toasts.toast("error", `Failed to copy ${label} to clipboard`);
+    }
   };
 
-  const copyCIDHash = () => {
-    navigator.clipboard.writeText(model.IpfsCID);
-    toasts.toast("success", "CID Hash copied to clipboard", {
-      autoClose: 700
-    });
-  };
+  const copyId = () => copyToClipboard(model.Id, "ID");
+
+  const copyCIDHash = () => copyToClipboard(model.IpfsCID, "CID Hash");
 
   // Format MOR values to prevent scientific notation and limit decimals
   const formatMorValue = (value) => {

--- a/ui-desktop/src/renderer/src/components/models/PinnedFilesTable.tsx
+++ b/ui-desktop/src/renderer/src/components/models/PinnedFilesTable.tsx
@@ -201,26 +201,24 @@ function ModelCard({ model, toasts, unpinFile }: { model: PinnedFile, toasts: an
     toasts.toast("success", "File unpinned successfully", { autoClose: 2000 });
   };
 
-  const copyHash = () => {
-    navigator.clipboard.writeText(model.metadataCIDHash);
-    toasts.toast("success", "Hash copied to clipboard", {
-      autoClose: 700
-    });
+  const copyToClipboard = async (text: string, label: string) => {
+    try {
+      // Use the Electron clipboard bridge; navigator.clipboard silently
+      // fails in the renderer (focus/permissions)
+      await window.copyToClipboard(text);
+      toasts.toast("success", `${label} copied to clipboard`, {
+        autoClose: 700
+      });
+    } catch (e) {
+      toasts.toast("error", `Failed to copy ${label} to clipboard`);
+    }
   };
 
-  const copyCID = () => {
-    navigator.clipboard.writeText(model.metadataCID);
-    toasts.toast("success", "CID copied to clipboard", {
-      autoClose: 700
-    });
-  };
+  const copyHash = () => copyToClipboard(model.metadataCIDHash, "Hash");
 
-  const copyId = () => {
-    navigator.clipboard.writeText(model.id);
-    toasts.toast("success", "ID copied to clipboard", {
-      autoClose: 700
-    });
-  };
+  const copyCID = () => copyToClipboard(model.metadataCID, "CID");
+
+  const copyId = () => copyToClipboard(model.id, "ID");
 
   const formatFileSize = (bytes: number) => {
     if (!bytes) return '';


### PR DESCRIPTION
# Release v7.8.0

Promote `test` → `main`. Proxy-router changed → expected tag **v7.8.0** (minor bump from `v7.7.0`).

Validated on `test` via pre-releases through [v7.7.5-test](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases/tag/v7.7.5-test) (includes `RATING_CONFIG_CONTENT` + denylist). Earlier test channel builds: [v7.7.2-test](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases/tag/v7.7.2-test) (proxy-first desktop), [v7.6.6-test](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases/tag/v7.6.6-test) (zombie-sweep wait).

## Highlights

### 1. Rating config via env + provider denylist (#828 / #829)

Consumer proxy-routers can supply rating config without mounting a file — same pattern as `MODELS_CONFIG_CONTENT`:

- **`RATING_CONFIG_CONTENT`** — inline JSON when the file at `RATING_CONFIG_PATH` / `./rating-config.json` is absent. File still wins when present; otherwise content; otherwise built-in defaults.
- **`providerDenylist`** — exclude provider addresses from rating and session opening (takes precedence over allowlist). Schema + docs updated.

Useful for container / ECS deployments where binding a rating file is awkward. Docs: [rating-config.json](https://nodedocs.mor.org/reference/rating-config).

### 2. Proxy-first desktop startup — onboarding no longer blocked by optional services (#823 / #824)

MorpheusUI starts **Proxy Router** before IPFS / AI Runtime / Docker, and soft-fails those optional services:

- A failing local `llama.cpp` (e.g. AVX2 illegal instruction on Windows ARM Parallels) no longer aborts the pipeline before `:8082` is up.
- Orchestrator is `ready` once the proxy is running; local tinyllama is **not** required for marketplace use.
- **Restart** works for services that never got a process handle; Restart is shown while status is still `pending`.

Fixes [#811](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/issues/811).

### 3. Model-card clipboard copy (#826)

Copy-to-clipboard on model / pinned-file tables now actually copies (was reporting success without writing the clipboard).

Fixes [#793](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/issues/793).

### 4. Zombie-session sweep waits for ECS-derived cutoff (#820 / #822)

`Sweep-Zombie-Sessions` resolves C-Node PRIMARY `updatedAt` from ECS and sleeps until `updatedAt + 90s + 120s` (+ skew buffer) before invoking `*-routed-sessions-sweep`. Stops the post-deploy future-cutoff 400 retry loop that left `OPEN` routed_sessions zombies long enough to fuel reopen/failover MOR burn. Applies to `test`→dev and `main`→prd.

### 5. CI: skip Docker/TEE on UI-only `test` pushes (#825)

On `test`, when `proxy-router/` did not change, skip Docker / TEE / service executables — same gate `main` already uses. UI-only test releases anchor desktop assets to the last known-good `-test` release that published router binaries.

## Included PRs (`main`..`test`)

| PR | What |
|----|------|
| [#820](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/820) / [#822](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/822) | Wait for ECS-derived sweep cutoff before zombie Lambda invoke |
| [#823](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/823) / [#824](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/824) | Proxy-first desktop startup; soft-fail optional AI/IPFS (#811) |
| [#825](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/825) | Skip Docker/TEE on UI-only `test` pushes (like main) |
| [#826](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/826) | Fix model-card clipboard copy (#793) |
| [#828](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/828) / [#829](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/829) | `RATING_CONFIG_CONTENT` + `providerDenylist` |

## Conflicts

None expected — clean `test` → `main` promote (`main` only has prior release merge commits ahead of `test`).

## Test plan (TEST env before merge)

- [x] Pre-release [v7.7.5-test](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/releases/tag/v7.7.5-test) published (proxy + UI + TEE assets)
- [x] Rating: `RATING_CONFIG_CONTENT` loads when no file; file path still wins; denylist excludes providers
- [x] Desktop: Proxy Router reaches `running` even if AI Runtime / IPFS fail; onboarding can complete (#811)
- [x] Clipboard copy on model / pinned-file tables works (#793)
- [x] Post C-Node deploy on test: Sweep job waits then `statusCode: 200` (not a string of future-cutoff 400s)
- [ ] After merge: tag `v7.8.0`; GHCR + TEE images publish; **prod SecretVM RTMR3 matches** (watch Deploy-SecretVM-Prod)
- [ ] After merge: Sweep-Zombie-Sessions on `main`→prd shows proactive wait + 200
- [ ] Close #811 after prod/desktop confirmation ( #793 already closed)

## Base branch

- [x] Maintainer promote into `main`

<details>
<summary>Release engineering notes (not part of user release notes)</summary>

- **Version is code-driven.** `Generate-Tag` on `main`: last clean prod tag `v7.7.0` + proxy-router changed → **v7.8.0**.
- **PR body = release notes.** Merge as a **merge commit** (not squash) so this description lands under `## 📝 Release Notes` on the GitHub Release.
- Back-merge `main → test` afterward to keep branches aligned.
- Pre-release channel references: `v7.7.5-test` (rating config), `v7.7.2-test` (proxy-first), `v7.6.6-test` (sweep wait).
</details>

Made with [Cursor](https://cursor.com)