### PR TITLE
fix(proxy-router): accept numeric version/tee_type from SecretAI portal

### DIFF
--- a/proxy-router/internal/attestation/verifier.go
+++ b/proxy-router/internal/attestation/verifier.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -43,6 +44,32 @@ func (c *collateralField) UnmarshalJSON(data []byte) error {
 	c.Error = obj.Error
 	return nil
 }
+
+// softString unmarshals a JSON string or number into a Go string.
+// SecretAI Portal quote-parse currently emits version/tee_type as numbers;
+// older responses used strings or omitted the fields.
+type softString string
+
+func (s *softString) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if bytes.Equal(data, []byte("null")) {
+		*s = ""
+		return nil
+	}
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		*s = softString(str)
+		return nil
+	}
+	var num float64
+	if err := json.Unmarshal(data, &num); err == nil {
+		*s = softString(strconv.FormatFloat(num, 'f', -1, 64))
+		return nil
+	}
+	return fmt.Errorf("softString: expected string or number, got %s", string(data))
+}
+
+func (s softString) String() string { return string(s) }
 
 const (
 	// AttestationPort is Phase 1 (consumer → P-Node): SecretVM host attestation.
@@ -117,18 +144,18 @@ type ParseQuoteResponse struct {
 }
 
 type QuoteFields struct {
-	Version     string `json:"version,omitempty"`
-	TEEType     string `json:"tee_type,omitempty"`
-	TCBSVN      string `json:"tcb_svn,omitempty"`
-	MRSeam      string `json:"mr_seam,omitempty"`
-	MRTD        string `json:"mr_td,omitempty"`
-	RTMR0       string `json:"rtmr0,omitempty"`
-	RTMR1       string `json:"rtmr1,omitempty"`
-	RTMR2       string `json:"rtmr2,omitempty"`
-	RTMR3       string `json:"rtmr3,omitempty"`
-	ReportData  string `json:"report_data,omitempty"`
-	Measurement string `json:"measurement,omitempty"`
-	MachineID   string `json:"machine_id,omitempty"`
+	Version     softString `json:"version,omitempty"`
+	TEEType     softString `json:"tee_type,omitempty"`
+	TCBSVN      string     `json:"tcb_svn,omitempty"`
+	MRSeam      string     `json:"mr_seam,omitempty"`
+	MRTD        string     `json:"mr_td,omitempty"`
+	RTMR0       string     `json:"rtmr0,omitempty"`
+	RTMR1       string     `json:"rtmr1,omitempty"`
+	RTMR2       string     `json:"rtmr2,omitempty"`
+	RTMR3       string     `json:"rtmr3,omitempty"`
+	ReportData  string     `json:"report_data,omitempty"`
+	Measurement string     `json:"measurement,omitempty"`
+	MachineID   string     `json:"machine_id,omitempty"`
 }
 
 type QuoteStatus struct {

--- a/proxy-router/internal/attestation/verifier_portal_test.go
+++ b/proxy-router/internal/attestation/verifier_portal_test.go
@@ -1,0 +1,111 @@
+package attestation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseQuoteResponse_NumericVersionAndTeeType(t *testing.T) {
+	// Live SecretAI Portal shape (TDX): version/tee_type are JSON numbers.
+	raw := []byte(`{
+		"status": {"attestation_type": "tdx", "result": "ok"},
+		"quote": {
+			"attestation_type": "tdx",
+			"version": 4,
+			"tee_type": 129,
+			"mr_td": "abcd",
+			"rtmr0": "1111",
+			"rtmr1": "2222",
+			"rtmr2": "3333",
+			"rtmr3": "4444",
+			"report_data": "deadbeef"
+		}
+	}`)
+
+	var parsed ParseQuoteResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal portal response: %v", err)
+	}
+	if parsed.Quote == nil {
+		t.Fatal("expected quote")
+	}
+	if got := parsed.Quote.Version.String(); got != "4" {
+		t.Fatalf("Version = %q, want 4", got)
+	}
+	if got := parsed.Quote.TEEType.String(); got != "129" {
+		t.Fatalf("TEEType = %q, want 129", got)
+	}
+	if parsed.Quote.MRTD != "abcd" {
+		t.Fatalf("MRTD = %q, want abcd", parsed.Quote.MRTD)
+	}
+}
+
+func TestParseQuoteResponse_StringVersionStillAccepted(t *testing.T) {
+	raw := []byte(`{"quote":{"version":"4","tee_type":"TDX","mr_td":"a","rtmr0":"b","rtmr1":"c","rtmr2":"d","report_data":"e"}}`)
+	var parsed ParseQuoteResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.Quote.Version.String() != "4" || parsed.Quote.TEEType.String() != "TDX" {
+		t.Fatalf("got version=%q tee_type=%q", parsed.Quote.Version, parsed.Quote.TEEType)
+	}
+}
+
+func TestParseQuoteResponse_SEVNumericVersion(t *testing.T) {
+	raw := []byte(`{
+		"status": {"attestation_type": "sev", "verify": "ok"},
+		"quote": {
+			"attestation_type": "sev",
+			"version": 3,
+			"report_data": "aa bb",
+			"measurement": "ff00"
+		}
+	}`)
+	var parsed ParseQuoteResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal SEV portal response: %v", err)
+	}
+	if parsed.Quote.Version.String() != "3" {
+		t.Fatalf("Version = %q, want 3", parsed.Quote.Version)
+	}
+	if parsed.Quote.Measurement != "ff00" {
+		t.Fatalf("Measurement = %q", parsed.Quote.Measurement)
+	}
+}
+
+func TestVerifyQuote_PortalNumericFields(t *testing.T) {
+	portal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"status": {"attestation_type": "tdx", "result": "ok"},
+			"quote": {
+				"version": 4,
+				"tee_type": 129,
+				"mr_td": "aaaa",
+				"rtmr0": "bbbb",
+				"rtmr1": "cccc",
+				"rtmr2": "dddd",
+				"rtmr3": "eeee",
+				"report_data": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+			}
+		}`))
+	}))
+	defer portal.Close()
+
+	result, err := VerifyQuote(context.Background(), portal.Client(), portal.URL, "0400020081000000deadbeef")
+	if err != nil {
+		t.Fatalf("VerifyQuote: %v", err)
+	}
+	if !result.Valid {
+		t.Fatalf("expected valid, got error %q", result.Error)
+	}
+	if result.Type != TEETypeTDX {
+		t.Fatalf("type = %s, want TDX", result.Type)
+	}
+	if result.MRTD != "aaaa" || result.ReportData == "" {
+		t.Fatalf("unexpected fields: %+v", result)
+	}
+}


### PR DESCRIPTION
## Summary
- SecretAI `quote-parse` / `quote-parse-sev` now returns `version` and `tee_type` as JSON numbers; proxy-router expected strings and failed Phase 2 backend attestation with `cannot unmarshal number into Go struct field QuoteFields.quote.version`.
- Accept string or number for those fields (`softString`) so TDX and SEV portal responses parse again.
- Add unit tests covering numeric TDX/SEV portal shapes and legacy string responses.

## Test plan
- [x] `go test ./internal/attestation/ -run 'TestParseQuoteResponse_|TestVerifyQuote_PortalNumeric'`
- [ ] Redeploy testnet TEE P-Node after promote; confirm startup logs show `CPU quote valid` instead of portal unmarshal failure
- [ ] Confirm models leave `tee_unverified` after health sweep


Made with [Cursor](https://cursor.com)