### PR TITLE
feat(proxy-router): SESSION_HEALTH_POLICY strictness modes and degrad…

### DIFF
--- a/docs/providers/full/model-health.mdx
+++ b/docs/providers/full/model-health.mdx
@@ -9,7 +9,7 @@ last_verified: "v7.4.0"
 Since v7.4.0 every provider proxy-router continuously verifies that the models it sells actually work, and publishes the result as a `models` array on its `/healthcheck` endpoint. This page is the operational reference for that capability: what runs, what it costs, how to tune it, and how to read the report when something is unhealthy. For the one-time post-setup walkthrough, see [Verify your provider setup](/providers/full/verify-setup).
 
 <Note>
-The `httpStatus` and `modelName` report fields, the `rate_limited` error kind, probe pacing (`MODEL_HEALTH_CHECK_PROBE_DELAY`), and the manual `POST /healthcheck/models/refresh` trigger were added in the release **after** v7.4.0. On v7.4.0 nodes you get the report without those features.
+The `httpStatus` and `modelName` report fields, the `rate_limited` error kind, probe pacing (`MODEL_HEALTH_CHECK_PROBE_DELAY`), and the manual `POST /healthcheck/models/refresh` trigger were added in the release **after** v7.4.0. On v7.4.0 nodes you get the report without those features. The `degraded` status (rate-limited backends) and the consumer-side `SESSION_HEALTH_POLICY` were added later still; on earlier nodes a rate-limited backend reports `unhealthy` with `errorKind: rate_limited`.
 </Note>
 
 ## What actually runs
@@ -42,10 +42,10 @@ Full env reference: [env-proxy-router](/reference/env-proxy-router).
 
 The report is not only cron-driven — real traffic updates it immediately:
 
-- **Consecutive session errors.** When prompts from open sessions fail against your backend (connection error, upstream `5xx`, `401`/`402`/`404`, `429`) `MODEL_HEALTH_MAX_CONSECUTIVE_ERRORS` times in a row, the model is marked `unhealthy` with `errorKind: session_errors` on the spot. Client-fault upstream responses (`400`, `403`, `413`, `422`) count neither way, so a consumer sending malformed requests cannot flip a healthy model. A later successful prompt — or a passing scheduled probe — heals the status and resets the streak.
+- **Consecutive session errors.** When prompts from open sessions fail against your backend (connection error, upstream `5xx`, `401`/`402`/`404`, `429`) `MODEL_HEALTH_MAX_CONSECUTIVE_ERRORS` times in a row, the model is flipped on the spot with `errorKind: session_errors` — to `degraded` when **every** failure in the streak was a `429` (pure throttling, capacity risk), to `unhealthy` otherwise. Client-fault upstream responses (`400`, `403`, `413`, `422`) count neither way, so a consumer sending malformed requests cannot flip a healthy model. A later successful prompt — or a passing scheduled probe — heals the status and resets the streak.
 - **TEE self-verification.** For `tee`-tagged models the provider verifies its own backend attestation. If that verification fails (at startup, during a sweep, or on the per-session fast-verify), the model is reported with the dedicated status `tee_unverified` and `errorKind: tee_attestation` instead of being probed — session requests for it would be rejected anyway. The status heals once attestation passes again.
 
