### PR TITLE
promote: TEE portal parse fix + Swagger Basic Auth docs to test

### DIFF
--- a/docs/consumers/install-from-source.mdx
+++ b/docs/consumers/install-from-source.mdx
@@ -3,7 +3,7 @@ title: "Install from source"
 description: "Set up a consumer node from the GitHub source so you can interact with remote providers via the API."
 audience: ["consumer", "developer"]
 product: ["proxy-router", "cli"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 source: "docs/04a-consumer-setup-source.md"
 ---
 
@@ -12,6 +12,7 @@ This guide builds the proxy-router from source and walks through the API-only co
 ## Pre-requisites
 
 - An ERC-20 wallet on BASE with MOR + ETH (use a top-level, not derived, address). **Never share your private key.**
+- Basic Auth credentials for the local API. On first start the proxy-router writes `admin:<password>` to `.cookie` next to the binary — use those credentials in Swagger (**Authorize**) and in every curl below. See [API auth](/reference/api-auth).
 
 ## TL;DR
 
@@ -61,7 +62,7 @@ This guide builds the proxy-router from source and walks through the API-only co
     ./proxy-router
     ```
     On future updates: `git pull && ./build.sh && ./proxy-router`.
-    Confirm Swagger at `http://localhost:8082/swagger/index.html`.
+    Confirm Swagger at `http://localhost:8082/swagger/index.html`. Click **Authorize** and enter the `admin` / password from `.cookie` before using **Try it out** — almost every route requires Basic Auth (same as the curl headers below).
   </Step>
 </Steps>
 
@@ -69,17 +70,25 @@ This guide builds the proxy-router from source and walks through the API-only co
 
 Either via Swagger or curl. **Once per wallet**, or when allowance is depleted.
 
+In Swagger: **Authorize** → run `POST /blockchain/approve`. Via curl (replace the Basic value with `base64(username:password)` from your `.cookie`, or use `-u 'admin:<password>'`):
+
 ```bash
 curl -X POST \
   'http://localhost:8082/blockchain/approve?spender=0x6aBE1d282f72B474E54527D93b979A4f64d3030a&amount=3' \
+  -H 'Authorization: Basic <base64(user:pass)>' \
   -H 'accept: application/json' -d ''
 ```
 
 ## C. Query for a model
 
 ```bash
-curl -X GET 'http://localhost:8082/wallet' -H 'accept: application/json'
-curl -X GET 'http://localhost:8082/blockchain/models' -H 'accept: application/json'
+curl -X GET 'http://localhost:8082/wallet' \
+  -H 'Authorization: Basic <base64(user:pass)>' \
+  -H 'accept: application/json'
+
+curl -X GET 'http://localhost:8082/blockchain/models' \
+  -H 'Authorization: Basic <base64(user:pass)>' \
+  -H 'accept: application/json'
 ```
 
 Pick an `Id` from the response and use it as `<modelId>` below. See the [API endpoints](/reference/api-endpoints) reference for the full schema.
@@ -89,6 +98,7 @@ Pick an `Id` from the response and use it as `<modelId>` below. See the [API end
 ```bash
 curl -s -X POST \
   'http://localhost:8082/blockchain/models/<modelId>/session' \
+  -H 'Authorization: Basic <base64(user:pass)>' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{"sessionDuration": 600}'
@@ -100,6 +110,7 @@ The transaction will appear in your wallet's history at `https://base.blockscout
 
 ```bash
 curl -X POST 'http://localhost:8082/v1/chat/completions' \
+  -H 'Authorization: Basic <base64(user:pass)>' \
   -H 'accept: application/json' \
   -H 'session_id: <sessionId>' \
   -H 'Content-Type: application/json' \
@@ -115,12 +126,18 @@ The response is OpenAI-compatible SSE.
 
 ```bash
 # Approve, query wallet, list models, open a session, prompt
-curl -X POST 'http://localhost:8082/blockchain/approve?spender=0x6aBE1d282f72B474E54527D93b979A4f64d3030a&amount=3' -H 'accept: application/json' -d ''
-curl -s 'http://localhost:8082/wallet' | jq .address
-curl -s 'http://localhost:8082/blockchain/models' | jq -r '.models[] | "\(.Id), \(.Name)"'
+# AUTH from .cookie — either header form or: curl -u 'admin:<password>' ...
+AUTH='Authorization: Basic <base64(user:pass)>'
+SPENDER=0x6aBE1d282f72B474E54527D93b979A4f64d3030a
+
+curl -X POST "http://localhost:8082/blockchain/approve?spender=$SPENDER&amount=3" \
+  -H "$AUTH" -H 'accept: application/json' -d ''
+curl -s 'http://localhost:8082/wallet' -H "$AUTH" | jq .address
+curl -s 'http://localhost:8082/blockchain/models' -H "$AUTH" \
+  | jq -r '.models[] | "\(.Id), \(.Name)"'
 SESSION=$(curl -s -X POST 'http://localhost:8082/blockchain/models/<modelId>/session' \
-  -H 'Content-Type: application/json' -d '{"sessionDuration":600}' | jq -r .sessionId)
+  -H "$AUTH" -H 'Content-Type: application/json' -d '{"sessionDuration":600}' | jq -r .sessionId)
 curl -X POST 'http://localhost:8082/v1/chat/completions' \
-  -H "session_id: $SESSION" -H 'Content-Type: application/json' \
+  -H "$AUTH" -H "session_id: $SESSION" -H 'Content-Type: application/json' \
   -d '{"messages":[{"role":"user","content":"tell me a joke"}],"stream":true}'
 ```

--- a/docs/consumers/install/docker.mdx
+++ b/docs/consumers/install/docker.mdx
@@ -56,7 +56,7 @@ For provider-side Docker (with model registration, public `:3333`, etc.), see [P
     ```bash
     curl http://localhost:8082/healthcheck
     ```
-    Open Swagger at `http://localhost:8082/swagger/index.html`.
+    Open Swagger at `http://localhost:8082/swagger/index.html`. For any authenticated route (**Try it out**), click **Authorize** first and use the `admin` / password from your `.cookie` (see [API auth](/reference/api-auth)). `GET /healthcheck` does not require auth.
   </Step>
 </Steps>
 

--- a/docs/consumers/install/linux.mdx
+++ b/docs/consumers/install/linux.mdx
@@ -28,7 +28,7 @@ The Linux release is a single **AppImage**. On first launch, the app downloads a
     Accept terms, set a UI password, create or recover a wallet. Save the mnemonic somewhere safe.
   </Step>
   <Step title="Validate">
-    Open `http://localhost:8082/swagger/index.html`. Use **Local Model** in Chat to verify the pipeline.
+    Open `http://localhost:8082/swagger/index.html`. For Swagger **Try it out**, click **Authorize** and use the proxy-router `.cookie` credentials ([API auth](/reference/api-auth)). Use **Local Model** in Chat to verify the pipeline.
   </Step>
 </Steps>
 

--- a/docs/consumers/install/macos.mdx
+++ b/docs/consumers/install/macos.mdx
@@ -99,7 +99,7 @@ You'll need:
     INFO  HTTP  http server is listening: 0.0.0.0:8082
     INFO  TCP   tcp server is listening: 0.0.0.0:3333
     ```
-    Open `http://localhost:8082/swagger/index.html`.
+    Open `http://localhost:8082/swagger/index.html`. For **Try it out**, click **Authorize** and use the `.cookie` credentials ([API auth](/reference/api-auth)).
   </Step>
 </Steps>
 

--- a/docs/consumers/install/windows.mdx
+++ b/docs/consumers/install/windows.mdx
@@ -24,7 +24,7 @@ The Windows release is a single **portable executable**. On first launch, the ap
     Accept terms, set a UI password, create or recover a wallet. Save the mnemonic somewhere safe.
   </Step>
   <Step title="Validate">
-    Open `http://localhost:8082/swagger/index.html`. Try the **Local Model** in the Chat tab to verify the local pipeline.
+    Open `http://localhost:8082/swagger/index.html`. For Swagger **Try it out**, click **Authorize** and use the proxy-router `.cookie` credentials ([API auth](/reference/api-auth)). Try the **Local Model** in the Chat tab to verify the local pipeline.
   </Step>
 </Steps>
 

--- a/docs/consumers/quickstart.mdx
+++ b/docs/consumers/quickstart.mdx
@@ -70,7 +70,8 @@ The consumer release is a **single desktop app** per OS. On first launch, the ap
 <Steps>
   <Step title="Confirm proxy-router is up">
     Open `http://localhost:8082/swagger/index.html` — the Swagger UI should render.
-    See [Troubleshooting](/reference/troubleshooting) if it doesn't.
+    If you use **Try it out** on API routes, click **Authorize** and enter the `admin` credentials from the proxy-router `.cookie` file (see [API auth](/reference/api-auth)).
+    See [Troubleshooting](/reference/troubleshooting) if Swagger doesn't load.
   </Step>
   <Step title="Local-model test (optional)">
     In MorpheusUI's **Chat** tab, ensure **Local Model** is selected. Type a prompt and press Enter. A response confirms the local model + proxy-router pipeline works.

--- a/docs/providers/full/aws.mdx
+++ b/docs/providers/full/aws.mdx
@@ -139,7 +139,7 @@ flowchart LR
     For long-lived operation, run it under `systemd` — see [Headless operation](/providers/full/headless).
   </Step>
   <Step title="Validate">
-    Open `http://<web_public_url>/swagger/index.html` to confirm the API is up.
+    Open `http://<web_public_url>/swagger/index.html` to confirm the API is up. For **Try it out**, click **Authorize** with your `.cookie` credentials ([API auth](/reference/api-auth)).
   </Step>
 </Steps>
 

--- a/docs/providers/full/proxy-router-docker.mdx
+++ b/docs/providers/full/proxy-router-docker.mdx
@@ -123,7 +123,7 @@ vi rating-config.json
 
 ## Validate & register
 
-- `http://localhost:8082/swagger/index.html` should render.
+- `http://localhost:8082/swagger/index.html` should render. Authenticated routes need **Authorize** with your `.cookie` credentials ([API auth](/reference/api-auth)).
 - Continue to [Register on chain](/providers/full/register-onchain).
 
 ## Notes

--- a/docs/providers/full/quickstart.mdx
+++ b/docs/providers/full/quickstart.mdx
@@ -118,7 +118,7 @@ Run from the working directory (so the relative config and data paths resolve):
 
 ## Validate
 
-- `http://localhost:8082/swagger/index.html` should render.
+- `http://localhost:8082/swagger/index.html` should render. Authenticated routes need **Authorize** with your `.cookie` credentials ([API auth](/reference/api-auth)).
 - `./data/` directory contains logs.
 - The proxy-router log should include:
   ```

--- a/docs/providers/full/register-onchain.mdx
+++ b/docs/providers/full/register-onchain.mdx
@@ -10,7 +10,7 @@ source: "docs/03-provider-offer.md"
 After your proxy-router is running, register on the BASE Diamond contract. **Prefer looking up an existing model and posting a bid on it** — minting a new model for every provider floods the marketplace with duplicate names.
 
 <Note>
-**Preferred operator UI:** [MyProvider](https://myprovider.mor.org) ([guide](/providers/full/myprovider-gui)) — especially on SecretVM, where the node already serves HTTPS. Swagger at `http://localhost:8082/swagger/index.html` (or `https://<your-node>/swagger/`) remains the API fallback.
+**Preferred operator UI:** [MyProvider](https://myprovider.mor.org) ([guide](/providers/full/myprovider-gui)) — especially on SecretVM, where the node already serves HTTPS. Swagger at `http://localhost:8082/swagger/index.html` (or `https://<your-node>/swagger/`) remains the API fallback — click **Authorize** and use your `.cookie` / `COOKIE_CONTENT` credentials before **Try it out** ([API auth](/reference/api-auth)).
 </Note>
 
 ## Contract minimums

--- a/docs/providers/full/secretvm-quickstart.mdx
+++ b/docs/providers/full/secretvm-quickstart.mdx
@@ -154,7 +154,7 @@ SecretVM already terminates TLS on port 443, so the hosted GUI at [myprovider.mo
   </Step>
 </Steps>
 
-Swagger fallback: `https://<your-secretvm-url>/swagger/index.html` — same contract calls as [Register on chain](/providers/full/register-onchain).
+Swagger fallback: `https://<your-secretvm-url>/swagger/index.html` — same contract calls as [Register on chain](/providers/full/register-onchain). Click **Authorize** with your `COOKIE_CONTENT` / `.cookie` credentials first ([API auth](/reference/api-auth)).
 
 ## Step 6: Verify your attestation
 

--- a/docs/reference/api-direct.mdx
+++ b/docs/reference/api-direct.mdx
@@ -3,7 +3,7 @@ title: "API direct (curl walkthrough)"
 description: "End-to-end consumer flow using only the proxy-router HTTP API: approve, query, open session, prompt."
 audience: ["consumer", "prosumer", "developer"]
 product: ["proxy-router"]
-last_verified: "v7.0.0"
+last_verified: "v7.9.0"
 source: "docs/proxy-router-api-direct.md"
 ---
 
@@ -13,6 +13,7 @@ This is the curl-only path through Morpheus — no MorpheusUI, no CLI. Useful fo
 
 - A consumer-side proxy-router running locally with a funded wallet. See [Install from source](/consumers/install-from-source) or [C-Node setup](/prosumers/c-node-setup).
 - BasicAuth credentials. The default `admin` lives in `.cookie`. See [API auth](/reference/api-auth).
+- If you prefer Swagger at `http://localhost:8082/swagger/index.html`, click **Authorize** and enter those same credentials before **Try it out** — Swagger's generated curl includes `Authorization: Basic …`; the examples below match that.
 
 ## TL;DR
 

--- a/proxy-router/internal/attestation/verifier.go
+++ b/proxy-router/internal/attestation/verifier.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -43,6 +44,32 @@ func (c *collateralField) UnmarshalJSON(data []byte) error {
 	c.Error = obj.Error
 	return nil
 }
+
+// softString unmarshals a JSON string or number into a Go string.
+// SecretAI Portal quote-parse currently emits version/tee_type as numbers;
+// older responses used strings or omitted the fields.
+type softString string
+
+func (s *softString) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if bytes.Equal(data, []byte("null")) {
+		*s = ""
+		return nil
+	}
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		*s = softString(str)
+		return nil
+	}
+	var num float64
+	if err := json.Unmarshal(data, &num); err == nil {
+		*s = softString(strconv.FormatFloat(num, 'f', -1, 64))
+		return nil
+	}
+	return fmt.Errorf("softString: expected string or number, got %s", string(data))
+}
+
+func (s softString) String() string { return string(s) }
 
 const (
 	// AttestationPort is Phase 1 (consumer → P-Node): SecretVM host attestation.
@@ -117,18 +144,18 @@ type ParseQuoteResponse struct {
 }
 
 type QuoteFields struct {
-	Version     string `json:"version,omitempty"`
-	TEEType     string `json:"tee_type,omitempty"`
-	TCBSVN      string `json:"tcb_svn,omitempty"`
-	MRSeam      string `json:"mr_seam,omitempty"`
-	MRTD        string `json:"mr_td,omitempty"`
-	RTMR0       string `json:"rtmr0,omitempty"`
-	RTMR1       string `json:"rtmr1,omitempty"`
-	RTMR2       string `json:"rtmr2,omitempty"`
-	RTMR3       string `json:"rtmr3,omitempty"`
-	ReportData  string `json:"report_data,omitempty"`
-	Measurement string `json:"measurement,omitempty"`
-	MachineID   string `json:"machine_id,omitempty"`
+	Version     softString `json:"version,omitempty"`
+	TEEType     softString `json:"tee_type,omitempty"`
+	TCBSVN      string     `json:"tcb_svn,omitempty"`
+	MRSeam      string     `json:"mr_seam,omitempty"`
+	MRTD        string     `json:"mr_td,omitempty"`
+	RTMR0       string     `json:"rtmr0,omitempty"`
+	RTMR1       string     `json:"rtmr1,omitempty"`
+	RTMR2       string     `json:"rtmr2,omitempty"`
+	RTMR3       string     `json:"rtmr3,omitempty"`
+	ReportData  string     `json:"report_data,omitempty"`
+	Measurement string     `json:"measurement,omitempty"`
+	MachineID   string     `json:"machine_id,omitempty"`
 }
 
 type QuoteStatus struct {

--- a/proxy-router/internal/attestation/verifier_portal_test.go
+++ b/proxy-router/internal/attestation/verifier_portal_test.go
@@ -1,0 +1,111 @@
+package attestation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseQuoteResponse_NumericVersionAndTeeType(t *testing.T) {
+	// Live SecretAI Portal shape (TDX): version/tee_type are JSON numbers.
+	raw := []byte(`{
+		"status": {"attestation_type": "tdx", "result": "ok"},
+		"quote": {
+			"attestation_type": "tdx",
+			"version": 4,
+			"tee_type": 129,
+			"mr_td": "abcd",
+			"rtmr0": "1111",
+			"rtmr1": "2222",
+			"rtmr2": "3333",
+			"rtmr3": "4444",
+			"report_data": "deadbeef"
+		}
+	}`)
+
+	var parsed ParseQuoteResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal portal response: %v", err)
+	}
+	if parsed.Quote == nil {
+		t.Fatal("expected quote")
+	}
+	if got := parsed.Quote.Version.String(); got != "4" {
+		t.Fatalf("Version = %q, want 4", got)
+	}
+	if got := parsed.Quote.TEEType.String(); got != "129" {
+		t.Fatalf("TEEType = %q, want 129", got)
+	}
+	if parsed.Quote.MRTD != "abcd" {
+		t.Fatalf("MRTD = %q, want abcd", parsed.Quote.MRTD)
+	}
+}
+
+func TestParseQuoteResponse_StringVersionStillAccepted(t *testing.T) {
+	raw := []byte(`{"quote":{"version":"4","tee_type":"TDX","mr_td":"a","rtmr0":"b","rtmr1":"c","rtmr2":"d","report_data":"e"}}`)
+	var parsed ParseQuoteResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.Quote.Version.String() != "4" || parsed.Quote.TEEType.String() != "TDX" {
+		t.Fatalf("got version=%q tee_type=%q", parsed.Quote.Version, parsed.Quote.TEEType)
+	}
+}
+
+func TestParseQuoteResponse_SEVNumericVersion(t *testing.T) {
+	raw := []byte(`{
+		"status": {"attestation_type": "sev", "verify": "ok"},
+		"quote": {
+			"attestation_type": "sev",
+			"version": 3,
+			"report_data": "aa bb",
+			"measurement": "ff00"
+		}
+	}`)
+	var parsed ParseQuoteResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal SEV portal response: %v", err)
+	}
+	if parsed.Quote.Version.String() != "3" {
+		t.Fatalf("Version = %q, want 3", parsed.Quote.Version)
+	}
+	if parsed.Quote.Measurement != "ff00" {
+		t.Fatalf("Measurement = %q", parsed.Quote.Measurement)
+	}
+}
+
+func TestVerifyQuote_PortalNumericFields(t *testing.T) {
+	portal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"status": {"attestation_type": "tdx", "result": "ok"},
+			"quote": {
+				"version": 4,
+				"tee_type": 129,
+				"mr_td": "aaaa",
+				"rtmr0": "bbbb",
+				"rtmr1": "cccc",
+				"rtmr2": "dddd",
+				"rtmr3": "eeee",
+				"report_data": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+			}
+		}`))
+	}))
+	defer portal.Close()
+
+	result, err := VerifyQuote(context.Background(), portal.Client(), portal.URL, "0400020081000000deadbeef")
+	if err != nil {
+		t.Fatalf("VerifyQuote: %v", err)
+	}
+	if !result.Valid {
+		t.Fatalf("expected valid, got error %q", result.Error)
+	}
+	if result.Type != TEETypeTDX {
+		t.Fatalf("type = %s, want TDX", result.Type)
+	}
+	if result.MRTD != "aaaa" || result.ReportData == "" {
+		t.Fatalf("unexpected fields: %+v", result)
+	}
+}


### PR DESCRIPTION
## Summary
- Promote `dev` → `test` with:
  - **TEE:** accept numeric `version` / `tee_type` from SecretAI `quote-parse` so Phase 2 backend attestation unmarshals again ([#840](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/840))
  - **Docs:** add Basic Auth to install-from-source curl walkthroughs and note Swagger **Authorize** / `.cookie` wherever docs point at Try it out ([#842](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/842))

## Test plan
- [ ] Review CI on this promote PR
- [ ] After test TEE P-Node deploy: startup logs show `CPU quote valid` (no `cannot unmarshal number into ... QuoteFields.quote.version`)
- [ ] Spot-check nodedocs.dev install-from-source curl examples include `Authorization: Basic …` and Swagger Authorize callouts