### PR TITLE
Promote: SessionRouter stipend day-lock (#830) to test

### DIFF
--- a/docs/ai/llm-prompt-cheatsheet.mdx
+++ b/docs/ai/llm-prompt-cheatsheet.mdx
@@ -3,7 +3,7 @@ title: "LLM prompt cheatsheet"
 description: "Guidance for AI agents and coding assistants answering Morpheus questions: what to cite, what to never invent, and where to look first."
 audience: ["developer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 ---
 
 If you are an LLM (Claude, GPT, Gemini, etc.) reading this repo to answer Morpheus questions, follow these rules. They will keep you out of the most common hallucination traps.
@@ -47,7 +47,10 @@ If you are an LLM (Claude, GPT, Gemini, etc.) reading this repo to answer Morphe
   - ✅ "Morpheus is a marketplace. Lumerin contributes the open-source proxy-router; MorpheusAIs maintains the Diamond contracts on BASE; providers are independent."
 
 - ❌ "Open a session and your MOR is gone."
-  - ✅ "Opening a session escrows MOR; unused MOR returns on close."
+  - ✅ "Opening a session escrows MOR; unused MOR returns on close; used stipend day-locks until the next UTC day (`withdrawUserStakes`)."
+
+- ❌ "Natural expiration returns the full stake with no hold / you can recycle MOR all day."
+  - ✅ "Used stipend day-locks on early and same-day natural close. Size consumer float for gross daily stake."
 
 - ❌ "Use this contract address: 0x...." (invented)
   - ✅ "Per Networks and tokens, the BASE Mainnet Diamond contract is `0x6aBE1d282f72B474E54527D93b979A4f64d3030a`. Confirm against the latest release."

--- a/docs/ai/myths.mdx
+++ b/docs/ai/myths.mdx
@@ -3,7 +3,7 @@ title: "Common myths and corrections"
 description: "Concise corrections of the most frequent wrong assumptions about Morpheus, written for both humans and LLMs."
 audience: ["consumer", "prosumer", "provider-full", "provider-resale", "developer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 ---
 
 If you are an AI assistant answering Morpheus questions, **read this page before responding**. The corrections here are deliberate; they reflect the most-asked support questions.
@@ -16,7 +16,7 @@ If you are an AI assistant answering Morpheus questions, **read this page before
   </Accordion>
 
   <Accordion title="MYTH: When I open a session, I have spent the staked MOR.">
-    **No.** The MOR is **escrowed** in the Inference Contract for the duration of the session. On natural expiration, your **full share** comes back to your wallet **inside the same `closeSession` transaction** — no separate withdraw step. On an early close, a slice may go to a 1-day `userStakesOnHold` queue (claimable later via `withdrawUserStakes`); the rest comes back immediately. The provider is paid from a separate protocol funding account, **not** from your stake in real time. See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
+    **No.** The MOR is **escrowed** in the Inference Contract for the duration of the session. On close, **unused** stake returns to your wallet inside the same `closeSession` transaction; the **used stipend** day-locks in `userStakesOnHold` until the next UTC day (claim via `withdrawUserStakes`). That day-lock applies to early close **and** same-day natural/late close — not only early close. The provider is paid from a separate protocol funding account, **not** from your stake in real time. See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
   </Accordion>
 
   <Accordion title="MYTH: The local demo model is a 'free Morpheus model.'">
@@ -52,11 +52,19 @@ If you are an AI assistant answering Morpheus questions, **read this page before
   </Accordion>
 
   <Accordion title="MYTH: There is a 'recover' RPC for stuck sessions.">
-    **No.** There are two distinct on-chain calls. **`closeSession`** stops the session and triggers refund logic. **`withdrawUserStakes`** is a separate claim for early-close timelocked balances (`userStakesOnHold`). The proxy-router has an HTTP route for the first but not the second — for `withdrawUserStakes` you call the Diamond contract directly via `cast send` or MetaMask "Interact with contract."
+    **No.** There are two distinct on-chain calls. **`closeSession`** stops the session and triggers refund logic. **`withdrawUserStakes`** is a separate claim for day-locked balances (`userStakesOnHold`). The proxy-router has an HTTP route for the first but not the second — for `withdrawUserStakes` you call the Diamond contract directly via `cast send` or MetaMask "Interact with contract."
+  </Accordion>
+
+  <Accordion title="MYTH: Natural expiration / late close returns all my MOR immediately with no hold.">
+    **No (after the day-lock fix).** Unused stake returns in the close txn. The used stipend day-locks with `releaseAt = startOfTheDay(min(closedAt, endsAt)) + 1 day` whenever you close before that timestamp — including a normal auto-close ~1 minute after `endsAt`. Only closes that land after `releaseAt` skip the hold.
   </Accordion>
 
   <Accordion title="MYTH: An early close returns all my unused MOR immediately.">
-    **No.** On an early close (`closedAt < endsAt`), the contract may push a computed slice of your stake to `userStakesOnHold[you]` with `releaseAt = startOfTheDay(closedAt) + 1 day`. The remainder is `safeTransfer`'d to your wallet immediately. After `releaseAt` you call `withdrawUserStakes` to pull the held slice. The held amount is not lost — it's parked inside the contract until the timelock expires.
+    **Partially.** Unused stake does return immediately. The used stipend may still go to `userStakesOnHold[you]` with `releaseAt = startOfTheDay(min(closedAt, endsAt)) + 1 day`. After `releaseAt` call `withdrawUserStakes`. The held amount is not lost — it's parked until the timelock expires. See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
+  </Accordion>
+
+  <Accordion title="MYTH: I can recycle the same MOR for many sessions in one day.">
+    **No.** The used stipend is day-locked until the next UTC day + `withdrawUserStakes`. Size your consumer wallet for the **gross** stake you need that day, not for intra-day reuse of one pile of MOR.
   </Accordion>
 
   <Accordion title="MYTH: Providers have a separate hot/cold wallet — rewards land in the cold wallet, signing happens in the hot one.">

--- a/docs/ai/session-states-open-close-recover.mdx
+++ b/docs/ai/session-states-open-close-recover.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Session states (open, close, claim)"
-description: "Deterministic, agent-citable reference for the Morpheus session state machine. The natural-expiration path returns the full stake inside one txn; the early-close path uses a userStakesOnHold timelock plus a separate withdrawUserStakes claim."
+description: "Deterministic, agent-citable reference for the Morpheus session state machine. Close returns unused stake immediately; the used stipend day-locks until the next UTC day and is claimed via withdrawUserStakes."
 audience: ["developer", "consumer", "provider-full", "provider-resale"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 ---
 
-Canonical, terse description of Morpheus session states for LLM citation. The longer human narrative lives at [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover). The authoritative external reference (with read-only wallet checker) is [tech.mor.org/session.html](https://tech.mor.org/session.html).
+Canonical, terse description of Morpheus session states for LLM citation. The longer human narrative lives at [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover). The hosted checker is [tech.mor.org/session.html](https://tech.mor.org/session.html) — **this page / the contract win if that site lags.**
 
 ## States
 
@@ -14,13 +14,11 @@ Canonical, terse description of Morpheus session states for LLM citation. The lo
 stateDiagram-v2
   [*] --> Opening
   Opening --> Open: openSession succeeds, stake escrowed in InferenceContract
-  Open --> ClosedNatural: closeSession with closedAt >= endsAt (consumer node usually submits)
-  Open --> ClosedEarly: user-initiated closeSession with closedAt < endsAt
+  Open --> Closed: closeSession (early or closedAt >= endsAt)
   Open --> StuckPastEndsAt: endsAt passed but no closeSession yet
-  StuckPastEndsAt --> ClosedNatural: closeSession finally succeeds
-  ClosedNatural --> [*]: full refund inside the same close txn
-  ClosedEarly --> OnHold: userStakesOnHold row created with releaseAt = startOfDay(closedAt) + 1 day
-  ClosedEarly --> [*]: remainder safeTransferred immediately
+  StuckPastEndsAt --> Closed: closeSession finally succeeds
+  Closed --> [*]: unused stake safeTransferred in the same txn
+  Closed --> OnHold: used stipend → userStakesOnHold if close before releaseAt
   OnHold --> [*]: withdrawUserStakes after releaseAt
 ```
 
@@ -28,32 +26,33 @@ stateDiagram-v2
 
 | From | To | Trigger | On-chain effect | Wallet visible |
 |------|----|---------|-----------------|----------------|
-| `[*]` | `Opening` | Consumer calls `openSession(bidId, duration)` | Tx submitted | Pending |
+| `[*]` | `Opening` | Consumer calls `openSession` | Tx submitted | Pending |
 | `Opening` | `Open` | Tx mined | `transferFrom(you, InferenceContract, stake)` | Wallet `−stake` |
-| `Open` | `ClosedNatural` | `closeSession` mined with `closedAt >= endsAt` | `_rewardUserAfterClose` `safeTransfer`s your share back; `_rewardProviderAfterClose` pays provider from `fundingAccount` | Wallet `+full share` (in same txn) |
-| `Open` | `ClosedEarly` | User calls `closeSession` before `endsAt` | Same two reward functions; user share split between immediate transfer and a `userStakesOnHold` row | Wallet `+immediate part` |
-| `ClosedEarly` | `OnHold` | (within close txn) `_rewardUserAfterClose` pushes a slice to `userStakesOnHold[you]` | `releaseAt = startOfDay(closedAt) + 1 day` | None until claim |
+| `Open` | `Closed` | `closeSession` mined | `_rewardUserAfterClose` returns unused stake; may park used stipend; `_rewardProviderAfterClose` pays provider from `fundingAccount` | Wallet `+unused` |
+| `Closed` | `OnHold` | (within close txn) close before `releaseAt` | `releaseAt = startOfDay(min(closedAt, endsAt)) + 1 day` | None until claim |
 | `OnHold` | `[*]` | `withdrawUserStakes(you, iterations)` after `releaseAt` | Releasable rows `safeTransfer`'d to your wallet | Wallet `+held part` |
 | `Open` | `StuckPastEndsAt` | Time passes without successful `closeSession` | None — session record unchanged | None |
-| `StuckPastEndsAt` | `ClosedNatural` | `closeSession` finally mined | Same as the direct `Open → ClosedNatural` path | Wallet `+full share` |
+| `StuckPastEndsAt` | `Closed` | `closeSession` finally mined | Same as `Open → Closed` | Wallet `+unused` (+ hold if still before `releaseAt`) |
 
 ## Definitions
 
-- **Natural expiration** — `closedAt >= endsAt`. **No on-hold row, no claim step needed.** Your share lands in your wallet inside the close transaction.
-- **Early close** — `closedAt < endsAt`. Some slice of the stake may go to `userStakesOnHold[you]`. The rest comes back immediately. After the timelock you call `withdrawUserStakes`.
-- **`userStakesOnHold`** — array on the Inference Contract. Each entry has an amount and a `releaseAt`. `getUserStakesOnHold(addr, iter)` returns `(hold_, available_)`.
-- **`releaseAt`** — `startOfTheDay(closedAt) + 1 day` (UTC). In practice ≈ "after the end of the next full UTC day from your close."
+- **`sessionEnd`** — `min(closedAt, endsAt)`. Anchor for the day-lock (when the session stopped consuming compute).
+- **`releaseAt`** — `startOfTheDay(sessionEnd) + 1 day` (UTC). In practice ≈ "after the end of the UTC day the session ended on."
+- **Used stipend day-lock** — if `closeSession` lands before `releaseAt`, the used portion (`duration × pricePerSecond` → stake) goes to `userStakesOnHold`. Applies to **early close and same-day natural/late close**.
+- **Unused stake** — returns inside the same `closeSession` transaction.
+- **`userStakesOnHold`** — array on the Inference Contract. `getUserStakesOnHold(addr, iter)` returns `(hold_, available_)`.
 - **`fundingAccount`** — separate protocol wallet. Pays providers via `transferFrom` inside `closeSession`. If empty or under-approved, **every** `closeSession` fails.
-- **Stuck session** — `closedAt == 0` past `endsAt`. The close transaction has not succeeded yet (failure modes: funding account, gas on the closing wallet, consumer node offline).
+- **Stuck session** — `closedAt == 0` past `endsAt`. The close transaction has not succeeded yet.
 
 ## Common LLM mistakes (prevent these)
 
 - ❌ "Open a session, then call `recover` to get MOR back." → No `recover` function exists. The two distinct calls are `closeSession` and `withdrawUserStakes`.
 - ❌ "MOR returns automatically on session expiry." → **Only after a successful `closeSession` transaction.** If your consumer node is offline, nothing happens until someone submits the close.
-- ❌ "Closing returns only the unused portion." → For **natural expiration**, the contract returns your full share inside the same txn (no on-hold row). For **early close**, a slice may be parked in `userStakesOnHold`; the rest comes back immediately.
-- ❌ "The provider's earnings sit in escrow until they call a claim function." → Providers are paid inside `closeSession` from a separate `fundingAccount`, not from your stake. There is no separate "provider claim" for typical staked sessions.
-- ❌ "Closing MorpheusUI closes my sessions." → No. The UI is just a client; the on-chain session is independent. Close explicitly via API or wait for `endsAt` + consumer node auto-close.
-- ❌ "I closed early, I should see all my MOR back instantly." → A slice may be in `userStakesOnHold` — call `withdrawUserStakes` after `releaseAt`.
+- ❌ "Natural expiration returns the full stake with no hold." → **Wrong after the day-lock fix.** Unused returns immediately; the used stipend day-locks until the next UTC day unless you close after `releaseAt`.
+- ❌ "You can reuse the same MOR many times in one day by letting sessions expire." → **No.** Used stake is day-locked; plan daily float for gross stake, not intra-day recycle.
+- ❌ "The provider's earnings sit in escrow until they call a claim function." → Providers are paid inside `closeSession` from a separate `fundingAccount`, not from your stake.
+- ❌ "Closing MorpheusUI closes my sessions." → No. Close explicitly via API or wait for `endsAt` + consumer node auto-close.
+- ❌ "I closed, I should see all my MOR back instantly." → Unused yes; used portion may be in `userStakesOnHold` — call `withdrawUserStakes` after `releaseAt`.
 
 ## Concrete API calls (consumer side, via proxy-router)
 
@@ -64,7 +63,7 @@ stateDiagram-v2
 | List session IDs only | `GET /blockchain/sessions/user/ids?user=0x…` |
 | Fetch one session | `GET /blockchain/sessions/0x…` |
 | Close | `POST /blockchain/sessions/:id/close` body: `{}` |
-| **Claim early-close on-hold balance** | **No HTTP route.** Send `withdrawUserStakes(addr, iterations)` to the Diamond contract via `cast send` or wallet UI. |
+| **Claim day-locked on-hold balance** | **No HTTP route.** Send `withdrawUserStakes(addr, iterations)` to the Diamond contract via `cast send` or wallet UI. |
 
 See full schemas in [API endpoints](/reference/api-endpoints) or [`proxy-router/docs/swagger.yaml`](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/blob/main/proxy-router/docs/swagger.yaml).
 

--- a/docs/ai/where-is-my-mor.mdx
+++ b/docs/ai/where-is-my-mor.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Where is my MOR? (diagnostic)"
-description: "A linear, agent-friendly diagnostic for users who think their MOR has gone missing. Almost always the answer is 'in an active session,' 'in the on-hold queue after an early close,' or 'on the wrong network' — not 'lost.'"
+description: "A linear, agent-friendly diagnostic for users who think their MOR has gone missing. Almost always the answer is 'in an active session,' 'in the day-lock on-hold queue,' or 'on the wrong network' — not 'lost.'"
 audience: ["consumer", "provider-full", "provider-resale", "developer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 ---
 
-The vast majority of "my MOR is gone" reports are **not** lost MOR. Per the canonical reference at [tech.mor.org/session.html](https://tech.mor.org/session.html), your MOR can only be in **three on-chain places**:
+The vast majority of "my MOR is gone" reports are **not** lost MOR. Your MOR can only be in **three on-chain places**:
 
 1. **Your wallet** — standard ERC-20 `balanceOf(you)` on the MOR token.
 2. **Active session** — `openSession` moved your stake into the Inference Contract; `closedAt == 0`.
-3. **`userStakesOnHold` queue** — early-close timelock; `releaseAt = startOfTheDay(closedAt) + 1 day`.
+3. **`userStakesOnHold` queue** — day-lock of the **used stipend** after close; `releaseAt = startOfTheDay(min(closedAt, endsAt)) + 1 day`.
 
 Walk this checklist top-to-bottom. The moment one matches, that is the answer.
 
@@ -25,14 +25,14 @@ If you recently opened a session in MorpheusUI or via `POST /blockchain/models/:
 
 **Resolution:**
 
-- **Wait** for natural expiration — your consumer node will submit `closeSession` ~1 minute after `endsAt` and your full stake will land back in your wallet **inside the same transaction** (no extra step).
-- **Or close early** with `POST /blockchain/sessions/<sessionId>/close`. The contract may park a slice in `userStakesOnHold` (see Bucket 2); the rest comes back immediately.
+- **Wait** for natural expiration — your consumer node will submit `closeSession` ~1 minute after `endsAt` (if online). **Unused** stake returns in that txn; the **used stipend day-locks** until the next UTC day (Bucket 2).
+- **Or close early** with `POST /blockchain/sessions/<sessionId>/close` — same split: unused immediate, used portion may go on-hold.
 
 See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover) for the full lifecycle.
 
-## Bucket 2: On-hold queue (early close timelock)
+## Bucket 2: On-hold queue (used-stipend day-lock)
 
-If you closed a session **before** its scheduled `endsAt`, the contract may have pushed a slice of your stake to `userStakesOnHold[you]` with `releaseAt = startOfTheDay(closedAt) + 1 day`. Effectively this means **after the end of the next full UTC day** from your close. Until then, that slice is parked inside the contract — not lost, not in your wallet, not in any active session.
+After a successful `closeSession`, the contract may park the **used stipend** in `userStakesOnHold[you]` with `releaseAt = startOfTheDay(min(closedAt, endsAt)) + 1 day`. This applies to **early close and same-day natural/late close** — not only early close. Until `releaseAt`, that slice is parked inside the contract — not lost, not in your wallet, not in any active session.
 
 **Confirm:**
 
@@ -115,7 +115,8 @@ If you tried an action and the transaction reverted because you didn't have enou
 | Symptom | Reality |
 |---------|---------|
 | "Wallet balance dropped after opening a session." | Expected — stake is in the active session (Bucket 1). |
-| "I closed early and only part came back." | Expected — the rest is in the on-hold queue (Bucket 2). Wait until after the next full UTC day, then `withdrawUserStakes`. |
+| "I closed (or let it expire) and only part came back." | Expected — unused returned; used stipend is in the on-hold queue (Bucket 2). Wait until after `releaseAt`, then `withdrawUserStakes`. |
+| "I can't open another session with the same MOR today." | Expected — used stake is day-locked; size wallet float for gross daily stake. |
 | "Session is past `endsAt` but still open." | Bucket 3 — close transaction hasn't succeeded yet. |
 | "I see the contract holding tokens." | The Inference Contract holds tokens for **all users' active sessions and on-hold queues** combined. Not all of it is yours. |
 

--- a/docs/ai/why-locked-in-contract.mdx
+++ b/docs/ai/why-locked-in-contract.mdx
@@ -1,24 +1,24 @@
 ---
 title: "Why is my MOR locked in the contract?"
-description: "Concise reasons MOR can sit in the Diamond contract instead of your wallet — what's normal vs what to investigate."
+description: "Concise reasons MOR can sit in the Diamond contract instead of your wallet — what's normal vs what to investigate, including the used-stipend day-lock."
 audience: ["consumer", "provider-full", "provider-resale"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 ---
 
-If you see your MOR sitting in the Inference Contract instead of your wallet, you are looking at one of these legitimate states. None of them are "stuck" or "lost." For the canonical mechanics, see [tech.mor.org/session.html](https://tech.mor.org/session.html) and [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
+If you see your MOR sitting in the Inference Contract instead of your wallet, you are looking at one of these legitimate states. None of them are "stuck" or "lost." For the canonical mechanics, see [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
 
 ## Cause 1: Active session
 
-You opened a session. The **entire stake** sits in the Inference Contract while `closedAt == 0`. It will return to your wallet **inside the same transaction** as `closeSession` — no separate withdraw needed for the natural-expiration path.
+You opened a session. The **entire stake** sits in the Inference Contract while `closedAt == 0`.
 
-- Resolution: wait for natural expiration (your consumer node submits `closeSession` ~1 minute after `endsAt`), or close early via `POST /blockchain/sessions/<id>/close`. See [Session states](/ai/session-states-open-close-recover).
+- Resolution: wait for natural expiration (your consumer node submits `closeSession` ~1 minute after `endsAt`), or close early via `POST /blockchain/sessions/<id>/close`. After close, unused stake returns immediately; the used stipend may day-lock (Cause 2). See [Session states](/ai/session-states-open-close-recover).
 
-## Cause 2: Early-close timelock (`userStakesOnHold`)
+## Cause 2: Used-stipend day-lock (`userStakesOnHold`)
 
-You closed a session **before** its scheduled `endsAt`. The contract pushed a slice to `userStakesOnHold[you]` with `releaseAt = startOfTheDay(closedAt) + 1 day` (≈ "after the end of the next full UTC day"). The rest of your stake was already `safeTransfer`'d to your wallet inside the close transaction.
+You closed a session (early **or** same-day natural/late close). The contract pushed the **used stipend** to `userStakesOnHold[you]` with `releaseAt = startOfTheDay(min(closedAt, endsAt)) + 1 day` (≈ "after the end of the UTC day the session ended on"). Unused stake was already `safeTransfer`'d to your wallet inside the close transaction.
 
-- Resolution: after `releaseAt`, call `withdrawUserStakes(yourAddress, iterations)` on the Diamond contract. **No HTTP route on the proxy-router** — use `cast send` or MetaMask "Interact with contract" directly. See [Where is my MOR? → Bucket 2](/ai/where-is-my-mor#bucket-2-on-hold-queue-early-close-timelock).
+- Resolution: after `releaseAt`, call `withdrawUserStakes(yourAddress, iterations)` on the Diamond contract. **No HTTP route on the proxy-router** — use `cast send` or MetaMask "Interact with contract" directly. See [Where is my MOR? → Bucket 2](/ai/where-is-my-mor#bucket-2-on-hold-queue-used-stipend-day-lock).
 
 ## Cause 3: Stuck close — funding account or gas
 
@@ -56,9 +56,9 @@ Each registered model carries a `0.1` MOR refundable stake.
 ```mermaid
 flowchart TD
   Start[MOR appears 'locked'] --> Q1{Active session?}
-  Q1 -->|Yes| A1[Wait for endsAt or close manually — full refund inside close txn]
-  Q1 -->|No| Q2{Closed early in last 24-48h?}
-  Q2 -->|Yes| A2[Some MOR likely in userStakesOnHold; call withdrawUserStakes after releaseAt]
+  Q1 -->|Yes| A1[Wait for endsAt or close manually — unused returns on close; used may day-lock]
+  Q1 -->|No| Q2{Closed in last ~24-48h?}
+  Q2 -->|Yes| A2[Used stipend likely in userStakesOnHold; call withdrawUserStakes after releaseAt]
   Q2 -->|No| Q3{Session past endsAt but still active?}
   Q3 -->|Yes| A3[Stuck close — funding account or your node's gas]
   Q3 -->|No| Q4{Active provider/model stake?}

--- a/docs/concepts/sessions-stake-close-recover.mdx
+++ b/docs/concepts/sessions-stake-close-recover.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Sessions: stake, close, claim"
-description: "The complete lifecycle of a Morpheus session — open, stake, close (natural vs early), and the on-hold timelock for early closes. Why MOR is not 'gone' just because the session is open."
+description: "The complete lifecycle of a Morpheus session — open, stake, close, day-lock of the used stipend, and withdrawUserStakes. Why MOR is not 'gone' just because the session is open, and why used stake is not reusable the same UTC day."
 audience: ["consumer", "provider-full", "provider-resale", "developer"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 ---
 
 This is the most misunderstood part of Morpheus. The vast majority of "where is my MOR?" support questions resolve here. Read carefully.
 
 <Note>
-The canonical reference for this lifecycle (with a read-only Base wallet checker) is [tech.mor.org/session.html](https://tech.mor.org/session.html). The page below is the curated repo-side summary; if it ever disagrees with `tech.mor.org`, that page wins.
+The hosted checker at [tech.mor.org/session.html](https://tech.mor.org/session.html) is useful for reading the three on-chain buckets. **Contract behavior in this repo is authoritative** if that page lags (especially the day-lock rules below).
 </Note>
 
 ## End-to-end flow
@@ -18,27 +18,12 @@ The canonical reference for this lifecycle (with a read-only Base wallet checker
 flowchart TB
   Wallet1["1. MOR in your wallet"] --> Open["2. Approve + Open session"]
   Open --> Active["3. Active session"]
-  Active --> NaturalPath["Natural expiration path"]
-  Active --> EarlyPath["Early close path"]
-
-  subgraph NaturalPath
-    direction TB
-    NatClose["4a. Consumer node submits close ~1 minute after endsAt"]
-    NatNoLock["5a. No timelock"]
-    NatRefund["6a. Full refund inside the same close txn"]
-    NatClose --> NatNoLock --> NatRefund
-  end
-
-  subgraph EarlyPath
-    direction TB
-    EarlyClose["4b. User calls close via API/app"]
-    EarlyLock["5b. Slice may go to userStakesOnHold (1-day timelock)"]
-    EarlyClaim["6b. Call withdrawUserStakes after the timelock"]
-    EarlyClose --> EarlyLock --> EarlyClaim
-  end
-
-  NaturalPath --> Wallet2["7. MOR back in your wallet"]
-  EarlyPath --> Wallet2
+  Active --> Close["4. closeSession (early or at/after endsAt)"]
+  Close --> Immediate["5a. Unused stake → wallet (same txn)"]
+  Close --> Hold["5b. Used stipend → userStakesOnHold until next UTC day"]
+  Hold --> Claim["6. withdrawUserStakes after releaseAt"]
+  Immediate --> Wallet2["7. Spendable MOR"]
+  Claim --> Wallet2
 ```
 
 ## The three places your MOR can be on chain
@@ -53,7 +38,7 @@ The Morpheus consumer node (proxy-router) does **not** custody tokens — it jus
     `openSession` does `transferFrom(you, InferenceContract, amount)`. While `closedAt == 0`, your stake lives inside the session record — not in your wallet, not yet in the on-hold queue.
   </Card>
   <Card title="3. On-hold queue" icon="lock">
-    `userStakesOnHold[user]` array. Entries are only created on **certain early closes** (`closedAt < endsAt`) with `releaseAt = startOfTheDay(closedAt) + 1 day`. After that timestamp you call `withdrawUserStakes` to move them to your wallet.
+    `userStakesOnHold[user]` array. Holds the **used stipend** after close until `releaseAt = startOfTheDay(min(closedAt, endsAt)) + 1 day`. Cleared via `withdrawUserStakes`.
   </Card>
 </CardGroup>
 
@@ -64,56 +49,54 @@ The Morpheus consumer node (proxy-router) does **not** custody tokens — it jus
     Standard ERC-20 balance, like any token.
   </Step>
   <Step title="Approve + open">
-    `openSession(bidId, sessionDuration)` does `transferFrom(you, Diamond, amount)`. The whole stake moves out of your wallet into the Inference Contract for the duration of the session. The session has a scheduled `endsAt` derived from `pricePerSecond × sessionDuration`.
+    `openSession` does `transferFrom(you, Diamond, amount)`. The whole stake moves out of your wallet into the Inference Contract for the duration of the session. Scheduled `endsAt` comes from stake → daily stipend ÷ `pricePerSecond` (capped by max session duration).
   </Step>
   <Step title="Active">
     Until `endsAt` (or until you close early), the session is active and your stake is reserved for inference with the chosen provider.
   </Step>
   <Step title="Close — one transaction">
-    Closing always happens in a single on-chain `closeSession` call. The path splits depending on **when** the close happens:
+    Closing always happens in a single on-chain `closeSession` call — either your consumer node ~1 minute after `endsAt` (if online), or you closing early via API / UI.
 
-    - **Natural expiration (`closedAt ≥ endsAt`)** — your consumer node usually submits the close transaction itself ~1 minute after `endsAt` (assuming it's online and caught up).
-    - **Early close (`closedAt < endsAt`)** — you (or your app/agent) call close via API / `cast` before the scheduled end. This is the first user-initiated step on the early-close path.
+    Refund math does **not** treat "late" vs "early" as a special case that skips the lock. It anchors to when the session stopped consuming compute: `sessionEnd = min(closedAt, endsAt)`.
   </Step>
-  <Step title="Token state right after close (5a vs 5b)">
-    <Tabs>
-      <Tab title="5a — Natural expiration">
-        **No on-hold row, no timelock.** The contract `safeTransfer`s your share back to your wallet **inside the same `closeSession` transaction**. You don't need a separate "withdraw" step.
-      </Tab>
-      <Tab title="5b — Early close">
-        The contract may push a computed slice of your stake to `userStakesOnHold[you]` with `releaseAt = startOfTheDay(closedAt) + 1 day`. The rest is `safeTransfer`'d to your wallet immediately. The held slice is *not* lost — it's parked inside the contract until the timelock passes. **How much is held depends on how long the session ran and the agreed price** — it's not a simple "minutes left on the clock" slider, and the rule mirrors how natural-expiration settlement would have paid out.
-      </Tab>
-    </Tabs>
-  </Step>
-  <Step title="Last mile — MOR back in your wallet (6a vs 6b)">
-    <Tabs>
-      <Tab title="6a — Natural expiration">
-        Already done in step 5a. No further action needed.
-      </Tab>
-      <Tab title="6b — Early close (claim)">
-        After the timelock passes (≈ "after the end of the next full UTC day" from `closedAt`), call `withdrawUserStakes(yourAddress, iterations)` on the Diamond contract. The held rows that have passed `releaseAt` move to your wallet. **There is no HTTP route for this on the proxy-router today** — you call it directly via `cast send`, MetaMask "Interact with contract", or your wallet app's withdraw / claim flow.
+  <Step title="Token state right after close">
+    Inside `_rewardUserAfterClose`:
 
-        ```bash
-        # Mainnet; replace placeholders
-        cast send 0x6aBE1d282f72B474E54527D93b979A4f64d3030a \
-          "withdrawUserStakes(address,uint8)" 0xYOUR_CONSUMER_WALLET 20 \
-          --rpc-url https://mainnet.base.org \
-          --private-key "$PRIVATE_KEY_OF_DELEGATEE"
-        ```
-      </Tab>
-    </Tabs>
+    - **Unused stake** is `safeTransfer`'d to your wallet **in the same transaction**.
+    - **Used stipend** (session time × `pricePerSecond`, converted back to stake) is pushed to `userStakesOnHold` with `releaseAt = startOfTheDay(sessionEnd) + 1 day`, **if you close before that timestamp**.
+
+    Practical effect: a normal natural expiration (close ~1 minute after `endsAt` on the same UTC day) **does** day-lock the used portion. Only a close that lands after `releaseAt` (e.g. days late) returns everything with no hold.
+  </Step>
+  <Step title="Claim the day-locked slice">
+    After `releaseAt` (≈ after the end of the UTC day the session ended on), call `withdrawUserStakes(yourAddress, iterations)` on the Diamond contract. **There is no HTTP route for this on the proxy-router today** — use `cast send`, MetaMask "Interact with contract", or your wallet's contract UI.
+
+    ```bash
+    # Mainnet; replace placeholders
+    cast send 0x6aBE1d282f72B474E54527D93b979A4f64d3030a \
+      "withdrawUserStakes(address,uint8)" 0xYOUR_CONSUMER_WALLET 20 \
+      --rpc-url https://mainnet.base.org \
+      --private-key "$PRIVATE_KEY_OF_DELEGATEE"
+    ```
   </Step>
   <Step title="Done">
-    Spendable MOR back in your wallet — either right after a successful natural-expiration close, or after an early close + claim once the timelock allows it.
+    Spendable MOR is back in your wallet — unused immediately after close, used portion after the day-lock + claim.
   </Step>
 </Steps>
+
+## Consumer capital expectation (important)
+
+The used portion of stake is **not reusable the same UTC day**. Plan float accordingly:
+
+- Opening many short sessions that each "use" most of their stake will park that capital until the next day + `withdrawUserStakes`.
+- Letting sessions expire naturally does **not** free the used stake for immediate reuse — the node auto-close still day-locks it.
+- Size your wallet for the **gross** stake you need in a day of concurrent / sequential sessions, not for recycling one pile of MOR many times before midnight UTC.
 
 ## How the provider gets paid (and what your stake has to do with it)
 
 Your stake **is not** what pays the provider in real time. Inside `closeSession`:
 
 1. The contract sets `closedAt` and marks the session inactive.
-2. **`_rewardUserAfterClose`** — your share is computed and either `safeTransfer`'d to your wallet (natural expiration) or split between an immediate transfer and an `userStakesOnHold` row (early close).
+2. **`_rewardUserAfterClose`** — unused stake returns immediately; used stipend may go to `userStakesOnHold`.
 3. **`_rewardProviderAfterClose`** — pays the provider for time actually used. For typical staked sessions, the payment comes from the protocol's separate **`fundingAccount` via `transferFrom`**, **not** from your stake in that same step.
 
 The practical implication: if the protocol's funding wallet is empty or has insufficient allowance to the Inference Contract, **no session can close** — yours included. That's a different failure mode from a stuck consumer node and is handled by the Morpheus operators, not by you. It can manifest as sessions sitting "active" past their `endsAt`.
@@ -124,11 +107,9 @@ The practical implication: if the protocol's funding wallet is empty or has insu
 stateDiagram-v2
   [*] --> Opening
   Opening --> Open: openSession succeeds, stake escrowed, sessionId issued
-  Open --> ClosedNatural: closeSession after endsAt (consumer node usually submits)
-  Open --> ClosedEarly: user-initiated close before endsAt
-  ClosedNatural --> [*]: full refund inside the same txn
-  ClosedEarly --> OnHold: contract may park a slice in userStakesOnHold (releaseAt = startOfDay(closedAt) + 1 day)
-  ClosedEarly --> [*]: remainder transferred immediately
+  Open --> Closed: closeSession (early or at/after endsAt)
+  Closed --> [*]: unused stake transferred immediately
+  Closed --> OnHold: used stipend parked until releaseAt = startOfDay(sessionEnd) + 1 day
   OnHold --> [*]: withdrawUserStakes after releaseAt
 ```
 
@@ -137,7 +118,7 @@ stateDiagram-v2
 Older docs (and even some early Morpheus discussion) used the word "recover" loosely. There is no single `recover` RPC. There are two distinct on-chain calls:
 
 - **`closeSession`** stops the session and triggers refund logic.
-- **`withdrawUserStakes`** is the *separate* claim action for early-close timelocked balances.
+- **`withdrawUserStakes`** is the *separate* claim action for day-locked balances.
 
 If a session is genuinely stuck (e.g. funding account empty, your consumer node offline past `endsAt`), the resolution is still a successful `closeSession` followed, if needed, by `withdrawUserStakes`. There is no other path.
 
@@ -151,7 +132,7 @@ If a session is genuinely stuck (e.g. funding account empty, your consumer node 
 | List session IDs only (lighter) | `GET /blockchain/sessions/user/ids?user=0x…` |
 | Fetch one session | `GET /blockchain/sessions/0x…` |
 | Close a session | `POST /blockchain/sessions/0x…/close` |
-| Claim early-close on-hold balance | **No HTTP route** — call `withdrawUserStakes` on the Diamond contract directly |
+| Claim day-locked on-hold balance | **No HTTP route** — call `withdrawUserStakes` on the Diamond contract directly |
 
 See [API endpoints](/reference/api-endpoints) for full curl examples.
 

--- a/docs/concepts/tokens-and-fees.mdx
+++ b/docs/concepts/tokens-and-fees.mdx
@@ -3,7 +3,7 @@ title: "Tokens, fees, and economics"
 description: "MOR vs ETH on BASE, who pays what when, and where the on-chain minimums come from."
 audience: ["consumer", "prosumer", "provider-resale", "provider-full"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 ---
 
 Two tokens, one chain. **MOR** is the unit of payment inside the Morpheus marketplace; **ETH on BASE** pays the underlying gas to the BASE Layer-2 network.
@@ -23,7 +23,7 @@ Token addresses by network are listed in [Networks and tokens](/get-started/netw
 
 <AccordionGroup>
   <Accordion title="Consumer session stake">
-    Total = `pricePerSecond * sessionDuration` (minimum `5` MOR). Paid in MOR, escrowed in the Inference Contract on `openSession`. On **natural expiration** (`closedAt >= endsAt`) your full share is `safeTransfer`'d back to your wallet inside the same `closeSession` transaction. On **early close** a slice may go to `userStakesOnHold` (1-day timelock), to be claimed later via `withdrawUserStakes`. The provider is paid by the contract from a separate protocol `fundingAccount`, not from your stake in real time. See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
+    Total = `pricePerSecond * sessionDuration` (minimum `5` MOR). Paid in MOR, escrowed in the Inference Contract on `openSession`. On close, **unused** stake returns immediately; the **used stipend** day-locks in `userStakesOnHold` until the next UTC day (`withdrawUserStakes`) — including same-day natural expiration. The provider is paid from a separate protocol `fundingAccount`, not from your stake in real time. See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
   </Accordion>
 
   <Accordion title="Provider stake">
@@ -62,7 +62,7 @@ session stake = pricePerSecond * sessionDuration
    (minimum 5 MOR escrowed at open)
 ```
 
-The full stake is escrowed at open. **Natural expiration** returns the full share to your wallet in one transaction. **Early close** splits the refund: a slice may be timelocked in `userStakesOnHold` for ~1 UTC day before you can claim it via `withdrawUserStakes`. See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
+The full stake is escrowed at open. On close, unused stake returns immediately; the used stipend day-locks until the next UTC day (`withdrawUserStakes`). Plan consumer float for gross daily stake — used MOR is not reusable the same UTC day. See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
 
 ## Two reward systems (do not conflate)
 

--- a/docs/concepts/what-is-morpheus.mdx
+++ b/docs/concepts/what-is-morpheus.mdx
@@ -3,7 +3,7 @@ title: "What is Morpheus?"
 description: "An opinionated explainer of the Morpheus Inference Marketplace: a decentralized, peer-to-peer marketplace for AI inference, coordinated by smart contracts on BASE."
 audience: ["consumer", "prosumer", "provider-resale", "provider-full", "developer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 ---
 
 The **Morpheus Inference Marketplace** is where decentralized AI becomes accessible to everyone. It connects people who need compute power (consumers) with providers who supply it, all coordinated by smart contracts on BASE. Instead of a centralized service, requests and responses flow **directly** between consumer and provider in a peer-to-peer system.
@@ -46,7 +46,7 @@ To participate, **both sides** run a **proxy-router** — a lightweight binary (
     Once a session is open, prompts and responses go **directly** between consumer and provider — no Morpheus-operated server in the data path. The blockchain only sees session open / close / settle, never the inference itself.
   </Card>
   <Card title="Session-time pricing, not tokens" icon="hourglass">
-    Pricing is **per-second of session time**, not per-token. Consumers stake MOR for a fixed duration; the MOR is escrowed and refunded on close (full refund on natural expiration; early close uses a 1-day timelock for part of the refund). See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
+    Pricing is **per-second of session time**, not per-token. Consumers stake MOR for a fixed duration; the MOR is escrowed on open. On close, unused stake returns immediately and the used stipend day-locks until the next UTC day. See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
   </Card>
   <Card title="Reputation-weighted matching" icon="trophy">
     Providers with strong uptime, time-to-first-token, throughput, and success rate are matched more often by the consumer-side rating system. See [rating-config.json](/reference/rating-config) for how the weights work.

--- a/docs/consumers/buy-bid.mdx
+++ b/docs/consumers/buy-bid.mdx
@@ -3,7 +3,7 @@ title: "Open a session (buy a bid)"
 description: "How to open a Morpheus session via MorpheusUI or the API: pick a model, select a bid, stake MOR, and what happens next."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 source: "docs/05-bid-purchase.md"
 ---
 
@@ -25,10 +25,12 @@ Opening a session = "buying a bid." You stake MOR for a fixed duration; the prox
     A transaction will be submitted. Once confirmed, the session is open and you can prompt.
   </Step>
   <Step title="Close when done (or let it expire naturally)">
-    Two paths:
+    Either path:
 
-    - **Natural expiration** — if you let the session run to its `endsAt`, your consumer node submits `closeSession` ~1 minute later (assuming it's online) and your **full share** lands back in your wallet inside that one transaction.
-    - **Early close** — click the time icon next to the model line; click **X** next to the session. The contract may park a slice in `userStakesOnHold` (1-day timelock); the rest comes back immediately. After the timelock you must call `withdrawUserStakes` to claim the held slice.
+    - **Natural expiration** — your consumer node submits `closeSession` ~1 minute after `endsAt` (if online).
+    - **Early close** — click the time icon next to the model line; click **X** next to the session.
+
+    In both cases: **unused** stake returns in the close txn; the **used stipend** day-locks in `userStakesOnHold` until the next UTC day. After `releaseAt`, call `withdrawUserStakes` to claim the held slice.
   </Step>
 </Steps>
 
@@ -57,9 +59,9 @@ curl -X POST 'http://localhost:8082/blockchain/sessions/<sessionId>/close' \
 ## What you should expect
 
 - **Wallet balance drops by the staked amount** the instant the open transaction is mined. The MOR is now in the Inference Contract on Base for the duration of the session.
-- **Natural expiration**: at `endsAt`, your consumer node submits `closeSession` ~1 minute later and the **full share** of your stake lands in your wallet inside that single transaction. No separate withdraw needed.
-- **Early close**: a slice may go to `userStakesOnHold` with `releaseAt = startOfTheDay(closedAt) + 1 day` (≈ "after the end of the next full UTC day"). The rest is returned immediately. After `releaseAt`, call `withdrawUserStakes(yourAddress, iterations)` directly on the Diamond contract — there is no HTTP route on the proxy-router.
-- **The provider is paid from a separate protocol funding account**, not from your stake in real time. If that funding account is empty or under-approved, every `closeSession` fails — yours included. The session sits "active" past `endsAt` until operators top it up. See [Why is my MOR locked?](/ai/why-locked-in-contract) and [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
+- **On close (early or natural):** unused stake returns in the same txn; the used stipend day-locks with `releaseAt = startOfTheDay(min(closedAt, endsAt)) + 1 day`. After `releaseAt`, call `withdrawUserStakes(yourAddress, iterations)` on the Diamond — there is no HTTP route on the proxy-router.
+- **Capital planning:** used stake is **not reusable the same UTC day**. Size your wallet for the gross stake you need that day, not for recycling one pile of MOR many times before midnight UTC. See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
+- **The provider is paid from a separate protocol funding account**, not from your stake in real time. If that funding account is empty or under-approved, every `closeSession` fails — yours included. The session sits "active" past `endsAt` until operators top it up. See [Why is my MOR locked?](/ai/why-locked-in-contract).
 - For a hosted read-only wallet checker that splits your MOR across the three on-chain buckets (wallet / active session / on-hold), see [tech.mor.org/session.html](https://tech.mor.org/session.html).
 
 ## Picking a good bid

--- a/docs/consumers/chat.mdx
+++ b/docs/consumers/chat.mdx
@@ -3,7 +3,7 @@ title: "Chat, audio, and embeddings"
 description: "Send prompts to a remote Morpheus model: streaming chat completions, audio transcription / TTS, and embeddings — all with OpenAI-compatible payloads."
 audience: ["consumer", "developer"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 ---
 
 Once a session is open, you talk to the proxy-router exactly like you would talk to OpenAI: same routes, same body schemas. The only difference is the `session_id` header and the BasicAuth header for the local API.
@@ -71,7 +71,7 @@ curl -X POST 'http://localhost:8082/v1/embeddings' \
 
 ## Closing a session early
 
-Always close manually if you are finished well before the session timer expires. Unused stake returns to your wallet on close.
+Always close manually if you are finished well before the session timer expires. Unused stake returns to your wallet on close; the used stipend day-locks until the next UTC day (`withdrawUserStakes`). See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
 
 ```bash
 curl -X POST 'http://localhost:8082/blockchain/sessions/<sessionId>/close' \

--- a/docs/consumers/troubleshooting.mdx
+++ b/docs/consumers/troubleshooting.mdx
@@ -3,7 +3,7 @@ title: "Consumer troubleshooting"
 description: "The most common consumer-side problems and their fixes."
 audience: ["consumer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.5.0"
+last_verified: "v7.9.0"
 ---
 
 This page focuses on consumer-side symptoms. For provider-side or deeper proxy-router operational issues, see the full [Reference: troubleshooting](/reference/troubleshooting).
@@ -22,7 +22,7 @@ You probably recovered a **derived** address from your mnemonic. MorpheusUI only
 ## "Provider not responding" or stuck mid-prompt
 
 - Confirm the proxy-router is still running (`http://localhost:8082/healthcheck`, or check the Proxy Router entry on MorpheusUI's startup screen).
-- The provider may be down. Close the session early; an immediate partial refund hits your wallet, and any timelocked slice in `userStakesOnHold` becomes claimable via `withdrawUserStakes` after ~1 UTC day:
+- The provider may be down. Close the session; unused stake returns immediately, and the used stipend in `userStakesOnHold` becomes claimable via `withdrawUserStakes` after ~1 UTC day:
   ```bash
   curl -X POST 'http://localhost:8082/blockchain/sessions/<sessionId>/close' \
     -H 'Authorization: Basic <base64(user:pass)>' -d '{}'

--- a/docs/prosumers/running-local-agents.mdx
+++ b/docs/prosumers/running-local-agents.mdx
@@ -3,7 +3,7 @@ title: "Running local agents"
 description: "Generalized patterns for running automated agents against your C-Node: per-agent users, scoped permissions, session policies."
 audience: ["prosumer", "developer"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 ---
 
 The C-Node is intentionally a thin OpenAI-shaped HTTP layer over Morpheus. That makes it a clean target for any agent framework — LangChain, LlamaIndex, custom tools, OpenClaw, etc.
@@ -33,7 +33,7 @@ This writes a new `rpcauth=` and `rpcwhitelist=` line to `proxy.conf`. Full meth
 | Open per task | Bursty, infrequent tasks | Higher gas overhead, simpler state |
 | Pool of pre-opened sessions | High-throughput multi-agent | Fan agents across sessions; close idle ones |
 
-Always **close sessions explicitly** when work is done. On natural expiration the consumer node submits the close itself and your full share comes back in one transaction. On manual / early close, an immediate partial refund hits your wallet plus a timelocked slice in `userStakesOnHold` (claimable via `withdrawUserStakes` after ~1 UTC day). See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
+Always **close sessions explicitly** when work is done. Unused stake returns in the close txn; the used stipend day-locks in `userStakesOnHold` until the next UTC day (claim via `withdrawUserStakes`). Plan agent float for **gross** daily stake — used MOR is not reusable the same UTC day. See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
 
 ## Streaming vs non-streaming
 

--- a/docs/reference/api-endpoints.mdx
+++ b/docs/reference/api-endpoints.mdx
@@ -3,7 +3,7 @@ title: "API endpoints (selected)"
 description: "Hand-picked, prose-explained endpoints of the proxy-router HTTP API. Full schema lives in the repo at proxy-router/docs/swagger.yaml."
 audience: ["developer", "prosumer", "provider-full", "provider-resale"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 source: "docs/proxy-router-api-endpoints.md"
 ---
 
@@ -165,7 +165,7 @@ curl --location 'http://localhost:8084/blockchain/sessions/0xf343b654cc8a21d0666
 
 Response includes the on-chain transaction hash.
 
-**Note on refunds:** on **natural expiration** (`closedAt >= endsAt`) your full share is `safeTransfer`'d back to your wallet inside this same transaction. On **early close** a slice may be parked in `userStakesOnHold` with a 1-day timelock — you must call `withdrawUserStakes` (below) after the timelock to receive it. See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover) for full mechanics.
+**Note on refunds:** **unused** stake is `safeTransfer`'d back in this same transaction. The **used stipend** may be parked in `userStakesOnHold` with `releaseAt = startOfTheDay(min(closedAt, endsAt)) + 1 day` — including same-day natural/late close. Call `withdrawUserStakes` (below) after the timelock. See [Sessions: stake, close, claim](/concepts/sessions-stake-close-recover).
 
 ---
 
@@ -182,7 +182,7 @@ Variant for IDs only: `GET /blockchain/sessions/user/ids?user=0x…`. Fetch one:
 
 ---
 
-## Claim early-close on-hold balance (no node HTTP route)
+## Claim day-locked on-hold balance (no node HTTP route)
 
 There is **no proxy-router HTTP route** for `withdrawUserStakes` today. You send a transaction to the Diamond (Inference) contract on Base directly:
 
@@ -193,7 +193,7 @@ cast send 0x6aBE1d282f72B474E54527D93b979A4f64d3030a \
   --private-key "$PRIVATE_KEY_OF_DELEGATEE"
 ```
 
-Function selector: `0xa98a7c6b`. The caller must be the delegatee allowed for that consumer (usually the same key your consumer node uses). `iterations_` (e.g. `20`) caps how many releasable on-hold rows to process per call. Read on-hold balance via `getUserStakesOnHold(addr, iterations_)` — see [Where is my MOR? → Bucket 2](/ai/where-is-my-mor#bucket-2-on-hold-queue-early-close-timelock).
+Function selector: `0xa98a7c6b`. The caller must be the delegatee allowed for that consumer (usually the same key your consumer node uses). `iterations_` (e.g. `20`) caps how many releasable on-hold rows to process per call. Read on-hold balance via `getUserStakesOnHold(addr, iterations_)` — see [Where is my MOR? → Bucket 2](/ai/where-is-my-mor#bucket-2-on-hold-queue-used-stipend-day-lock).
 
 ---
 

--- a/docs/reference/glossary.mdx
+++ b/docs/reference/glossary.mdx
@@ -3,7 +3,7 @@ title: "Glossary"
 description: "Canonical, agent-friendly definitions of Morpheus terms."
 audience: ["consumer", "prosumer", "provider-full", "provider-resale", "developer"]
 product: ["proxy-router", "ui-desktop"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 ---
 
 LLM-friendly definitions — short, opinionated, and consistent across the rest of the docs. If a term here disagrees with anything elsewhere on this site, the rest of the site is wrong; file an issue.
@@ -21,13 +21,14 @@ LLM-friendly definitions — short, opinionated, and consistent across the rest 
 | **P-Node** | A "Provider Node" — the proxy-router process running in the provider role. |
 | **C-Node** | A "Consumer Node" — the proxy-router process running in the consumer role. |
 | **Bid** | An on-chain offer: `(modelId, providerId, pricePerSecond)`. Consumers accept by opening a session. |
-| **Session** | A time-boxed contract with escrowed MOR. `openSession` moves stake into the Inference Contract; `closeSession` returns the consumer's share and pays the provider from a separate `fundingAccount`. Natural expiration returns the full share inside one txn; early close may park a slice in `userStakesOnHold`. |
+| **Session** | A time-boxed contract with escrowed MOR. `openSession` moves stake into the Inference Contract; `closeSession` returns unused stake immediately, may day-lock the used stipend in `userStakesOnHold`, and pays the provider from a separate `fundingAccount`. |
 | **Stake** | (1) Consumer: MOR escrowed for a session. (2) Provider: refundable bond a provider must post to register a provider or model. |
-| **`userStakesOnHold`** | Per-user array on the Inference Contract that holds early-close timelock entries. Each entry has an amount and `releaseAt = startOfTheDay(closedAt) + 1 day`. Cleared via `withdrawUserStakes`. |
+| **`userStakesOnHold`** | Per-user array on the Inference Contract that holds the **used stipend** after close. Each entry has an amount and `releaseAt = startOfTheDay(min(closedAt, endsAt)) + 1 day`. Cleared via `withdrawUserStakes`. |
 | **`withdrawUserStakes`** | On-chain function (`withdrawUserStakes(address, uint8)`, selector `0xa98a7c6b`) on the Diamond contract that moves past-`releaseAt` rows from `userStakesOnHold` to the user's wallet. **No HTTP route** on the proxy-router. |
 | **`fundingAccount`** | Protocol-owned wallet that pays providers inside `closeSession` via `transferFrom`. If empty or under-approved, every `closeSession` fails network-wide. |
-| **Natural expiration** | Session close where `closedAt >= endsAt`. Full consumer share returns inside the same `closeSession` transaction. No `userStakesOnHold` row created. |
-| **Early close** | User-initiated `closeSession` before `endsAt`. May create a `userStakesOnHold` row alongside the immediate transfer. |
+| **Natural expiration** | Session close where `closedAt >= endsAt` (often auto-submitted ~1 minute after `endsAt`). Unused stake returns in the close txn; the used stipend still day-locks if the close lands before `releaseAt`. |
+| **Early close** | User-initiated `closeSession` before `endsAt`. Unused stake returns immediately; used stipend may go to `userStakesOnHold`. |
+| **Used-stipend day-lock** | Hold of the stake equivalent of session time × `pricePerSecond` until the next UTC day after `sessionEnd`. Blocks same-day reuse of that capital. |
 | **Subnet provider** | A provider that has staked `10000` MOR (vs the standard `0.2`) and gets elevated marketplace standing. |
 | **Allowance** | Standard ERC-20 approval the consumer / provider grants to the Diamond contract so it can move MOR on their behalf. |
 | **proxy-router** | The Go service in this repo. Same binary serves consumer and provider roles; configuration differs. |

--- a/smart-contracts/contracts/diamond/facets/SessionRouter.sol
+++ b/smart-contracts/contracts/diamond/facets/SessionRouter.sol
@@ -291,20 +291,25 @@ contract SessionRouter is
     }
 
     function _rewardUserAfterClose(Session storage session, Bid storage bid) private {
-        uint128 startOfClosedAt_ = startOfTheDay(session.closedAt);
-        bool isClosingLate_ = session.closedAt >= session.endsAt;
+        // Anchor to when the session actually stopped consuming compute,
+        // not to when the close tx landed (PR #830 stipend-recycle fix).
+        uint128 sessionEnd_ = uint128(session.closedAt.min(session.endsAt));
+        uint128 startOfEndDay_ = startOfTheDay(sessionEnd_);
+        uint128 releaseAt_ = startOfEndDay_ + 1 days;
 
         uint256 userStakeToProvider = session.isDirectPaymentFromUser ? _getProviderRewards(session, bid, false) : 0;
         uint256 userStake = session.stake - userStakeToProvider;
         uint256 userStakeToLock_ = 0;
-        if (!isClosingLate_) {
-            uint256 userDuration_ = session.endsAt.min(session.closedAt) - session.openedAt.max(startOfClosedAt_);
-            uint256 userInitialLock_ = userDuration_ * bid.pricePerSecond;
-            userStakeToLock_ = userStake.min(stipendToStake(userInitialLock_, startOfClosedAt_));
 
-            _getSessionsStorage().userStakesOnHold[session.user].push(
-                OnHold(userStakeToLock_, uint128(startOfClosedAt_ + 1 days))
-            );
+        // Lock only while the epoch the stipend was drawn against is still open.
+        if (block.timestamp < releaseAt_) {
+            uint256 userDuration_ = sessionEnd_ - session.openedAt.max(startOfEndDay_);
+            uint256 userInitialLock_ = userDuration_ * bid.pricePerSecond;
+            userStakeToLock_ = userStake.min(stipendToStake(userInitialLock_, startOfEndDay_));
+
+            if (userStakeToLock_ > 0) {
+                _getSessionsStorage().userStakesOnHold[session.user].push(OnHold(userStakeToLock_, releaseAt_));
+            }
         }
         uint256 userAmountToWithdraw_ = userStake - userStakeToLock_;
         IERC20(_getBidsStorage().token).safeTransfer(session.user, userAmountToWithdraw_);

--- a/smart-contracts/deploy/5_session_day_lock_deploy_facet.migration.ts
+++ b/smart-contracts/deploy/5_session_day_lock_deploy_facet.migration.ts
@@ -1,0 +1,31 @@
+import { Deployer, Reporter } from '@solarity/hardhat-migrate';
+
+import { LinearDistributionIntervalDecrease__factory, SessionRouter__factory } from '@/generated-types/ethers';
+
+// Step 1 of the two-step, owner-signed SessionRouter day-lock upgrade (#830).
+// Deploys and verifies new facet bytecode from ANY funded EOA — facet deploy is
+// permissionless; only the diamondCut in step 2 is signed by the diamond owner
+// (EOA on BASE Sepolia, Safe on mainnet).
+//
+// Performs NO diamondCut and touches NO live state.
+// After this completes, generate the owner's cut payload with:
+//   NEW_SESSION_ROUTER_FACET=0x... \
+//     npx hardhat run scripts/session-day-lock-cut-calldata.ts --network <network>
+//
+// See smart-contracts/docs/session-day-lock-upgrade-runbook.md
+module.exports = async function (deployer: Deployer) {
+  const ldid = await deployer.deploy(LinearDistributionIntervalDecrease__factory);
+  const newSessionRouterFacet = await deployer.deploy(SessionRouter__factory, {
+    libraries: {
+      LinearDistributionIntervalDecrease: ldid,
+    },
+  });
+
+  Reporter.reportContracts(
+    ['LinearDistributionIntervalDecrease (library)', await ldid.getAddress()],
+    ['SessionRouter Facet (new)', await newSessionRouterFacet.getAddress()],
+  );
+};
+
+// npx hardhat migrate --network base_sepolia --only 5 --verify
+// npx hardhat migrate --network base --only 5 --verify

--- a/smart-contracts/docs/session-day-lock-upgrade-runbook.md
+++ b/smart-contracts/docs/session-day-lock-upgrade-runbook.md
@@ -1,0 +1,84 @@
+# SessionRouter stipend day-lock — diamond upgrade runbook
+
+Two-step, owner-signed upgrade for the #830 day-lock fix. **Same ceremony on BASE
+Sepolia and BASE mainnet:** any EOA deploys facet bytecode; the diamond owner signs
+exactly one `diamondCut`. No proxy-router / node changes.
+
+| | BASE Sepolia | BASE mainnet |
+|---|---|---|
+| Diamond | `0x6e4d0B775E3C3b02683A6F277Ac80240C4aFF930` | `0x6aBE1d282f72B474E54527D93b979A4f64d3030a` |
+| Owner | EOA `0x19ec1E4b714990620edf41fE28e9a1552953a7F4` | Gnosis Safe **5-of-9** `0x1FE04BC15Cf2c5A2d41a0b3a96725596676eBa1E` |
+| Who signs the cut | Key-holder directly | Safe proposal → 5 sigs → execute |
+
+Re-read `owner()` on-chain before starting (the calldata script prints it).
+
+## What the cut does
+
+Atomic `diamondCut`:
+
+1. **Remove** every selector on the live SessionRouter facet (fresh loupe read).
+2. **Add** all `ISessionRouter` selectors → new SessionRouter facet.
+3. **Add** all `IStatsStorage` selectors → new SessionRouter facet.
+
+ABI unchanged. Behavior change: session close day-locks the used stipend even on
+late close (anchors to `min(closedAt, endsAt)`).
+
+**Forward-only.** Do not re-add a pre-fix SessionRouter facet. Hotfix = new facet
+via the same two-step ceremony.
+
+## Step 0 — preflight (deployer)
+
+From `smart-contracts/` on the release commit:
+
+```bash
+npm ci && npx hardhat compile
+npx hardhat test test/diamond/facets/SessionRouter.test.ts
+```
+
+`.env`: `PRIVATE_KEY` (throwaway EOA), `ALCHEMY_KEY` (or public RPC), `BASESCAN_API_KEY`.
+Fund the deployer with gas ETH.
+
+## Step 1 — deploy facet (permissionless)
+
+```bash
+# Sepolia
+npx hardhat migrate --network base_sepolia --only 5 --verify
+
+# Mainnet (same steps)
+npx hardhat migrate --network base --only 5 --verify
+```
+
+Records library + new SessionRouter addresses. **No diamond state changes yet.**
+
+## Step 2 — generate owner calldata (read-only)
+
+```bash
+# Sepolia (DIAMOND defaults to config_base_sepolia.json)
+NEW_SESSION_ROUTER_FACET=0x... \
+  npx hardhat run scripts/session-day-lock-cut-calldata.ts --network base_sepolia
+
+# Mainnet — DIAMOND required (config-parser is Sepolia-default)
+NEW_SESSION_ROUTER_FACET=0x... \
+  DIAMOND=0x6aBE1d282f72B474E54527D93b979A4f64d3030a \
+  npx hardhat run scripts/session-day-lock-cut-calldata.ts --network base
+```
+
+Prints owner, selector lists, and the single `to` / `value: 0` / `data` hex.
+
+## Step 3 — review (before signing)
+
+- [ ] New facet verified on Basescan; source matches the release commit.
+- [ ] Remove target equals live SessionRouter (`facetAddress(closeSession)`).
+- [ ] No unexpected selector drops; brand-new list is empty (ABI unchanged).
+- [ ] Simulate the cut (Tenderly / Safe UI).
+- [ ] `to` = diamond, `value` = 0.
+
+## Step 4 — owner signs
+
+- **Sepolia:** EOA sends the printed tx to the diamond.
+- **Mainnet:** Safe → Transaction Builder → paste `data` (or `diamondCut`) → 5-of-9 → execute.
+
+## Step 5 — verify
+
+- Loupe: old SessionRouter gone; new facet serves `ISessionRouter` + `IStatsStorage`.
+- Smoke: open a short funded session, late-close same day → `getUserStakesOnHold` shows a lock until next 00:00 UTC; unused stake returned immediately.

--- a/smart-contracts/scripts/session-day-lock-cut-calldata.ts
+++ b/smart-contracts/scripts/session-day-lock-cut-calldata.ts
@@ -1,0 +1,179 @@
+import { Fragment, Interface } from 'ethers';
+import { ethers } from 'hardhat';
+
+import { parseConfig } from '../deploy/helpers/config-parser';
+
+import {
+  ISessionRouter__factory,
+  IStatsStorage__factory,
+  LumerinDiamond__factory,
+} from '@/generated-types/ethers';
+import { FacetAction } from '@/test/helpers/deployers';
+
+/**
+ * Step 2 of the two-step SessionRouter day-lock upgrade (#830): builds the
+ * exact `diamondCut` the diamond owner must sign, from a fresh loupe read.
+ * Read-only; sends nothing.
+ *
+ * Usage (after migration 5):
+ *   NEW_SESSION_ROUTER_FACET=0x... \
+ *     npx hardhat run scripts/session-day-lock-cut-calldata.ts --network base_sepolia
+ *
+ * Env:
+ *   NEW_SESSION_ROUTER_FACET  (required) SessionRouter facet from migration 5
+ *   DIAMOND                   (optional) defaults to config_base_sepolia.json;
+ *                             MUST be set explicitly for mainnet
+ *                             (0x6aBE1d282f72B474E54527D93b979A4f64d3030a)
+ *   REMOVED_SELECTORS_ALLOWLIST (optional) comma-separated selectors this cut
+ *                             intentionally drops; anything else aborts
+ *
+ * Same ceremony on Sepolia and mainnet — see
+ * smart-contracts/docs/session-day-lock-upgrade-runbook.md
+ */
+
+function requireAddress(name: string): string {
+  const value = process.env[name];
+  if (!value || !ethers.isAddress(value)) {
+    throw new Error(`Set ${name} to a valid address (got: ${value ?? 'unset'})`);
+  }
+  return ethers.getAddress(value);
+}
+
+function interfaceSelectors(iface: Interface): string[] {
+  return iface.fragments.filter(Fragment.isFunction).map((f) => f.selector);
+}
+
+function selectorNames(): Map<string, string> {
+  const names = new Map<string, string>();
+  for (const [label, iface] of [
+    ['ISessionRouter', ISessionRouter__factory.createInterface()],
+    ['IStatsStorage', IStatsStorage__factory.createInterface()],
+  ] as const) {
+    for (const fragment of iface.fragments.filter(Fragment.isFunction)) {
+      names.set(fragment.selector, `${label}.${fragment.format('sighash')}`);
+    }
+  }
+  return names;
+}
+
+async function main() {
+  const network = await ethers.provider.getNetwork();
+  const diamondAddr = process.env.DIAMOND
+    ? ethers.getAddress(process.env.DIAMOND)
+    : ethers.getAddress(parseConfig().lumerinProtocol);
+  const newSessionRouterFacet = requireAddress('NEW_SESSION_ROUTER_FACET');
+
+  if ((await ethers.provider.getCode(newSessionRouterFacet)) === '0x') {
+    throw new Error(
+      `NEW_SESSION_ROUTER_FACET ${newSessionRouterFacet} has no code on chain ${network.chainId} — run migration 5 first`,
+    );
+  }
+
+  const diamond = LumerinDiamond__factory.connect(diamondAddr, ethers.provider);
+  const owner = await diamond.owner();
+  const ownerCode = await ethers.provider.getCode(owner);
+
+  const closeSessionSelector = ISessionRouter__factory.createInterface().getFunction('closeSession').selector;
+  const oldSessionRouterFacet = await diamond.facetAddress(closeSessionSelector);
+  if (oldSessionRouterFacet === ethers.ZeroAddress) {
+    throw new Error('closeSession selector not registered — is DIAMOND pointing at the right contract?');
+  }
+  const oldSelectors = [...(await diamond.facetFunctionSelectors(oldSessionRouterFacet))];
+
+  const sessionRouterSelectors = interfaceSelectors(ISessionRouter__factory.createInterface());
+  const statsSelectors = interfaceSelectors(IStatsStorage__factory.createInterface());
+
+  for (const selector of [...sessionRouterSelectors, ...statsSelectors]) {
+    const current = await diamond.facetAddress(selector);
+    if (current !== ethers.ZeroAddress && current !== oldSessionRouterFacet) {
+      throw new Error(`Selector ${selector} is already served by unrelated facet ${current} — aborting`);
+    }
+  }
+
+  const allowedDrops = new Set(
+    (process.env.REMOVED_SELECTORS_ALLOWLIST ?? '')
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  const reAdded = new Set([...sessionRouterSelectors, ...statsSelectors].map((s) => s.toLowerCase()));
+  const dropped = oldSelectors.filter((s) => !reAdded.has(s.toLowerCase()));
+  const unexpectedDrops = dropped.filter((s) => !allowedDrops.has(s.toLowerCase()));
+  if (unexpectedDrops.length > 0) {
+    throw new Error(
+      `This cut would drop ${unexpectedDrops.length} selector(s) the live facet serves: ` +
+        `${unexpectedDrops.join(', ')}. If intentional, list them in REMOVED_SELECTORS_ALLOWLIST.`,
+    );
+  }
+
+  const registeredFacets = new Set((await diamond.facetAddresses()).map((a: string) => a.toLowerCase()));
+  if (registeredFacets.has(newSessionRouterFacet.toLowerCase())) {
+    throw new Error(
+      `NEW_SESSION_ROUTER_FACET ${newSessionRouterFacet} is already registered — upgrades are ` +
+        `forward-only (fresh bytecode via migration 5); re-adding an old facet is prohibited.`,
+    );
+  }
+
+  const cuts = [
+    {
+      facetAddress: oldSessionRouterFacet,
+      action: FacetAction.Remove,
+      functionSelectors: oldSelectors,
+    },
+    {
+      facetAddress: newSessionRouterFacet,
+      action: FacetAction.Add,
+      functionSelectors: sessionRouterSelectors,
+    },
+    {
+      facetAddress: newSessionRouterFacet,
+      action: FacetAction.Add,
+      functionSelectors: statsSelectors,
+    },
+  ];
+
+  const calldata = LumerinDiamond__factory.createInterface().encodeFunctionData(
+    'diamondCut((address,uint8,bytes4[])[])',
+    [cuts],
+  );
+
+  const names = selectorNames();
+  const describe = (selector: string) => names.get(selector) ?? '(not in current ABI — removed function)';
+  const actionLabel = ['Add', 'Replace', 'Remove'];
+
+  console.log('=== diamondCut payload: SessionRouter stipend day-lock (#830) ===');
+  console.log(`network:            ${network.name} (chainId ${network.chainId})`);
+  console.log(`diamond:            ${diamondAddr}`);
+  console.log(
+    `diamond owner:      ${owner} (${ownerCode === '0x' ? 'EOA — signs directly' : 'contract — likely a Safe, propose there'})`,
+  );
+  console.log(`old SessionRouter:  ${oldSessionRouterFacet} (${oldSelectors.length} selectors removed)`);
+  console.log(`new SessionRouter:  ${newSessionRouterFacet}`);
+  console.log('');
+
+  for (const cut of cuts) {
+    console.log(`--- ${actionLabel[cut.action]} @ ${cut.facetAddress} (${cut.functionSelectors.length} selectors) ---`);
+    for (const selector of cut.functionSelectors) {
+      console.log(`  ${selector}  ${describe(selector)}`);
+    }
+  }
+
+  const brandNew = [...sessionRouterSelectors, ...statsSelectors].filter((s) => !oldSelectors.includes(s));
+  console.log('');
+  console.log(
+    `selectors carried over unchanged: ${sessionRouterSelectors.length + statsSelectors.length - brandNew.length}`,
+  );
+  console.log(`brand-new selectors: ${brandNew.map((s) => `${s} ${describe(s)}`).join(', ') || '(none — ABI unchanged)'}`);
+
+  console.log('');
+  console.log('=== transaction for the diamond owner (single atomic tx) ===');
+  console.log(`to:       ${diamondAddr}`);
+  console.log(`value:    0`);
+  console.log(`function: diamondCut((address,uint8,bytes4[])[])`);
+  console.log(`data:     ${calldata}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/smart-contracts/test/diamond/facets/SessionRouter.test.ts
+++ b/smart-contracts/test/diamond/facets/SessionRouter.test.ts
@@ -614,6 +614,24 @@ describe('SessionRouter', () => {
       const contractBalAfter = await token.balanceOf(sessionRouter);
       expect(contractBalBefore - contractBalAfter).to.eq(wei(50));
     });
+    it('should day-lock the used stipend when closing late on the same day the session ended (#830)', async () => {
+      const { sessionId } = await _createSession();
+      const session = await sessionRouter.getSession(sessionId);
+
+      const userBalBefore = await token.balanceOf(SECOND);
+
+      // late close, but still inside the stipend epoch (same calendar day as endsAt)
+      await setTime(Number(session.endsAt) + 100);
+      const { msg: receiptMsg, signature: receiptSig } = await getReceipt(PROVIDER, sessionId, 0, 0);
+      await sessionRouter.connect(SECOND).closeSession(receiptMsg, receiptSig);
+
+      const stakesOnHold = await sessionRouter.getUserStakesOnHold(SECOND, 20);
+      expect(stakesOnHold[0]).to.eq(0);
+      expect(stakesOnHold[1]).to.greaterThan(0);
+
+      const userBalAfter = await token.balanceOf(SECOND);
+      expect(userBalAfter - userBalBefore).to.eq(wei(50) - stakesOnHold[1]);
+    });
     it('should close session and send rewards for the user, early closure', async () => {
       const { sessionId, openedAt, secondsToDayEnd } = await _createSession();
 


### PR DESCRIPTION
## Summary
- Promote [#833](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/833) from `dev` → `test`: SessionRouter day-lock so late/same-day close locks the used stipend (closes intra-day stake recycle).
- Includes nodedocs updates for consumer MOR expectations + two-step Sepolia/mainnet deploy ceremony (`smart-contracts/docs/session-day-lock-upgrade-runbook.md`).
- Supersedes [#830](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/830). Contract-only; no proxy-router changes.

## Test plan
- [ ] CI green on this promote PR
- [ ] Sepolia: migration 5 → cut calldata → owner `diamondCut` → late-close smoke (`getUserStakesOnHold`)
- [ ] Spot-check nodedocs.dev pages after deploy (sessions / where-is-my-mor)


Made with [Cursor](https://cursor.com)