-Consumers use this report **before opening a session**: the pre-open healthcheck ping reads the pong's `models` array and skips providers that self-report the bid's model as `unhealthy`, `tee_unverified`, or `no_model_configured`, moving on to the next rated bid.
+Consumers use this report **before opening a session**: the pre-open healthcheck ping reads the pong's `models` array and skips providers that self-report the bid's model as `unhealthy`, `tee_unverified`, or `no_model_configured`, moving on to the next rated bid. How strictly the consumer treats the report is controlled by its `SESSION_HEALTH_POLICY` (`permissive` — the default behavior just described; `preferred` — prefer providers reporting `healthy`/`degraded` and skip unknown reports when such a peer exists; `strict` — only providers reporting `healthy`). When a model has a single candidate provider, the consumer always falls back to `permissive` so the model stays usable. See [env-proxy-router](/reference/env-proxy-router#session-health-policy-consumer).
 
 ### Impact on your node and your backend
 
@@ -82,25 +82,26 @@ curl -s http://localhost:8082/healthcheck | jq '.models'
 | Status | Meaning |
 |--------|---------|
 | `healthy` | Probe succeeded; for LLMs `promptCorrect` says whether the answer was right |
+| `degraded` | Upstream rate limited (`429`) — backend up and correctly configured, just throttled. Set by a probe (`errorKind: rate_limited`) or by a streak of real-session failures that were all `429` (`errorKind: session_errors`). Capacity risk, not failure: consumers still treat the model as serviceable unless they run the `strict` session health policy |
 | `unhealthy` | Probe failed — `errorKind` and `httpStatus` say why (see below) |
 | `no_bid` | Configured but no active bid; **not probed** |
 | `no_model_configured` | Active bid but no `models-config.json` entry — consumers can open sessions against this bid and get errors |
 | `skipped` | Model type not probeable (TTS, image, video) |
 | `tee_unverified` | `tee`-tagged model whose backend TEE attestation failed or never succeeded; **not probed**, and session requests for it are rejected |
 
-For `unhealthy` models, the diagnosis is the combination of `errorKind` and `httpStatus`:
+For `unhealthy` (and `degraded`) models, the diagnosis is the combination of `errorKind` and `httpStatus`:
 
 | errorKind | httpStatus | Almost always means |
 |-----------|------------|---------------------|
 | `connection` | — | Backend `apiUrl` unreachable: wrong host/port, container down, DNS |
 | `timeout` | — | Backend reachable but slower than `MODEL_HEALTH_CHECK_TIMEOUT` |
-| `rate_limited` | `429` | Backend up and correctly configured, just throttled — often transient; if persistent, your upstream quota is too small for your traffic |
+| `rate_limited` | `429` | Reported with status `degraded`: backend up and correctly configured, just throttled — often transient; if persistent, your upstream quota is too small for your traffic |
 | `bad_response` | `402` | Upstream account out of credits / payment required — a billing problem, not a node problem |
 | `bad_response` | `400` / `404` | Upstream rejected the request: wrong model name in `models-config.json`, model retired upstream, malformed base URL |
 | `bad_response` | `401` / `403` | Bad or expired `apiKey` |
 | `bad_response` | `5xx` | Upstream itself is failing |
 | `bad_response` | *(absent)* | Backend returned 200 but an empty/invalid completion |
-| `session_errors` | — | Flipped by consecutive real-session prompt failures (see [Live signals](#live-signals-between-sweeps)), not by a probe |
+| `session_errors` | `429` or — | Flipped by consecutive real-session prompt failures (see [Live signals](#live-signals-between-sweeps)), not by a probe; carries status `degraded` with `httpStatus: 429` when the whole streak was rate limiting, `unhealthy` otherwise |
 | `tee_attestation` | — | Accompanies `tee_unverified`: the backend TEE attestation is not currently passed |
 
 A `healthy` model with `promptCorrect: false` deserves attention too: the backend responds, but the model can't answer 2-digit addition — usually the `apiUrl`/`modelName` pair is wired to the wrong model.
@@ -130,11 +131,11 @@ curl -s -X POST 'http://<your-c-node>:8082/proxy/provider/ping' \
 
 Use the provider's **own registered wallet and endpoint** exactly as they appear on-chain (`/blockchain/providers`) — a mismatched pair fails signature verification.
 
-**Quick triage one-liner** — group your unhealthy models by cause:
+**Quick triage one-liner** — group your unhealthy and degraded models by cause:
 
 ```bash
 curl -s http://localhost:8082/healthcheck \
-  | jq -r '.models[] | select(.status=="unhealthy")
+  | jq -r '.models[] | select(.status=="unhealthy" or .status=="degraded")
       | "\(.errorKind)/\(.httpStatus // "-")\t\(.modelName // .modelId)"' \
   | sort | uniq -c | sort -rn
 ```

--- a/docs/proxy-router.all.env
+++ b/docs/proxy-router.all.env
@@ -95,6 +95,17 @@ MODEL_HEALTH_CHECK_TIMEOUT=60s
 # unhealthy immediately, without waiting for the next scheduled probe (default 3)
 MODEL_HEALTH_MAX_CONSECUTIVE_ERRORS=3
 
+# Consumer-side health strictness when opening a session by model ID:
+# permissive (default; skip only providers self-reporting the model as
+# unhealthy/tee_unverified/no_model_configured — unknown or missing reports
+# are allowed), preferred (when any provider reports healthy or degraded,
+# skip unknown/missing reports; otherwise fall back to permissive for that
+# open), strict (only try providers reporting healthy).
+# Single-bid caveat: healthPolicySingleBid is fixed to "permissive" — when
+# only one candidate provider remains for a model, preferred/strict are
+# forced to permissive so the sole provider can still be tried.
+SESSION_HEALTH_POLICY=permissive
+
 # System Configurations
 # Enable system-level configuration adjustments
 SYS_ENABLE=false

--- a/docs/reference/env-proxy-router.mdx
+++ b/docs/reference/env-proxy-router.mdx
@@ -185,6 +185,22 @@ On provider nodes the proxy-router periodically probes every model from `models-
 | `MODEL_HEALTH_CHECK_PROBE_DELAY` | `2s` | Pause between per-model probes so many-model providers don't burst their upstream into a rate limit |
 | `MODEL_HEALTH_MAX_CONSECUTIVE_ERRORS` | `3` | Consecutive real-session prompt failures after which the model is reported `unhealthy` (`errorKind: session_errors`) immediately, without waiting for the next scheduled probe |
 
+## Session health policy (consumer)
+
+On consumer nodes, `SESSION_HEALTH_POLICY` controls how strictly the pre-open healthcheck pings gate provider selection when opening a session **by model ID** (the failover loop). Opening by a specific bid ID is unaffected.
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `SESSION_HEALTH_POLICY` | `permissive` | One of `permissive`, `preferred`, `strict` — see below |
+
+| Policy | Behavior |
+|--------|----------|
+| `permissive` | Default, same as previous releases: skip only providers that self-report the bid's model as `unhealthy`, `tee_unverified`, or `no_model_configured`. Providers with an unknown or missing report are still tried. |
+| `preferred` | When at least one provider reports the model `healthy` or `degraded`, only those providers are tried and unknown/missing reports are skipped. When none does, the open falls back to `permissive` so the model is not black-holed. |
+| `strict` | Only providers that report the model `healthy` are tried. `degraded` and unknown reports are excluded. |
+
+**Single-bid caveat** (`healthPolicySingleBid: permissive`, fixed): when the hard filters (omitted provider, own bids) leave a single candidate provider for the model, `preferred`/`strict` are forced to `permissive` for that open so the sole provider can still be tried — single-provider models must remain usable.
+
 ## TEE (Phase 1 + Phase 2 attestation)
 
 These are only consulted when at least one model in the marketplace is `tee`-tagged. Otherwise they are unused.

--- a/proxy-router/cmd/main.go
+++ b/proxy-router/cmd/main.go
@@ -294,6 +294,7 @@ func start() error {
 	}
 
 	blockchainApi := blockchainapi.NewBlockchainService(ethClient, multicallBackend, *cfg.Marketplace.DiamondContractAddress, *cfg.Marketplace.MorTokenAddress, explorer, wallet, proxyRouterApi, sessionRepo, scorer, authCfg, appLog, rpcLog, cfg.Blockchain.EthLegacyTx, teeVerifier)
+	blockchainApi.SetSessionHealthPolicy(cfg.Proxy.SessionHealthPolicy)
 	sessionRepo.SetModelTagsProvider(blockchainApi)
 	proxyRouterApi.SetSessionService(blockchainApi)
 	proxyRouterApi.SetAttestationVerifier(teeVerifier)

--- a/proxy-router/internal/blockchainapi/model_health_gate_test.go
+++ b/proxy-router/internal/blockchainapi/model_health_gate_test.go
@@ -35,3 +35,94 @@ func TestBlockingModelHealthStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestClassifyModelHealth(t *testing.T) {
+	modelID := common.HexToHash("0x01")
+	otherID := common.HexToHash("0x02")
+
+	tests := []struct {
+		name       string
+		reports    []system.ModelHealthReport
+		wantClass  modelHealthClass
+		wantStatus string
+	}{
+		{"no reports", nil, modelHealthUnknown, ""},
+		{"model not in report", []system.ModelHealthReport{{ModelID: otherID.Hex(), Status: system.ModelHealthStatusHealthy}}, modelHealthUnknown, ""},
+		{"healthy", []system.ModelHealthReport{{ModelID: modelID.Hex(), Status: system.ModelHealthStatusHealthy}}, modelHealthHealthy, system.ModelHealthStatusHealthy},
+		{"degraded", []system.ModelHealthReport{{ModelID: modelID.Hex(), Status: system.ModelHealthStatusDegraded}}, modelHealthDegraded, system.ModelHealthStatusDegraded},
+		{"skipped is unknown", []system.ModelHealthReport{{ModelID: modelID.Hex(), Status: system.ModelHealthStatusSkipped}}, modelHealthUnknown, system.ModelHealthStatusSkipped},
+		{"no_bid is unknown", []system.ModelHealthReport{{ModelID: modelID.Hex(), Status: system.ModelHealthStatusNoBid}}, modelHealthUnknown, system.ModelHealthStatusNoBid},
+		{"unhealthy is blocked", []system.ModelHealthReport{{ModelID: modelID.Hex(), Status: system.ModelHealthStatusUnhealthy}}, modelHealthBlocked, system.ModelHealthStatusUnhealthy},
+		{"tee_unverified is blocked", []system.ModelHealthReport{{ModelID: modelID.Hex(), Status: system.ModelHealthStatusTeeUnverified}}, modelHealthBlocked, system.ModelHealthStatusTeeUnverified},
+		{"no_model_configured is blocked", []system.ModelHealthReport{{ModelID: modelID.Hex(), Status: system.ModelHealthStatusNoModel}}, modelHealthBlocked, system.ModelHealthStatusNoModel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			class, status := classifyModelHealth(tt.reports, modelID)
+			require.Equal(t, tt.wantClass, class)
+			require.Equal(t, tt.wantStatus, status)
+		})
+	}
+}
+
+func TestApplyHealthPolicy(t *testing.T) {
+	tests := []struct {
+		name         string
+		policy       string
+		classes      []modelHealthClass
+		wantKeep     []bool
+		wantFallback bool
+	}{
+		{
+			"permissive keeps healthy, degraded and unknown",
+			HealthPolicyPermissive,
+			[]modelHealthClass{modelHealthHealthy, modelHealthDegraded, modelHealthUnknown, modelHealthBlocked, modelHealthUnreachable},
+			[]bool{true, true, true, false, false},
+			false,
+		},
+		{
+			"strict keeps only healthy",
+			HealthPolicyStrict,
+			[]modelHealthClass{modelHealthHealthy, modelHealthDegraded, modelHealthUnknown, modelHealthBlocked, modelHealthUnreachable},
+			[]bool{true, false, false, false, false},
+			false,
+		},
+		{
+			"preferred skips unknown when a healthy peer exists",
+			HealthPolicyPreferred,
+			[]modelHealthClass{modelHealthHealthy, modelHealthUnknown, modelHealthBlocked},
+			[]bool{true, false, false},
+			false,
+		},
+		{
+			"preferred treats degraded as serviceable",
+			HealthPolicyPreferred,
+			[]modelHealthClass{modelHealthDegraded, modelHealthUnknown},
+			[]bool{true, false},
+			false,
+		},
+		{
+			"preferred falls back to permissive when no peer reports healthy or degraded",
+			HealthPolicyPreferred,
+			[]modelHealthClass{modelHealthUnknown, modelHealthBlocked, modelHealthUnreachable},
+			[]bool{true, false, false},
+			true,
+		},
+		{
+			"strict with no healthy peers keeps nothing",
+			HealthPolicyStrict,
+			[]modelHealthClass{modelHealthUnknown, modelHealthDegraded},
+			[]bool{false, false},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keep, fallback := applyHealthPolicy(tt.policy, tt.classes)
+			require.Equal(t, tt.wantKeep, keep)
+			require.Equal(t, tt.wantFallback, fallback)
+		})
+	}
+}

--- a/proxy-router/internal/blockchainapi/service.go
+++ b/proxy-router/internal/blockchainapi/service.go
@@ -55,6 +55,25 @@ const sessionTxMaxRetries = 3
 
 var maxUint256 = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
 
+// Consumer-side model health strictness policies applied when opening a
+// session by model ID (SESSION_HEALTH_POLICY). They control how provider
+// model health self-reports (read from the healthcheck pong) gate the
+// failover loop. Single-bid opens always force permissive
+// (healthPolicySingleBid is fixed to "permissive") so single-provider models
+// remain usable.
+const (
+	// HealthPolicyPermissive is the default: skip only providers that
+	// self-report the model as unhealthy, tee_unverified or
+	// no_model_configured. Unknown or missing reports are allowed.
+	HealthPolicyPermissive = "permissive"
+	// HealthPolicyPreferred: when any provider reports the model healthy or
+	// degraded, skip providers with unknown/missing reports; when none does,
+	// fall back to permissive for that open (don't black-hole the model).
+	HealthPolicyPreferred = "preferred"
+	// HealthPolicyStrict: only try providers that report the model healthy.
+	HealthPolicyStrict = "strict"
+)
+
 type BlockchainService struct {
 	ethClient           i.EthClient
 	providerRegistry    *r.ProviderRegistry
@@ -71,6 +90,9 @@ type BlockchainService struct {
 	rating              *rating.Rating
 	minStake            *big.Int
 	attestationVerifier *attestation.Verifier
+	// sessionHealthPolicy is the consumer-side model health strictness for
+	// OpenSessionByModelId; empty means HealthPolicyPermissive.
+	sessionHealthPolicy string
 
 	supplyBudgetMu sync.Mutex
 	cachedSupply   *big.Int
@@ -162,6 +184,13 @@ func NewBlockchainService(
 		txEscalator:         txEscalator,
 		attestationVerifier: attestationVerifier,
 	}
+}
+
+// SetSessionHealthPolicy sets the consumer-side model health strictness used
+// by OpenSessionByModelId (one of HealthPolicyPermissive, HealthPolicyPreferred,
+// HealthPolicyStrict). An empty value means permissive.
+func (s *BlockchainService) SetSessionHealthPolicy(policy string) {
+	s.sessionHealthPolicy = policy
 }
 
 func (s *BlockchainService) requestLog(ctx context.Context) lib.ILogger {
@@ -1300,26 +1329,69 @@ func (s *BlockchainService) OpenSessionByModelId(ctx context.Context, modelID co
 
 	log := s.requestLog(ctx)
 	scoredBids := s.rateBids(bidIDs, bids, providerStats, providers, modelStats, minStake, log)
-	for i, bid := range scoredBids {
+
+	// Hard filters (omitted provider, own bids) come first so the health
+	// policy below only sees bids that are actually attemptable.
+	candidates := make([]structs.ScoredBid, 0, len(scoredBids))
+	distinctProviders := make(map[common.Address]struct{}, len(scoredBids))
+	for _, bid := range scoredBids {
 		providerAddr := bid.Bid.Provider
 		if providerAddr == omitProvider {
-			log.Infof("skipping provider #%d %s", i, providerAddr.String())
+			log.Infof("skipping omitted provider %s", providerAddr.String())
 			failures = append(failures, providerFailure{Provider: providerAddr.String(), Reason: "skipped: omitted provider"})
 			continue
 		}
 
 		if providerAddr == userAddr {
-			log.Infof("skipping own bid #%d %s", i, bid.Bid.Id)
+			log.Infof("skipping own bid %s", bid.Bid.Id)
 			continue
 		}
 
+		candidates = append(candidates, bid)
+		distinctProviders[providerAddr] = struct{}{}
+	}
+
+	policy := s.sessionHealthPolicy
+	if policy == "" {
+		policy = HealthPolicyPermissive
+	}
+	// Single-bid caveat (healthPolicySingleBid: permissive): when the hard
+	// filters leave a single bid — or a single provider for the model —
+	// preferred/strict must not yield zero attempts, so the open is forced
+	// permissive and the sole provider can still be tried.
+	if policy != HealthPolicyPermissive && len(distinctProviders) <= 1 {
+		log.Infof("health policy %q forced to permissive for this open: single candidate provider for model %s", policy, modelID)
+		policy = HealthPolicyPermissive
+	}
+
+	if policy != HealthPolicyPermissive {
+		classes, details := s.candidateModelHealth(ctx, candidates, modelID)
+		keep, permissiveFallback := applyHealthPolicy(policy, classes)
+		if permissiveFallback {
+			log.Infof("health policy preferred: no provider reports model %s as healthy or degraded, falling back to permissive for this open", modelID)
+		}
+
+		kept := make([]structs.ScoredBid, 0, len(candidates))
+		for i, bid := range candidates {
+			if keep[i] {
+				kept = append(kept, bid)
+				continue
+			}
+			reason := fmt.Sprintf("skipped by health policy %s: %s", policy, details[i])
+			log.Infof("provider %s %s", bid.Bid.Provider.String(), reason)
+			failures = append(failures, providerFailure{Provider: bid.Bid.Provider.String(), Reason: reason})
+		}
+		candidates = kept
+	}
+
+	for i, bid := range candidates {
 		log.Infof("trying to open session with provider #%d %s", i, bid.Bid.Provider.String())
 		durationCopy := new(big.Int).Set(duration)
 
 		hash, tryNext, err := s.tryOpenSession(ctx, &bid.Bid, durationCopy, supply, budget, userAddr, directPayment, isFailoverEnabled, agentUsername, isTee)
 		if err != nil {
 			log.Errorf("failed to open session with provider %s: %s", bid.Bid.Provider.String(), err.Error())
-			failures = append(failures, providerFailure{Provider: providerAddr.String(), Reason: err.Error()})
+			failures = append(failures, providerFailure{Provider: bid.Bid.Provider.String(), Reason: err.Error()})
 			if tryNext {
 				continue
 			} else {
@@ -1496,6 +1568,50 @@ func (s *BlockchainService) tryOpenSession(ctx context.Context, bid *structs.Bid
 	return hash, false, nil
 }
 
+// modelHealthClass is the consumer-side classification of a provider's model
+// health self-report, used by the session health policy.
+type modelHealthClass int
+
+const (
+	// modelHealthUnknown: no report at all (pre-upgrade provider or health
+	// checks disabled), the model is absent from the report, or the reported
+	// status carries no serviceability signal (skipped, no_bid).
+	modelHealthUnknown modelHealthClass = iota
+	// modelHealthHealthy: the provider reports the model as healthy.
+	modelHealthHealthy
+	// modelHealthDegraded: serving at reduced capacity. Serviceable under
+	// permissive and preferred (capacity risk is not "don't open"); only
+	// strict excludes it.
+	modelHealthDegraded
+	// modelHealthBlocked: the report says a session for the model would not
+	// be serviceable (unhealthy, tee_unverified, no_model_configured);
+	// skipped under every policy.
+	modelHealthBlocked
+	// modelHealthUnreachable: the healthcheck ping itself failed.
+	modelHealthUnreachable
+)
+
+// classifyModelHealth maps the provider's model health self-report (from the
+// healthcheck pong) to its consumer-side class for the given model, along
+// with the raw reported status (empty when the model has no report).
+func classifyModelHealth(models []system.ModelHealthReport, modelID common.Hash) (modelHealthClass, string) {
+	for _, report := range models {
+		if !strings.EqualFold(report.ModelID, modelID.Hex()) {
+			continue
+		}
+		switch report.Status {
+		case system.ModelHealthStatusHealthy:
+			return modelHealthHealthy, report.Status
+		case system.ModelHealthStatusDegraded:
+			return modelHealthDegraded, report.Status
+		case system.ModelHealthStatusUnhealthy, system.ModelHealthStatusTeeUnverified, system.ModelHealthStatusNoModel:
+			return modelHealthBlocked, report.Status
+		}
+		return modelHealthUnknown, report.Status
+	}
+	return modelHealthUnknown, ""
+}
+
 // blockingModelHealthStatus inspects the provider's model health self-report
 // (from the healthcheck pong) and returns the reported status when it means a
 // session for the model would not be serviceable: the model backend is
@@ -1503,19 +1619,94 @@ func (s *BlockchainService) tryOpenSession(ctx context.Context, bid *structs.Bid
 // but no backend configured for the model. An empty result means the session
 // open may proceed — including when the report is absent (pre-upgrade
 // provider or health checks disabled), since absence of data is not evidence
-// of failure.
+// of failure. This is the permissive baseline gate applied on every attempt
+// regardless of the configured session health policy.
 func blockingModelHealthStatus(models []system.ModelHealthReport, modelID common.Hash) string {
-	for _, report := range models {
-		if !strings.EqualFold(report.ModelID, modelID.Hex()) {
-			continue
-		}
-		switch report.Status {
-		case system.ModelHealthStatusUnhealthy, system.ModelHealthStatusTeeUnverified, system.ModelHealthStatusNoModel:
-			return report.Status
-		}
-		return ""
+	class, status := classifyModelHealth(models, modelID)
+	if class == modelHealthBlocked {
+		return status
 	}
 	return ""
+}
+
+// applyHealthPolicy decides, per candidate provider, whether the session open
+// loop should attempt it under the given health policy (classes[i] is the
+// health class of candidate i for the model being opened). It returns keep
+// flags aligned with classes and whether the preferred policy fell back to
+// permissive because no candidate reported the model healthy or degraded.
+// The single-bid caveat (forcing permissive when only one candidate remains)
+// is handled by the caller before this point.
+func applyHealthPolicy(policy string, classes []modelHealthClass) (keep []bool, permissiveFallback bool) {
+	anyServiceable := false
+	for _, c := range classes {
+		if c == modelHealthHealthy || c == modelHealthDegraded {
+			anyServiceable = true
+			break
+		}
+	}
+
+	keep = make([]bool, len(classes))
+	for i, c := range classes {
+		switch policy {
+		case HealthPolicyStrict:
+			keep[i] = c == modelHealthHealthy
+		case HealthPolicyPreferred:
+			if anyServiceable {
+				keep[i] = c == modelHealthHealthy || c == modelHealthDegraded
+			} else {
+				keep[i] = c == modelHealthUnknown
+			}
+		default:
+			keep[i] = c != modelHealthBlocked && c != modelHealthUnreachable
+		}
+	}
+
+	return keep, policy == HealthPolicyPreferred && !anyServiceable
+}
+
+// candidateModelHealth pings every candidate provider concurrently and
+// classifies its self-reported health for the model. It returns classes and
+// human-readable details (reported status or ping error) aligned with
+// candidates. Used only for the preferred and strict policies; permissive
+// keeps relying on the per-attempt ping inside tryOpenSession.
+func (s *BlockchainService) candidateModelHealth(ctx context.Context, candidates []structs.ScoredBid, modelID common.Hash) ([]modelHealthClass, []string) {
+	classes := make([]modelHealthClass, len(candidates))
+	details := make([]string, len(candidates))
+
+	var wg sync.WaitGroup
+	for i := range candidates {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			providerAddr := candidates[i].Bid.Provider
+			provider, err := s.providerRegistry.GetProviderById(ctx, providerAddr)
+			if err != nil {
+				classes[i] = modelHealthUnreachable
+				details[i] = fmt.Sprintf("failed to get provider: %s", err)
+				return
+			}
+
+			pingCtx, cancel := context.WithTimeout(ctx, proxyapi.TimeoutPingDefault)
+			_, _, models, err := s.proxyService.Ping(pingCtx, provider.Endpoint, providerAddr)
+			cancel()
+			if err != nil {
+				classes[i] = modelHealthUnreachable
+				details[i] = fmt.Sprintf("healthcheck ping failed: %s", err)
+				return
+			}
+
+			class, status := classifyModelHealth(models, modelID)
+			classes[i] = class
+			if status == "" {
+				status = "no health report for model"
+			}
+			details[i] = status
+		}(i)
+	}
+	wg.Wait()
+
+	return classes, details
 }
 
 func (s *BlockchainService) GetMyAddress(ctx context.Context) (common.Address, error) {

--- a/proxy-router/internal/config/config.go
+++ b/proxy-router/internal/config/config.go
@@ -79,7 +79,12 @@ type Config struct {
 		ModelHealthCheckInterval   time.Duration `env:"MODEL_HEALTH_CHECK_INTERVAL" flag:"model-health-check-interval" validate:"omitempty,duration" desc:"how often to probe configured models with a test prompt, result is cached between runs"`
 		ModelHealthCheckTimeout    time.Duration `env:"MODEL_HEALTH_CHECK_TIMEOUT" flag:"model-health-check-timeout" validate:"omitempty,duration" desc:"per-model health probe timeout"`
 		ModelHealthCheckProbeDelay time.Duration `env:"MODEL_HEALTH_CHECK_PROBE_DELAY" flag:"model-health-check-probe-delay" validate:"omitempty,duration" desc:"pause between per-model health probes so many-model providers don't burst their upstream and trip rate limits"`
-		ModelHealthMaxConsecErrors int           `env:"MODEL_HEALTH_MAX_CONSECUTIVE_ERRORS" flag:"model-health-max-consecutive-errors" validate:"omitempty,gte=1" desc:"consecutive session prompt failures after which a model is immediately reported unhealthy, without waiting for the next scheduled probe"`
+		ModelHealthMaxConsecErrors int           `env:"MODEL_HEALTH_MAX_CONSECUTIVE_ERRORS" flag:"model-health-max-consecutive-errors" validate:"omitempty,gte=1" desc:"consecutive session prompt failures after which a model is immediately reported unhealthy (or degraded when every failure was upstream rate limiting), without waiting for the next scheduled probe"`
+		// SessionHealthPolicy is the consumer-side strictness towards provider
+		// model health self-reports when opening a session by model ID.
+		// Single-bid opens always force permissive (healthPolicySingleBid is
+		// fixed to "permissive") so single-provider models remain usable.
+		SessionHealthPolicy string `env:"SESSION_HEALTH_POLICY" flag:"session-health-policy" validate:"omitempty,oneof=permissive preferred strict" desc:"model health strictness when opening a session by model: permissive (default; skip only providers self-reporting unhealthy/tee_unverified/no_model_configured), preferred (when any provider reports healthy or degraded, skip providers with unknown/missing reports; otherwise fall back to permissive), strict (only try providers reporting healthy); opens with a single candidate bid always use permissive"`
 	}
 	System struct {
 		Enable           bool   `env:"SYS_ENABLE"              flag:"sys-enable" desc:"enable system level configuration adjustments"`
@@ -227,6 +232,9 @@ func (cfg *Config) SetDefaults() {
 	if cfg.Proxy.ModelHealthMaxConsecErrors == 0 {
 		cfg.Proxy.ModelHealthMaxConsecErrors = 3
 	}
+	if cfg.Proxy.SessionHealthPolicy == "" {
+		cfg.Proxy.SessionHealthPolicy = "permissive"
+	}
 
 	// IPFS
 	if cfg.IPFS.Address == "" {
@@ -306,6 +314,7 @@ func (cfg *Config) GetSanitized() interface{} {
 	publicCfg.Proxy.ModelHealthCheckTimeout = cfg.Proxy.ModelHealthCheckTimeout
 	publicCfg.Proxy.ModelHealthCheckProbeDelay = cfg.Proxy.ModelHealthCheckProbeDelay
 	publicCfg.Proxy.ModelHealthMaxConsecErrors = cfg.Proxy.ModelHealthMaxConsecErrors
+	publicCfg.Proxy.SessionHealthPolicy = cfg.Proxy.SessionHealthPolicy
 
 	publicCfg.System.Enable = cfg.System.Enable
 	publicCfg.System.LocalPortRange = cfg.System.LocalPortRange

--- a/proxy-router/internal/modelhealth/checker.go
+++ b/proxy-router/internal/modelhealth/checker.go
@@ -69,8 +69,9 @@ type TeeStatusProvider interface {
 }
 
 // DefaultMaxConsecutiveErrors is the number of consecutive real-session
-// prompt failures after which a model is flipped to unhealthy without
-// waiting for the next scheduled probe sweep.
+// prompt failures after which a model is flipped to unhealthy (or degraded,
+// when the whole streak is upstream rate limiting) without waiting for the
+// next scheduled probe sweep.
 const DefaultMaxConsecutiveErrors = 3
 
 // modelMeta caches the public on-chain facts about a model so each sweep
@@ -87,15 +88,16 @@ type Checker struct {
 	timeout    time.Duration
 	probeDelay time.Duration
 	// maxConsecutiveErrors is the threshold of consecutive session prompt
-	// failures that dynamically flips a model to unhealthy.
+	// failures that dynamically flips a model to unhealthy or degraded.
 	maxConsecutiveErrors int
 	log                  lib.ILogger
 
 	mu        sync.RWMutex
 	reports   map[string]system.ModelHealthReport
 	modelMeta map[string]modelMeta
-	// failures counts consecutive real-session prompt failures per model.
-	failures map[string]int
+	// failures tracks the consecutive real-session prompt failure streak per
+	// model, including whether the whole streak was upstream rate limiting.
+	failures map[string]failureStreak
 
 	// triggerCh carries manual re-check requests into the Run loop; buffered
 	// at 1 so triggers queue at most one extra sweep and can never overlap.
@@ -134,7 +136,7 @@ func NewChecker(deps Deps, interval, timeout, probeDelay time.Duration, maxConse
 		log:                  log.Named("MODEL_HEALTH"),
 		reports:              make(map[string]system.ModelHealthReport),
 		modelMeta:            make(map[string]modelMeta),
-		failures:             make(map[string]int),
+		failures:             make(map[string]failureStreak),
 		triggerCh:            make(chan struct{}, 1),
 	}
 }
@@ -421,13 +423,16 @@ func (c *Checker) checkModel(ctx context.Context, modelID common.Hash, bidID com
 
 	if err != nil {
 		c.log.Warnf("model %s: probe failed: %s", lib.Short(modelID), err)
-		report.Status = system.ModelHealthStatusUnhealthy
 		// 429 means the backend is up and correctly configured, just
-		// throttled right now — a materially different signal than a
-		// billing (402) or configuration (404) failure.
+		// throttled right now — capacity risk, not failure, and materially
+		// different from a billing (402) or configuration (404) problem.
+		// Reported as degraded so consumers still treat the model as
+		// serviceable (only the strict session health policy excludes it).
 		if report.HttpStatus == http.StatusTooManyRequests {
+			report.Status = system.ModelHealthStatusDegraded
 			report.ErrorKind = system.ModelHealthErrorRateLimited
 		} else {
+			report.Status = system.ModelHealthStatusUnhealthy
 			report.ErrorKind = classifyError(err)
 		}
 	} else {
@@ -546,21 +551,43 @@ func (c *Checker) setReport(report system.ModelHealthReport) {
 	c.reports[report.ModelID] = report
 }
 
-// ReportPromptFailure records a failed real-session prompt for the model.
-// After maxConsecutiveErrors failures in a row the model's health report is
-// flipped to unhealthy immediately, without waiting for the next scheduled
-// probe sweep, so consumers pinging before session open skip this provider.
-func (c *Checker) ReportPromptFailure(modelID common.Hash) {
+// failureStreak tracks consecutive real-session prompt failures for a model.
+type failureStreak struct {
+	count int
+	// rateLimitedOnly stays true while every failure in the current streak
+	// was an upstream 429 — a pure throttling streak flips the model to
+	// degraded (capacity risk) instead of unhealthy.
+	rateLimitedOnly bool
+}
+
+// ReportPromptFailure records a failed real-session prompt for the model;
+// upstreamStatus is the HTTP status returned by the backend (0 when the
+// failure never got an HTTP response). After maxConsecutiveErrors failures in
+// a row the model's health report is flipped immediately, without waiting for
+// the next scheduled probe sweep: to degraded when the whole streak was
+// upstream rate limiting (429), to unhealthy otherwise.
+func (c *Checker) ReportPromptFailure(modelID common.Hash, upstreamStatus int) {
 	id := modelID.Hex()
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.failures[id]++
-	count := c.failures[id]
-	if count < c.maxConsecutiveErrors {
-		c.log.Warnf("model %s: session prompt failed (%d/%d consecutive)", lib.Short(modelID), count, c.maxConsecutiveErrors)
+	streak, ok := c.failures[id]
+	if !ok {
+		streak.rateLimitedOnly = true
+	}
+	streak.count++
+	streak.rateLimitedOnly = streak.rateLimitedOnly && upstreamStatus == http.StatusTooManyRequests
+	c.failures[id] = streak
+
+	if streak.count < c.maxConsecutiveErrors {
+		c.log.Warnf("model %s: session prompt failed (%d/%d consecutive)", lib.Short(modelID), streak.count, c.maxConsecutiveErrors)
 		return
+	}
+
+	status := system.ModelHealthStatusUnhealthy
+	if streak.rateLimitedOnly {
+		status = system.ModelHealthStatusDegraded
 	}
 
 	report, ok := c.reports[id]
@@ -569,19 +596,22 @@ func (c *Checker) ReportPromptFailure(modelID common.Hash) {
 		// if no sweep has reported on it yet.
 		report = system.ModelHealthReport{ModelID: id, HasActiveBid: true}
 	}
-	if report.Status != system.ModelHealthStatusUnhealthy {
-		c.log.Warnf("model %s: %d consecutive session prompt failures, marking unhealthy", lib.Short(modelID), count)
+	if report.Status != status {
+		c.log.Warnf("model %s: %d consecutive session prompt failures, marking %s", lib.Short(modelID), streak.count, status)
 	}
-	report.Status = system.ModelHealthStatusUnhealthy
+	report.Status = status
 	report.ErrorKind = system.ModelHealthErrorSessionErrors
+	if streak.rateLimitedOnly {
+		report.HttpStatus = http.StatusTooManyRequests
+	}
 	report.LastChecked = time.Now().Unix()
 	c.reports[id] = report
 }
 
 // ReportPromptSuccess records a successful real-session prompt: the failure
-// streak resets and, if the model was flipped to unhealthy by session errors,
-// it is healed right away (a real prompt succeeding is stronger evidence than
-// a probe).
+// streak resets and, if the model was flipped to unhealthy or degraded by
+// session errors, it is healed right away (a real prompt succeeding is
+// stronger evidence than a probe).
 func (c *Checker) ReportPromptSuccess(modelID common.Hash) {
 	id := modelID.Hex()
 
@@ -594,9 +624,11 @@ func (c *Checker) ReportPromptSuccess(modelID common.Hash) {
 	if !ok {
 		return
 	}
-	if report.Status == system.ModelHealthStatusUnhealthy && report.ErrorKind == system.ModelHealthErrorSessionErrors {
+	sessionFlipped := report.Status == system.ModelHealthStatusUnhealthy || report.Status == system.ModelHealthStatusDegraded
+	if sessionFlipped && report.ErrorKind == system.ModelHealthErrorSessionErrors {
 		report.Status = system.ModelHealthStatusHealthy
 		report.ErrorKind = ""
+		report.HttpStatus = 0
 		report.LastChecked = time.Now().Unix()
 	}
 	report.LastHealthy = time.Now().Unix()

--- a/proxy-router/internal/modelhealth/checker_test.go
+++ b/proxy-router/internal/modelhealth/checker_test.go
@@ -353,7 +353,7 @@ func TestCheckAllRateLimited(t *testing.T) {
 	checker.checkAll(context.Background(), common.Address{})
 
 	llm := reportByID(t, checker.GetReports(), modelLLM)
-	require.Equal(t, system.ModelHealthStatusUnhealthy, llm.Status)
+	require.Equal(t, system.ModelHealthStatusDegraded, llm.Status)
 	require.Equal(t, system.ModelHealthErrorRateLimited, llm.ErrorKind)
 	require.Equal(t, 429, llm.HttpStatus)
 }
@@ -547,12 +547,12 @@ func TestReportPromptFailureFlipsAfterThreshold(t *testing.T) {
 	checker.checkAll(context.Background(), common.Address{})
 	require.Equal(t, system.ModelHealthStatusHealthy, reportByID(t, checker.GetReports(), modelLLM).Status)
 
-	checker.ReportPromptFailure(modelLLM)
-	checker.ReportPromptFailure(modelLLM)
+	checker.ReportPromptFailure(modelLLM, 0)
+	checker.ReportPromptFailure(modelLLM, 0)
 	require.Equal(t, system.ModelHealthStatusHealthy, reportByID(t, checker.GetReports(), modelLLM).Status,
 		"below the threshold the status must not change")
 
-	checker.ReportPromptFailure(modelLLM)
+	checker.ReportPromptFailure(modelLLM, 0)
 	llm := reportByID(t, checker.GetReports(), modelLLM)
 	require.Equal(t, system.ModelHealthStatusUnhealthy, llm.Status)
 	require.Equal(t, system.ModelHealthErrorSessionErrors, llm.ErrorKind)
@@ -569,15 +569,15 @@ func TestReportPromptSuccessResetsStreakAndHeals(t *testing.T) {
 	checker.checkAll(context.Background(), common.Address{})
 
 	// success in the middle of a streak resets the counter
-	checker.ReportPromptFailure(modelLLM)
-	checker.ReportPromptFailure(modelLLM)
+	checker.ReportPromptFailure(modelLLM, 0)
+	checker.ReportPromptFailure(modelLLM, 0)
 	checker.ReportPromptSuccess(modelLLM)
-	checker.ReportPromptFailure(modelLLM)
-	checker.ReportPromptFailure(modelLLM)
+	checker.ReportPromptFailure(modelLLM, 0)
+	checker.ReportPromptFailure(modelLLM, 0)
 	require.Equal(t, system.ModelHealthStatusHealthy, reportByID(t, checker.GetReports(), modelLLM).Status)
 
 	// third consecutive failure flips it...
-	checker.ReportPromptFailure(modelLLM)
+	checker.ReportPromptFailure(modelLLM, 0)
 	require.Equal(t, system.ModelHealthStatusUnhealthy, reportByID(t, checker.GetReports(), modelLLM).Status)
 
 	// ...and a successful real prompt heals it right away
@@ -597,22 +597,90 @@ func TestHealthyProbeResetsFailureStreak(t *testing.T) {
 	}
 	checker := newTestChecker(deps)
 
-	checker.ReportPromptFailure(modelLLM)
-	checker.ReportPromptFailure(modelLLM)
+	checker.ReportPromptFailure(modelLLM, 0)
+	checker.ReportPromptFailure(modelLLM, 0)
 
 	// a healthy scheduled sweep clears the streak: two more failures stay
 	// below the threshold again
 	checker.checkAll(context.Background(), common.Address{})
-	checker.ReportPromptFailure(modelLLM)
-	checker.ReportPromptFailure(modelLLM)
+	checker.ReportPromptFailure(modelLLM, 0)
+	checker.ReportPromptFailure(modelLLM, 0)
 	require.Equal(t, system.ModelHealthStatusHealthy, reportByID(t, checker.GetReports(), modelLLM).Status)
+}
+
+func TestReportPromptFailureRateLimitedStreakFlipsDegraded(t *testing.T) {
+	deps := &mockDeps{
+		bids:     []*structs.Bid{bidFor(modelLLM)},
+		tags:     map[common.Hash][]string{modelLLM: {"llm"}},
+		modelIDs: []common.Hash{modelLLM},
+		adapter:  &mathSolvingAdapter{},
+	}
+	checker := newTestChecker(deps) // threshold defaults to 3
+	checker.checkAll(context.Background(), common.Address{})
+
+	// a streak that is pure upstream throttling flips to degraded, not unhealthy
+	checker.ReportPromptFailure(modelLLM, 429)
+	checker.ReportPromptFailure(modelLLM, 429)
+	checker.ReportPromptFailure(modelLLM, 429)
+
+	llm := reportByID(t, checker.GetReports(), modelLLM)
+	require.Equal(t, system.ModelHealthStatusDegraded, llm.Status)
+	require.Equal(t, system.ModelHealthErrorSessionErrors, llm.ErrorKind)
+	require.Equal(t, 429, llm.HttpStatus)
+
+	// a successful real prompt heals session-flipped degraded right away
+	checker.ReportPromptSuccess(modelLLM)
+	llm = reportByID(t, checker.GetReports(), modelLLM)
+	require.Equal(t, system.ModelHealthStatusHealthy, llm.Status)
+	require.Empty(t, llm.ErrorKind)
+	require.Zero(t, llm.HttpStatus)
+}
+
+func TestReportPromptFailureMixedStreakFlipsUnhealthy(t *testing.T) {
+	deps := &mockDeps{
+		bids:     []*structs.Bid{bidFor(modelLLM)},
+		tags:     map[common.Hash][]string{modelLLM: {"llm"}},
+		modelIDs: []common.Hash{modelLLM},
+		adapter:  &mathSolvingAdapter{},
+	}
+	checker := newTestChecker(deps)
+	checker.checkAll(context.Background(), common.Address{})
+
+	// any non-429 failure in the streak means real errors, not just throttling
+	checker.ReportPromptFailure(modelLLM, 429)
+	checker.ReportPromptFailure(modelLLM, 500)
+	checker.ReportPromptFailure(modelLLM, 429)
+
+	llm := reportByID(t, checker.GetReports(), modelLLM)
+	require.Equal(t, system.ModelHealthStatusUnhealthy, llm.Status)
+	require.Equal(t, system.ModelHealthErrorSessionErrors, llm.ErrorKind)
+}
+
+func TestReportPromptFailureDegradedEscalatesToUnhealthy(t *testing.T) {
+	deps := &mockDeps{
+		bids:     []*structs.Bid{bidFor(modelLLM)},
+		tags:     map[common.Hash][]string{modelLLM: {"llm"}},
+		modelIDs: []common.Hash{modelLLM},
+		adapter:  &mathSolvingAdapter{},
+	}
+	checker := newTestChecker(deps)
+	checker.checkAll(context.Background(), common.Address{})
+
+	checker.ReportPromptFailure(modelLLM, 429)
+	checker.ReportPromptFailure(modelLLM, 429)
+	checker.ReportPromptFailure(modelLLM, 429)
+	require.Equal(t, system.ModelHealthStatusDegraded, reportByID(t, checker.GetReports(), modelLLM).Status)
+
+	// a non-429 failure joining the still-open streak escalates to unhealthy
+	checker.ReportPromptFailure(modelLLM, 500)
+	require.Equal(t, system.ModelHealthStatusUnhealthy, reportByID(t, checker.GetReports(), modelLLM).Status)
 }
 
 func TestReportPromptFailureWithoutPriorReport(t *testing.T) {
 	checker := newTestChecker(&mockDeps{})
 
 	for i := 0; i < DefaultMaxConsecutiveErrors; i++ {
-		checker.ReportPromptFailure(modelLLM)
+		checker.ReportPromptFailure(modelLLM, 0)
 	}
 
 	llm := reportByID(t, checker.GetReports(), modelLLM)

--- a/proxy-router/internal/proxyapi/model_health_tracking_test.go
+++ b/proxy-router/internal/proxyapi/model_health_tracking_test.go
@@ -8,14 +8,18 @@ import (
 )
 
 type fakeHealthTracker struct {
-	successes int
-	failures  int
-	tee       int
+	successes      int
+	failures       int
+	lastFailStatus int
+	tee            int
 }
 
 func (f *fakeHealthTracker) ReportPromptSuccess(modelID common.Hash) { f.successes++ }
-func (f *fakeHealthTracker) ReportPromptFailure(modelID common.Hash) { f.failures++ }
-func (f *fakeHealthTracker) ReportTeeFailure(modelID common.Hash)    { f.tee++ }
+func (f *fakeHealthTracker) ReportPromptFailure(modelID common.Hash, upstreamStatus int) {
+	f.failures++
+	f.lastFailStatus = upstreamStatus
+}
+func (f *fakeHealthTracker) ReportTeeFailure(modelID common.Hash) { f.tee++ }
 
 func TestTrackPromptResult(t *testing.T) {
 	modelID := common.HexToHash("0x01")
@@ -48,6 +52,15 @@ func TestTrackPromptResult(t *testing.T) {
 			}
 			if tracker.failures != tt.wantFailures {
 				t.Errorf("failures = %d, want %d", tracker.failures, tt.wantFailures)
+			}
+			// A recorded failure must carry the upstream HTTP status (0 for
+			// transport errors) so the tracker can tell throttling apart.
+			wantStatus := 0
+			if tt.wantFailures > 0 && tt.gotEngineErr {
+				wantStatus = tt.engineStatus
+			}
+			if tracker.failures > 0 && tracker.lastFailStatus != wantStatus {
+				t.Errorf("lastFailStatus = %d, want %d", tracker.lastFailStatus, wantStatus)
 			}
 		})
 	}

--- a/proxy-router/internal/proxyapi/proxy_receiver.go
+++ b/proxy-router/internal/proxyapi/proxy_receiver.go
@@ -31,7 +31,11 @@ type BackendTEEVerifier interface {
 // modelhealth.Checker).
 type ModelHealthTracker interface {
 	ReportPromptSuccess(modelID common.Hash)
-	ReportPromptFailure(modelID common.Hash)
+	// ReportPromptFailure records a failed prompt; upstreamStatus is the HTTP
+	// status returned by the model backend (0 when the failure never got an
+	// HTTP response, e.g. a transport error). An all-429 failure streak flips
+	// the model to degraded instead of unhealthy.
+	ReportPromptFailure(modelID common.Hash, upstreamStatus int)
 	ReportTeeFailure(modelID common.Hash)
 }
 
@@ -103,12 +107,12 @@ func (s *ProxyReceiver) trackPromptResult(modelID common.Hash, transportErr erro
 		return
 	}
 	if transportErr != nil {
-		s.modelHealth.ReportPromptFailure(modelID)
+		s.modelHealth.ReportPromptFailure(modelID, 0)
 		return
 	}
 	if gotEngineErr {
 		if isBackendFaultStatus(engineErrStatus) {
-			s.modelHealth.ReportPromptFailure(modelID)
+			s.modelHealth.ReportPromptFailure(modelID, engineErrStatus)
 		}
 		// client-fault errors count neither as failure nor success
 		return

--- a/proxy-router/internal/system/structs.go
+++ b/proxy-router/internal/system/structs.go
@@ -35,14 +35,22 @@ const (
 	// Session requests for the model would be rejected, so it is reported
 	// separately from a plain backend probe failure.
 	ModelHealthStatusTeeUnverified = "tee_unverified"
+	// ModelHealthStatusDegraded marks a model that is serving but at reduced
+	// capacity: emitted when a health probe fails with HTTP 429 (upstream
+	// throttled). It signals capacity risk, not failure: consumers treat it
+	// as serviceable under the permissive and preferred health policies;
+	// only the strict policy excludes it.
+	ModelHealthStatusDegraded = "degraded"
 
 	ModelHealthErrorTimeout     = "timeout"
 	ModelHealthErrorConnection  = "connection"
 	ModelHealthErrorBadResponse = "bad_response"
 	ModelHealthErrorRateLimited = "rate_limited"
 	ModelHealthErrorTypeLookup  = "model_type_lookup"
-	// ModelHealthErrorSessionErrors marks a model flipped to unhealthy by
-	// consecutive real-session prompt failures rather than a scheduled probe.
+	// ModelHealthErrorSessionErrors marks a model flipped to unhealthy — or
+	// to degraded, when the whole failure streak was upstream rate limiting
+	// (429) — by consecutive real-session prompt failures rather than a
+	// scheduled probe.
 	ModelHealthErrorSessionErrors = "session_errors"
 	// ModelHealthErrorTeeAttestation accompanies ModelHealthStatusTeeUnverified.
 	ModelHealthErrorTeeAttestation = "tee_attestation"


### PR DESCRIPTION
…ed model status

Consumers can now choose how strictly provider model health self-reports gate session opens by model ID: permissive (default, unchanged), preferred (prefer providers reporting healthy/degraded, fall back to permissive when none does), or strict (healthy only). Single-provider models always open permissive so they stay usable.

Rate-limited backends (429 probe results or all-429 session failure streaks) are now reported as degraded instead of unhealthy — capacity risk, not failure — so only strict consumers skip them.